### PR TITLE
feat(dataplane): enforce threat score above a configurable threshold (I-001)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,6 +6,13 @@ dataplane:
   anonymization:
     secret: "${PHANTOM_ANON_SECRET:-change-me-in-production}"
   blocklist_update_interval: "6h"
+  # Threat-score enforcement for the heuristic detector (DGA / entropy / tunneling).
+  # 0 disables enforcement — the detector still scores and logs (historical default).
+  # Set a value in (0, 1], e.g. 0.8, to block queries scored at or above it.
+  # threat_block_dryrun logs would-be blocks without blocking (safe rollout).
+  # Env overrides: THREAT_BLOCK_THRESHOLD, THREAT_BLOCK_DRYRUN.
+  threat_block_threshold: 0
+  threat_block_dryrun: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 // SPDX-License-Identifier: GPL-3.0-or-later
 import (
 	"os"
+	"strconv"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,14 @@ type DataPlaneConfig struct {
 	UpstreamResolvers       []string         `yaml:"upstream_resolvers"`
 	GRPCServer              GRPCServerConfig `yaml:"grpc_server"`
 	BlocklistUpdateInterval string           `yaml:"blocklist_update_interval"`
+
+	// ThreatBlockThreshold enables enforcement of the heuristic threat detector.
+	// When > 0, a query scored suspicious with ThreatScore >= threshold is blocked
+	// (or logged as a would-be block when ThreatBlockDryRun is set). 0 disables
+	// enforcement, preserving the historical log-only behaviour.
+	ThreatBlockThreshold float64 `yaml:"threat_block_threshold"`
+	// ThreatBlockDryRun logs would-be threat blocks without actually blocking.
+	ThreatBlockDryRun bool `yaml:"threat_block_dryrun"`
 }
 
 type ControlPlaneConfig struct {
@@ -69,6 +78,20 @@ var DefaultConfig = func() *Config {
 	}
 	if interval := os.Getenv("BLOCKLIST_UPDATE_INTERVAL"); interval != "" {
 		cfg.DataPlane.BlocklistUpdateInterval = interval
+	}
+	if v := os.Getenv("THREAT_BLOCK_THRESHOLD"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			cfg.DataPlane.ThreatBlockThreshold = f
+		} else {
+			logger.Log.Warnf("Invalid THREAT_BLOCK_THRESHOLD %q, ignoring: %v", v, err)
+		}
+	}
+	if v := os.Getenv("THREAT_BLOCK_DRYRUN"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.ThreatBlockDryRun = b
+		} else {
+			logger.Log.Warnf("Invalid THREAT_BLOCK_DRYRUN %q, ignoring: %v", v, err)
+		}
 	}
 	return cfg
 }()

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -35,6 +35,12 @@ type Engine struct {
 	queryLog        repositories.QueryLogRepository
 	statistics      repositories.StatisticsRepository
 	threatDetector  *threat.Detector
+
+	// threatBlockThreshold, when > 0, turns the heuristic threat detector from
+	// log-only into enforcement: a suspicious query with ThreatScore >= threshold
+	// is blocked. threatBlockDryRun logs a would-be block instead of blocking.
+	threatBlockThreshold float64
+	threatBlockDryRun    bool
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -51,13 +57,15 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		return nil, err
 	}
 	return &Engine{
-		upstreamManager: mgr,
-		policyEngine:    pE,
-		state:           state,
-		metrics:         qm,
-		queryLog:        repos.QueryLogs,
-		statistics:      repos.Statistics,
-		threatDetector:  threat.NewDetector(),
+		upstreamManager:      mgr,
+		policyEngine:         pE,
+		state:                state,
+		metrics:              qm,
+		queryLog:             repos.QueryLogs,
+		statistics:           repos.Statistics,
+		threatDetector:       threat.NewDetector(),
+		threatBlockThreshold: cfg.ThreatBlockThreshold,
+		threatBlockDryRun:    cfg.ThreatBlockDryRun,
 	}, nil
 }
 
@@ -172,6 +180,33 @@ func stripSearchDomain(domain string) string {
 	return domain
 }
 
+// threatAction is the enforcement decision for a scored query.
+type threatAction int
+
+const (
+	threatNone   threatAction = iota // do not enforce; forward as usual
+	threatBlock                      // block the query
+	threatDryRun                     // log a would-be block, but still allow
+)
+
+// shouldEnforceThreat reports whether a scored threat result crosses the
+// configured block threshold. A threshold of 0 disables enforcement, preserving
+// the historical log-only behaviour.
+func shouldEnforceThreat(tr threat.Result, threshold float64) bool {
+	return threshold > 0 && tr.IsSuspicious && tr.ThreatScore >= threshold
+}
+
+// threatDecision maps a scored result to an enforcement action for this engine.
+func (e *Engine) threatDecision(tr threat.Result) threatAction {
+	if !shouldEnforceThreat(tr, e.threatBlockThreshold) {
+		return threatNone
+	}
+	if e.threatBlockDryRun {
+		return threatDryRun
+	}
+	return threatBlock
+}
+
 // ProcessDNSQuery processes the DNS query and returns a response
 func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	if r == nil || len(r.Question) == 0 {
@@ -243,6 +278,22 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		success = true
 
 	default: // policy.ActionAllow
+		// The query is not on any blocklist or block policy. If threat enforcement
+		// is enabled, a sufficiently suspicious domain is blocked here (dry-run only
+		// logs). Threshold 0 keeps the historical log-only behaviour.
+		switch e.threatDecision(threatResult) {
+		case threatBlock:
+			logger.Log.Warnf("Blocking suspicious domain %s (score=%.2f >= %.2f, method=%s)",
+				domainName, threatResult.ThreatScore, e.threatBlockThreshold, threatResult.DetectionMethod)
+			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.respondBlocked(w, r, domainName, "threat:"+threatResult.DetectionMethod)
+			success = true
+			return
+		case threatDryRun:
+			logger.Log.Warnf("[threat dry-run] would block %s (score=%.2f >= %.2f, method=%s)",
+				domainName, threatResult.ThreatScore, e.threatBlockThreshold, threatResult.DetectionMethod)
+		}
+
 		action := "allow"
 		if threatResult.IsSuspicious {
 			action = "flagged"

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lopster568/phantomDNS/internal/metrics"
 	"github.com/lopster568/phantomDNS/internal/policy"
+	"github.com/lopster568/phantomDNS/internal/threat"
 	"github.com/miekg/dns"
 )
 
@@ -335,5 +336,74 @@ func TestSetAcceptQueries(t *testing.T) {
 	e.SetAcceptQueries(true)
 	if !e.state.acceptQueries.Load() {
 		t.Error("expected true after SetAcceptQueries(true)")
+	}
+}
+
+func TestShouldEnforceThreat(t *testing.T) {
+	tests := []struct {
+		name      string
+		tr        threat.Result
+		threshold float64
+		want      bool
+	}{
+		{"threshold 0 disables", threat.Result{IsSuspicious: true, ThreatScore: 0.9}, 0, false},
+		{"above threshold", threat.Result{IsSuspicious: true, ThreatScore: 0.9}, 0.8, true},
+		{"equal to threshold", threat.Result{IsSuspicious: true, ThreatScore: 0.8}, 0.8, true},
+		{"below threshold", threat.Result{IsSuspicious: true, ThreatScore: 0.7}, 0.8, false},
+		{"not suspicious", threat.Result{IsSuspicious: false, ThreatScore: 0.9}, 0.8, false},
+	}
+	for _, tt := range tests {
+		if got := shouldEnforceThreat(tt.tr, tt.threshold); got != tt.want {
+			t.Errorf("%s: shouldEnforceThreat = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestThreatDecision(t *testing.T) {
+	sus := threat.Result{IsSuspicious: true, ThreatScore: 0.9}
+
+	if got := (&Engine{threatBlockThreshold: 0}).threatDecision(sus); got != threatNone {
+		t.Errorf("threshold 0: want threatNone, got %v", got)
+	}
+	if got := (&Engine{threatBlockThreshold: 0.8}).threatDecision(sus); got != threatBlock {
+		t.Errorf("enforce: want threatBlock, got %v", got)
+	}
+	if got := (&Engine{threatBlockThreshold: 0.8, threatBlockDryRun: true}).threatDecision(sus); got != threatDryRun {
+		t.Errorf("dry-run: want threatDryRun, got %v", got)
+	}
+}
+
+func TestProcessDNSQuery_ThreatBlockEnforced(t *testing.T) {
+	// A long hex label scores dga_hex (0.9). With enforcement on and no
+	// blocklist/policy match, it must be blocked — this returns before any
+	// upstream forward, so no UpstreamManager is required.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.threatDetector = threat.NewDetector()
+	e.threatBlockThreshold = 0.8
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("abcdef0123456789.example.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response for the suspicious domain")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected suspicious domain blocked (0.0.0.0), got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_ThreatBlockDisabledByDefault(t *testing.T) {
+	// With the default threshold of 0, the detector must not enforce even on a
+	// clearly suspicious domain (verified at the decision layer to avoid the
+	// upstream-forward path, which needs a real UpstreamManager).
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.threatDetector = threat.NewDetector()
+
+	sus := e.threatDetector.Analyze("abcdef0123456789.example.com")
+	if !sus.IsSuspicious {
+		t.Fatal("test precondition: expected the sample domain to be flagged suspicious")
+	}
+	if got := e.threatDecision(sus); got != threatNone {
+		t.Errorf("default threshold (0) must not enforce, got %v", got)
 	}
 }


### PR DESCRIPTION
## What
Turns the existing (idle) heuristic threat detector from **log-only** into **optional enforcement**.

## Why
`internal/threat/detector.go` already scores every query (entropy, DGA-hex, base64, digit-ratio, length, subdomain-depth), but `ProcessDNSQuery` only logged the result ("non-blocking, just scoring"). There was no way to actually block a high-confidence suspicious domain that isn't already on a blocklist or block policy.

## How
- New dataplane config: `threat_block_threshold` (float, default `0` = disabled) and `threat_block_dryrun` (bool). Env overrides: `THREAT_BLOCK_THRESHOLD`, `THREAT_BLOCK_DRYRUN`.
- In the allow path, a query with `IsSuspicious && ThreatScore >= threshold` is blocked via the existing `respondBlocked` (reason `threat:<method>`). Dry-run logs a would-be block and still forwards.
- Decision logic extracted into `shouldEnforceThreat` (pure) + `threatDecision` (enum) for testability.

## Safety / compatibility
- **Default `threshold: 0` is the exact current behaviour** (log-only) — no regression.
- The detector's existing CDN/infra allowlist limits false positives; `dryrun` lets operators A/B before enforcing.
- Blocklist and block-policy paths are unchanged and still take precedence over threat enforcement.

## Tests
`go test ./...` is green. Added: threshold-gating table, decision enum, an end-to-end enforced block (`abcdef0123456789.example.com` → `dga_hex`), and a default-off assertion.

Implements idea **I-001** from the DNS-security feature backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
