### PR TITLE
feat(policy): evaluate regex and wildcard rules at query time (I-002)

### DIFF
--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -23,17 +23,22 @@ func (e *Engine) LoadPolicies(policies []Policy) error {
 }
 
 // Evaluate returns the decision for given domain and context.
-// Current implementation:
+// Evaluation order:
 //   - normalize domain
-//   - bloom negative => ALLOW
-//   - exact match => return highest-priority policy decision
-//   - otherwise => ALLOW (TODO: wildcard/regex)
+//   - exact-match/Bloom fast path (walks up parent domains) => decision
+//   - regex + wildcard slow path (only on exact miss) => decision
+//   - otherwise => ALLOW
+//
+// The exact-match fast path returns immediately when it hits, so an exact rule
+// always wins over regex/wildcard rules. Within the regex/wildcard slow path,
+// the usual priority ordering applies (higher priority wins; tie => lexicographic ID).
 func (e *Engine) Evaluate(domain string) (Decision, error) {
 	d := normalizeDomain(domain)
 	snap := e.snapshot.Load().(*PolicySnapshot)
 
 	// Check exact match first, then walk up parent domains for subdomain matching.
-	// e.g., www.godaddy.com → check www.godaddy.com, then godaddy.com
+	// e.g., www.godaddy.com → check www.godaddy.com, then godaddy.com.
+	// This is the hot path and is intentionally left untouched.
 	parts := strings.Split(d, ".")
 	for i := 0; i < len(parts)-1; i++ {
 		candidate := strings.Join(parts[i:], ".")
@@ -46,7 +51,34 @@ func (e *Engine) Evaluate(domain string) (Decision, error) {
 		}
 	}
 
+	// Slow path: no exact match. Evaluate wildcard and compiled-regex rules,
+	// respecting the same priority ordering as the exact path.
+	if best := matchDynamic(snap, d); best != nil {
+		return policyDecision(best), nil
+	}
+
 	return Decision{Action: ActionAllow}, nil
+}
+
+// matchDynamic returns the highest-priority policy whose wildcard or compiled
+// regex rule matches d, or nil when nothing matches. A wildcard "*.example.com"
+// matches the base domain ("example.com") and any subdomain of it.
+func matchDynamic(snap *PolicySnapshot, d string) *Policy {
+	var candidates []*Policy
+	for _, w := range snap.Wildcards {
+		if d == w.base || strings.HasSuffix(d, "."+w.base) {
+			candidates = append(candidates, w.policy)
+		}
+	}
+	for _, r := range snap.Regexes {
+		if r.re.MatchString(d) {
+			candidates = append(candidates, r.policy)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	return pickHighestPriority(candidates)
 }
 
 // pickHighestPriority returns the matching policy with highest priority (deterministic).

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -194,6 +194,190 @@ func TestPolicyDecision_Nil(t *testing.T) {
 	}
 }
 
+func TestEvaluate_BlockByRegex(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "rx-block", Action: "BLOCK", Priority: 100, Regexes: []string{`.*\.doubleclick\.net$`}},
+	})
+
+	d, err := e.Evaluate("ads.doubleclick.net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny {
+		t.Errorf("expected ActionDeny for regex match, got %v", d.Action)
+	}
+	if d.PolicyID != "rx-block" {
+		t.Errorf("expected policy ID rx-block, got %q", d.PolicyID)
+	}
+
+	// Non-matching domain should fall through to ALLOW.
+	d, err = e.Evaluate("safe.example.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow {
+		t.Errorf("expected ActionAllow for non-matching domain, got %v", d.Action)
+	}
+}
+
+func TestEvaluate_RegexAllowOverridesByPriority(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "rx-block", Action: "BLOCK", Priority: 10, Regexes: []string{`.*\.tracking\.com$`}},
+		{ID: "rx-allow", Action: "ALLOW", Priority: 100, Regexes: []string{`.*\.tracking\.com$`}},
+	})
+
+	d, err := e.Evaluate("beacon.tracking.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow {
+		t.Errorf("expected higher-priority ALLOW regex to win, got %v", d.Action)
+	}
+	if d.PolicyID != "rx-allow" {
+		t.Errorf("expected policy ID rx-allow, got %q", d.PolicyID)
+	}
+}
+
+func TestEvaluate_RegexTieBreakByID(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "zzz-rx", Action: "ALLOW", Priority: 50, Regexes: []string{`^tie\.rx$`}},
+		{ID: "aaa-rx", Action: "BLOCK", Priority: 50, Regexes: []string{`^tie\.rx$`}},
+	})
+
+	d, err := e.Evaluate("tie.rx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.PolicyID != "aaa-rx" {
+		t.Errorf("expected lexicographically first ID 'aaa-rx' on tie, got %q", d.PolicyID)
+	}
+	if d.Action != ActionDeny {
+		t.Errorf("expected ActionDeny from tie-break winner, got %v", d.Action)
+	}
+}
+
+func TestEvaluate_WildcardMatchesSubdomains(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "wild", Action: "BLOCK", Priority: 100, Domains: []string{"*.example.com"}},
+	})
+
+	// Wildcard matches the base domain and any depth of subdomain.
+	for _, domain := range []string{"example.com", "sub.example.com", "a.b.example.com"} {
+		d, err := e.Evaluate(domain)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Action != ActionDeny {
+			t.Errorf("expected %s to be blocked by wildcard, got %v", domain, d.Action)
+		}
+		if d.PolicyID != "wild" {
+			t.Errorf("expected policy ID wild for %s, got %q", domain, d.PolicyID)
+		}
+	}
+
+	// Unrelated domains must not match.
+	for _, domain := range []string{"notexample.com", "example.com.evil.net", "other.org"} {
+		d, err := e.Evaluate(domain)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Action != ActionAllow {
+			t.Errorf("expected %s to be allowed (no wildcard match), got %v", domain, d.Action)
+		}
+	}
+}
+
+func TestEvaluate_WildcardPriority(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "wild-block", Action: "BLOCK", Priority: 10, Domains: []string{"*.corp.com"}},
+		{ID: "wild-allow", Action: "ALLOW", Priority: 100, Domains: []string{"*.corp.com"}},
+	})
+
+	d, err := e.Evaluate("intra.corp.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow || d.PolicyID != "wild-allow" {
+		t.Errorf("expected higher-priority wildcard ALLOW to win, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
+func TestEvaluate_ExactWinsOverRegex(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "exact", Action: "BLOCK", Priority: 10, Domains: []string{"exact.com"}},
+		// Catch-all regex at much higher priority; exact fast path must still win.
+		{ID: "rx-all", Action: "ALLOW", Priority: 999, Regexes: []string{`.*`}},
+	})
+
+	d, err := e.Evaluate("exact.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny || d.PolicyID != "exact" {
+		t.Errorf("expected exact-match fast path to win, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+
+	// A domain with no exact match falls through to the regex slow path.
+	d, err = e.Evaluate("anything.else")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow || d.PolicyID != "rx-all" {
+		t.Errorf("expected regex slow path to match, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
+func TestEvaluate_InvalidRegexDoesNotCrash(t *testing.T) {
+	e := NewPolicyEngine()
+	// Bad regex reaches the snapshot directly (LoadPolicies skips load-time
+	// validation); it must be skipped, and valid rules must still work.
+	e.LoadPolicies([]Policy{
+		{ID: "bad-rx", Action: "BLOCK", Priority: 100, Regexes: []string{`[invalid(`}},
+		{ID: "good-rx", Action: "BLOCK", Priority: 100, Regexes: []string{`^good\.net$`}},
+	})
+
+	// The invalid regex is skipped; querying anything must not panic.
+	d, err := e.Evaluate("harmless.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow {
+		t.Errorf("expected ActionAllow (invalid regex skipped), got %v", d.Action)
+	}
+
+	// The valid regex alongside it still matches.
+	d, err = e.Evaluate("good.net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny || d.PolicyID != "good-rx" {
+		t.Errorf("expected valid regex to still match, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
+func TestEvaluate_ExactStillWorksWithDynamicRulesPresent(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "exact-block", Action: "BLOCK", Priority: 100, Domains: []string{"ads.example.com"}},
+		{ID: "wild", Action: "BLOCK", Priority: 100, Domains: []string{"*.tracker.net"}},
+		{ID: "rx", Action: "BLOCK", Priority: 100, Regexes: []string{`^evil\.io$`}},
+	})
+
+	d, err := e.Evaluate("ads.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny || d.PolicyID != "exact-block" {
+		t.Errorf("expected exact match to still work with regex/wildcard present, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
 func TestActionString(t *testing.T) {
 	tests := []struct {
 		a    Action

--- a/internal/policy/snapshot.go
+++ b/internal/policy/snapshot.go
@@ -1,34 +1,67 @@
 package policy
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/willf/bloom"
 )
 
+// compiledRegexRule pairs a pre-compiled regex with the policy that owns it.
+type compiledRegexRule struct {
+	re     *regexp.Regexp
+	policy *Policy
+}
+
+// wildcardRule holds a wildcard entry (e.g. "*.example.com") reduced to its
+// base domain ("example.com") plus the policy that owns it.
+type wildcardRule struct {
+	base   string
+	policy *Policy
+}
+
 type PolicySnapshot struct {
 	Bloom *bloom.BloomFilter
 	Exact map[string][]*Policy // exact domain to policies
+
+	// Regexes and Wildcards are evaluated only AFTER the exact/Bloom fast
+	// path misses, so the hot path stays untouched. Regexes are compiled
+	// once at snapshot-build time and cached here.
+	Regexes   []compiledRegexRule
+	Wildcards []wildcardRule
 }
 
 func buildSnapshot(policies []Policy) *PolicySnapshot {
 	exact := make(map[string][]*Policy)
+	var wildcards []wildcardRule
+	var regexes []compiledRegexRule
 	totalDomains := 0
 
 	// normalize domains and count total
 	for i := range policies {
-		for _, d := range policies[i].Domains {
+		p := &policies[i]
+		for _, d := range p.Domains {
 			normalized := normalizeDomain(d)
 			totalDomains++
 			if strings.Contains(normalized, "*") {
-				// TODO: wildcard handling later - for now still add to bloom
+				// wildcard entry, e.g. "*.example.com"
+				if base := wildcardBase(normalized); base != "" {
+					wildcards = append(wildcards, wildcardRule{base: base, policy: p})
+				}
 				continue
 			}
-			exact[normalized] = append(exact[normalized], &policies[i])
+			exact[normalized] = append(exact[normalized], p)
 		}
-		for _, rx := range policies[i].Regexes {
+		for _, rx := range p.Regexes {
 			totalDomains++
-			_ = rx
+			re, err := regexp.Compile(rx)
+			if err != nil {
+				// Invalid regex: skip safely. Load-time validation already
+				// rejects these, but guard here so a bad rule that reaches
+				// the snapshot never crashes the query path.
+				continue
+			}
+			regexes = append(regexes, compiledRegexRule{re: re, policy: p})
 		}
 	}
 
@@ -54,7 +87,18 @@ func buildSnapshot(policies []Policy) *PolicySnapshot {
 	}
 
 	return &PolicySnapshot{
-		Exact: exact,
-		Bloom: bf,
+		Exact:     exact,
+		Bloom:     bf,
+		Regexes:   regexes,
+		Wildcards: wildcards,
 	}
+}
+
+// wildcardBase reduces a leading-label wildcard pattern to its base domain.
+// "*.example.com" => "example.com". Returns "" for unsupported patterns.
+func wildcardBase(pattern string) string {
+	if strings.HasPrefix(pattern, "*.") {
+		return pattern[2:]
+	}
+	return ""
 }


### PR DESCRIPTION
## What
`policy.Engine.Evaluate` now matches **regex** and **wildcard** rules at query time. Previously the engine parsed `Regexes` and wildcard domains on load but only ever evaluated exact-domain matches (via the `Exact` map / Bloom filter), so those rules silently never fired.

## Why
Policies could declare `Regexes` and `*.example.com` wildcard domains, and the loader even validated/compiled them, but `Evaluate` ignored them entirely. This makes the advertised rule types actually enforce.

## How
- **Snapshot (`snapshot.go`):** compile each regex once at snapshot-build time and cache the `*regexp.Regexp` (in `Regexes []compiledRegexRule`); store wildcard entries reduced to their base domain (`*.example.com` → `example.com`) in `Wildcards []wildcardRule`. Invalid regexes are skipped safely so a bad rule can never crash the query path (load-time validation still rejects them up front).
- **Evaluate (`engine.go`):** the exact-match/Bloom fast path is unchanged and returns immediately on a hit (hot path preserved, exact rules win). Only on an exact miss does the new slow path run: wildcard `*.example.com` matches the base domain and any subdomain, compiled regexes match the normalized domain, and the winner is chosen with the **same** priority ordering as the exact path (higher priority wins; tie → lexicographic policy ID).

## Tests
Added coverage for: BLOCK regex match; ALLOW regex overriding by priority; regex tie-break by ID; wildcard matching base + subdomains (and *not* unrelated domains); wildcard priority; exact-match still working (and winning) with regex/wildcard rules present; invalid regex skipped without crashing. `go build ./...`, `go vet ./internal/policy/...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)