### PR TITLE
feat(dataplane): optional high-abuse TLD blocking (I-043)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"gopkg.in/yaml.v3"
@@ -32,6 +33,10 @@ type DataPlaneConfig struct {
 	ThreatBlockThreshold float64 `yaml:"threat_block_threshold"`
 	// ThreatBlockDryRun logs would-be threat blocks without actually blocking.
 	ThreatBlockDryRun bool `yaml:"threat_block_dryrun"`
+
+	// AbusedTLDs is the set of high-abuse TLDs (e.g. "zip", "mov", "top") to
+	// block on the default allow path. Empty (the default) disables the feature.
+	AbusedTLDs []string `yaml:"abused_tlds"`
 }
 
 type ControlPlaneConfig struct {
@@ -93,8 +98,25 @@ var DefaultConfig = func() *Config {
 			logger.Log.Warnf("Invalid THREAT_BLOCK_DRYRUN %q, ignoring: %v", v, err)
 		}
 	}
+	if v := os.Getenv("ABUSED_TLDS"); v != "" {
+		cfg.DataPlane.AbusedTLDs = parseAbusedTLDs(v)
+	}
 	return cfg
 }()
+
+// parseAbusedTLDs splits a comma-separated env value into a normalized list of
+// TLDs: split on ",", trim surrounding spaces, lowercase, and drop empties.
+func parseAbusedTLDs(v string) []string {
+	parts := strings.Split(v, ",")
+	tlds := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" {
+			tlds = append(tlds, p)
+		}
+	}
+	return tlds
+}
 
 func configPath() string {
 	if p := os.Getenv("PHANTOM_CONFIG"); p != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAbusedTLDs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"simple", "zip,mov,top", []string{"zip", "mov", "top"}},
+		{"trims spaces", " zip , mov ,top ", []string{"zip", "mov", "top"}},
+		{"lowercases", "ZIP,Mov,TOP", []string{"zip", "mov", "top"}},
+		{"drops empties", "zip,,mov,", []string{"zip", "mov"}},
+		{"single", "xyz", []string{"xyz"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAbusedTLDs(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAbusedTLDs(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -41,6 +41,10 @@ type Engine struct {
 	// is blocked. threatBlockDryRun logs a would-be block instead of blocking.
 	threatBlockThreshold float64
 	threatBlockDryRun    bool
+
+	// abusedTLDs is the set of high-abuse TLDs to block on the default allow
+	// path (lowercased, no leading dot). Empty/nil disables the feature.
+	abusedTLDs map[string]bool
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -56,6 +60,20 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 	if err != nil {
 		return nil, err
 	}
+
+	// Build the abused-TLD set once so the hot path does a plain map lookup
+	// instead of scanning a slice or reading globals.
+	var abusedTLDs map[string]bool
+	if len(cfg.AbusedTLDs) > 0 {
+		abusedTLDs = make(map[string]bool, len(cfg.AbusedTLDs))
+		for _, t := range cfg.AbusedTLDs {
+			t = strings.ToLower(strings.TrimSpace(t))
+			if t != "" {
+				abusedTLDs[t] = true
+			}
+		}
+	}
+
 	return &Engine{
 		upstreamManager:      mgr,
 		policyEngine:         pE,
@@ -66,7 +84,22 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		threatDetector:       threat.NewDetector(),
 		threatBlockThreshold: cfg.ThreatBlockThreshold,
 		threatBlockDryRun:    cfg.ThreatBlockDryRun,
+		abusedTLDs:           abusedTLDs,
 	}, nil
+}
+
+// isAbusedTLD reports whether the domain's final label (TLD) is in the
+// configured high-abuse set. Returns false when the set is empty (feature off).
+// domain is expected to be already normalized (lowercased, no trailing dot).
+func (e *Engine) isAbusedTLD(domain string) bool {
+	if len(e.abusedTLDs) == 0 {
+		return false
+	}
+	tld := domain
+	if i := strings.LastIndex(domain, "."); i >= 0 {
+		tld = domain[i+1:]
+	}
+	return e.abusedTLDs[strings.ToLower(tld)]
 }
 
 func (e *Engine) SetAcceptQueries(enabled bool) {
@@ -294,6 +327,16 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				domainName, threatResult.ThreatScore, e.threatBlockThreshold, threatResult.DetectionMethod)
 		}
 
+		// Abused-TLD block applies only on the default allow path (no explicit
+		// policy matched). An explicit ALLOW policy, which carries a PolicyID,
+		// still wins and is forwarded normally.
+		if decision.PolicyID == "" && e.isAbusedTLD(domainName) {
+			logger.Log.Infof("Blocking via abused TLD: %s", domainName)
+			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.respondBlocked(w, r, domainName, "abused-tld")
+			success = true
+			return
+		}
 		action := "allow"
 		if threatResult.IsSuspicious {
 			action = "flagged"

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -325,6 +325,77 @@ func TestEngineStatus_WithError(t *testing.T) {
 	}
 }
 
+func TestProcessDNSQuery_AbusedTLDBlocks(t *testing.T) {
+	// TLD in the configured set is blocked on the default allow path.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.abusedTLDs = map[string]bool{"zip": true, "mov": true}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("malware.zip"))
+
+	if w.msg == nil {
+		t.Fatal("expected response for abused-TLD domain")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected blocked (0.0.0.0) for abused TLD, got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_AbusedTLDNotInSetAllowed(t *testing.T) {
+	// TLD not in the set reaches the allow path (no block).
+	// Empty (pool-less) upstream manager returns SERVFAIL without a network call.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.abusedTLDs = map[string]bool{"zip": true}
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("example.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected response for allowed domain")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("expected non-abused TLD to reach allow path, but it was blocked")
+	}
+}
+
+func TestProcessDNSQuery_AbusedTLDEmptySetIsOff(t *testing.T) {
+	// Empty set = feature off: a .zip domain must not be blocked.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	// abusedTLDs left nil (empty).
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("example.zip"))
+
+	if w.msg == nil {
+		t.Fatal("expected response when abused-TLD feature is off")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("expected no block with empty abused-TLD set, but domain was blocked")
+	}
+}
+
+func TestProcessDNSQuery_AbusedTLDAllowPolicyOverrides(t *testing.T) {
+	// An explicit ALLOW policy for the domain must win over the TLD block.
+	policies := []policy.Policy{
+		{ID: "allow-trusted", Action: "ALLOW", Priority: 100, Domains: []string{"trusted.zip"}},
+	}
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, policies)
+	e.abusedTLDs = map[string]bool{"zip": true}
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("trusted.zip"))
+
+	if w.msg == nil {
+		t.Fatal("expected response for explicitly-allowed abused-TLD domain")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("expected explicit ALLOW policy to override abused-TLD block, but domain was blocked")
+	}
+}
+
 func TestSetAcceptQueries(t *testing.T) {
 	e := newTestEngine(nil, nil)
 


### PR DESCRIPTION
## What

Adds an **opt-in** data-plane guard that blocks DNS queries whose final label (TLD) is in a configured high-abuse set (e.g. `zip`, `mov`, `top`, `xyz`). The feature is **default OFF** — an empty list is a complete no-op.

## Why

Several TLDs (notably `.zip` and `.mov`, which collide with common file extensions, plus cheap bulk-registered ones like `.top`/`.xyz`) are disproportionately used for phishing and malware C2. Operators who never expect legitimate traffic to these TLDs can now block them wholesale without maintaining a per-domain blocklist.

## How

- **`internal/config`**: new `AbusedTLDs []string` field on `DataPlaneConfig` (yaml `abused_tlds`), plus an `ABUSED_TLDS` env override (comma-separated, split on `,`, trimmed, lowercased) following the existing `DefaultConfig` env-override pattern.
- **`internal/dnsengine`**: the configured set is normalized into a `map[string]bool` **once** in `NewDNSEngine` and stored on the `Engine` struct — no globals in the hot path. Enforcement lives in `ProcessDNSQuery` on the **default allow path only**, mirroring the suspicious-but-allowed handling. It blocks via the existing `respondBlocked(w, r, domain, "abused-tld")` (returns `0.0.0.0` / `::`).
- **Ordering / precedence preserved**: blocklist and `BLOCK`/`REDIRECT` policies are untouched. An **explicit `ALLOW` policy still wins** — the TLD block is skipped when the policy decision carries a `PolicyID` (i.e. an explicit match), so it only fires on the true default-allow path.
- Empty/nil set = zero behaviour change.

## Tests

- `TestProcessDNSQuery_AbusedTLDBlocks` — TLD in set is blocked (`0.0.0.0`).
- `TestProcessDNSQuery_AbusedTLDNotInSetAllowed` — TLD not in set reaches the allow path.
- `TestProcessDNSQuery_AbusedTLDEmptySetIsOff` — empty set = feature off, `.zip` not blocked.
- `TestProcessDNSQuery_AbusedTLDAllowPolicyOverrides` — explicit `ALLOW` policy overrides the TLD block.
- `TestParseAbusedTLDs` — env parsing: split, trim, lowercase, drop empties.

`gofmt`, `go build ./...`, `go vet ./internal/dnsengine/... ./internal/config/...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)