### PR TITLE
feat(dataplane): optional DNS rebinding protection (I-044)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -13,6 +13,9 @@ dataplane:
   # Env overrides: THREAT_BLOCK_THRESHOLD, THREAT_BLOCK_DRYRUN.
   threat_block_threshold: 0
   threat_block_dryrun: false
+  # Reject upstream answers that map a public name to a private/loopback/
+  # link-local IP (DNS rebinding defense). Env override: REBIND_PROTECTION.
+  rebind_protection: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,10 @@ type DataPlaneConfig struct {
 	// AbusedTLDs is the set of high-abuse TLDs (e.g. "zip", "mov", "top") to
 	// block on the default allow path. Empty (the default) disables the feature.
 	AbusedTLDs []string `yaml:"abused_tlds"`
+
+	// RebindProtection rejects upstream answers that map a public name to a
+	// private/loopback/link-local IP (DNS rebinding defense). Default false.
+	RebindProtection bool `yaml:"rebind_protection"`
 }
 
 type ControlPlaneConfig struct {
@@ -100,6 +104,13 @@ var DefaultConfig = func() *Config {
 	}
 	if v := os.Getenv("ABUSED_TLDS"); v != "" {
 		cfg.DataPlane.AbusedTLDs = parseAbusedTLDs(v)
+	}
+	if v := os.Getenv("REBIND_PROTECTION"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.RebindProtection = b
+		} else {
+			logger.Log.Warnf("Invalid REBIND_PROTECTION value %q: %v", v, err)
+		}
 	}
 	return cfg
 }()

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -2,6 +2,7 @@
 package dnsengine
 
 import (
+	"net"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -45,6 +46,10 @@ type Engine struct {
 	// abusedTLDs is the set of high-abuse TLDs to block on the default allow
 	// path (lowercased, no leading dot). Empty/nil disables the feature.
 	abusedTLDs map[string]bool
+
+	// rebindProtection, when true, strips A/AAAA answers that resolve a public
+	// name to a private/loopback/link-local IP. Default false (unchanged behaviour).
+	rebindProtection bool
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -85,6 +90,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		threatBlockThreshold: cfg.ThreatBlockThreshold,
 		threatBlockDryRun:    cfg.ThreatBlockDryRun,
 		abusedTLDs:           abusedTLDs,
+		rebindProtection:     cfg.RebindProtection,
 	}, nil
 }
 
@@ -153,6 +159,33 @@ func (e *Engine) respondRedirect(w dns.ResponseWriter, r *dns.Msg, domain, ip st
 	}
 }
 
+// filterRebind removes A/AAAA answer records whose IP is private, loopback,
+// link-local, or unspecified. This defends against DNS rebinding, where a
+// public name is resolved to an internal address to reach services behind the
+// resolver. Non-A/AAAA records are always kept. It is a pure function: it
+// returns the surviving records and the number that were dropped.
+func filterRebind(answers []dns.RR) (kept []dns.RR, dropped int) {
+	for _, rr := range answers {
+		var ip net.IP
+		switch v := rr.(type) {
+		case *dns.A:
+			ip = v.A
+		case *dns.AAAA:
+			ip = v.AAAA
+		default:
+			kept = append(kept, rr)
+			continue
+		}
+		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			dropped++
+			continue
+		}
+		kept = append(kept, rr)
+	}
+	return kept, dropped
+}
+
 func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string) {
 	resp, err := e.upstreamManager.Exchange(r, 5, 2)
 	if err != nil {
@@ -169,6 +202,23 @@ func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string
 		_ = w.WriteMsg(m)
 		return
 	}
+
+	// DNS rebinding protection: strip answers that map a public name to an
+	// internal IP. If dropping them leaves an A/AAAA query with no answers at
+	// all, block the response outright instead of returning an empty reply.
+	if e.rebindProtection {
+		kept, dropped := filterRebind(resp.Answer)
+		if dropped > 0 {
+			logger.Log.Warnf("Rebind protection dropped %d record(s) for %s", dropped, domain)
+			resp.Answer = kept
+			qtype := r.Question[0].Qtype
+			if len(kept) == 0 && (qtype == dns.TypeA || qtype == dns.TypeAAAA) {
+				e.respondBlocked(w, r, domain, "rebind")
+				return
+			}
+		}
+	}
+
 	if err := w.WriteMsg(resp); err != nil {
 		logger.Log.Error("Failed to write DNS response: " + err.Error())
 	}

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -430,6 +430,97 @@ func TestShouldEnforceThreat(t *testing.T) {
 	}
 }
 
+// mustRR builds a dns.RR from its zone-file string form or fails the test.
+func mustRR(t *testing.T, s string) dns.RR {
+	t.Helper()
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		t.Fatalf("failed to build RR %q: %v", s, err)
+	}
+	return rr
+}
+
+// TestFilterRebind_SingleRecord classifies one record at a time: private,
+// loopback, link-local (unicast + multicast), and unspecified addresses must be
+// dropped, while genuine public addresses must be kept — for both A and AAAA.
+func TestFilterRebind_SingleRecord(t *testing.T) {
+	tests := []struct {
+		name     string
+		rr       string
+		wantDrop bool
+	}{
+		// Private IPv4 (RFC 1918)
+		{"private-10", "example.com. 300 IN A 10.0.0.1", true},
+		{"private-172", "example.com. 300 IN A 172.16.5.4", true},
+		{"private-192", "example.com. 300 IN A 192.168.1.1", true},
+		// Loopback
+		{"loopback-v4", "example.com. 300 IN A 127.0.0.1", true},
+		{"loopback-v6", "example.com. 300 IN AAAA ::1", true},
+		// Link-local unicast
+		{"linklocal-v4", "example.com. 300 IN A 169.254.1.1", true},
+		{"linklocal-v6", "example.com. 300 IN AAAA fe80::1", true},
+		// Link-local multicast
+		{"llmulticast-v4", "example.com. 300 IN A 224.0.0.251", true},
+		{"llmulticast-v6", "example.com. 300 IN AAAA ff02::1", true},
+		// Unspecified
+		{"unspecified-v4", "example.com. 300 IN A 0.0.0.0", true},
+		{"unspecified-v6", "example.com. 300 IN AAAA ::", true},
+		// Private IPv6 (ULA fc00::/7)
+		{"ula-v6", "example.com. 300 IN AAAA fc00::1", true},
+		// Public — kept
+		{"public-v4-google", "example.com. 300 IN A 8.8.8.8", false},
+		{"public-v4-cf", "example.com. 300 IN A 1.1.1.1", false},
+		{"public-v6-cf", "example.com. 300 IN AAAA 2606:4700:4700::1111", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kept, dropped := filterRebind([]dns.RR{mustRR(t, tt.rr)})
+			if tt.wantDrop {
+				if dropped != 1 || len(kept) != 0 {
+					t.Errorf("%s: expected dropped=1 kept=0, got dropped=%d kept=%d", tt.rr, dropped, len(kept))
+				}
+			} else {
+				if dropped != 0 || len(kept) != 1 {
+					t.Errorf("%s: expected dropped=0 kept=1, got dropped=%d kept=%d", tt.rr, dropped, len(kept))
+				}
+			}
+		})
+	}
+}
+
+// TestFilterRebind_Mixed verifies a mixed answer set keeps only the public
+// records and reports the correct drop count.
+func TestFilterRebind_Mixed(t *testing.T) {
+	answers := []dns.RR{
+		mustRR(t, "example.com. 300 IN A 8.8.8.8"),                 // public, keep
+		mustRR(t, "example.com. 300 IN A 192.168.1.1"),             // private, drop
+		mustRR(t, "example.com. 300 IN AAAA 2606:4700:4700::1111"), // public, keep
+		mustRR(t, "example.com. 300 IN AAAA ::1"),                  // loopback, drop
+		mustRR(t, "example.com. 300 IN A 127.0.0.1"),               // loopback, drop
+	}
+	kept, dropped := filterRebind(answers)
+	if dropped != 3 {
+		t.Errorf("expected 3 dropped, got %d", dropped)
+	}
+	if len(kept) != 2 {
+		t.Fatalf("expected 2 kept, got %d", len(kept))
+	}
+	for _, rr := range kept {
+		switch v := rr.(type) {
+		case *dns.A:
+			if v.A.String() != "8.8.8.8" {
+				t.Errorf("unexpected A kept: %s", v.A.String())
+			}
+		case *dns.AAAA:
+			if v.AAAA.String() != "2606:4700:4700::1111" {
+				t.Errorf("unexpected AAAA kept: %s", v.AAAA.String())
+			}
+		default:
+			t.Errorf("unexpected record type kept: %T", rr)
+		}
+	}
+}
+
 func TestThreatDecision(t *testing.T) {
 	sus := threat.Result{IsSuspicious: true, ThreatScore: 0.9}
 
@@ -476,5 +567,58 @@ func TestProcessDNSQuery_ThreatBlockDisabledByDefault(t *testing.T) {
 	}
 	if got := e.threatDecision(sus); got != threatNone {
 		t.Errorf("default threshold (0) must not enforce, got %v", got)
+	}
+}
+
+// TestFilterRebind_NonAddressRecordsUntouched ensures records that are not
+// A/AAAA (CNAME, MX, TXT) are always preserved, even alongside dropped IPs.
+func TestFilterRebind_NonAddressRecordsUntouched(t *testing.T) {
+	answers := []dns.RR{
+		mustRR(t, "example.com. 300 IN CNAME target.example.net."),
+		mustRR(t, "example.com. 300 IN MX 10 mail.example.net."),
+		mustRR(t, "example.com. 300 IN TXT \"v=spf1 -all\""),
+		mustRR(t, "example.com. 300 IN A 10.0.0.1"), // private, drop
+	}
+	kept, dropped := filterRebind(answers)
+	if dropped != 1 {
+		t.Errorf("expected 1 dropped, got %d", dropped)
+	}
+	if len(kept) != 3 {
+		t.Fatalf("expected 3 non-address records kept, got %d", len(kept))
+	}
+	for _, rr := range kept {
+		switch rr.(type) {
+		case *dns.A, *dns.AAAA:
+			t.Errorf("no address record should survive, got %T", rr)
+		}
+	}
+}
+
+// TestFilterRebind_AllPublicUnchanged verifies a fully public answer set is
+// passed through untouched with zero drops.
+func TestFilterRebind_AllPublicUnchanged(t *testing.T) {
+	answers := []dns.RR{
+		mustRR(t, "example.com. 300 IN A 8.8.8.8"),
+		mustRR(t, "example.com. 300 IN A 1.1.1.1"),
+		mustRR(t, "example.com. 300 IN AAAA 2001:4860:4860::8888"),
+	}
+	kept, dropped := filterRebind(answers)
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	if len(kept) != len(answers) {
+		t.Errorf("expected all %d records kept, got %d", len(answers), len(kept))
+	}
+}
+
+// TestFilterRebind_Empty verifies the empty/nil-input edge cases.
+func TestFilterRebind_Empty(t *testing.T) {
+	kept, dropped := filterRebind(nil)
+	if dropped != 0 || len(kept) != 0 {
+		t.Errorf("expected empty result for nil input, got dropped=%d kept=%d", dropped, len(kept))
+	}
+	kept, dropped = filterRebind([]dns.RR{})
+	if dropped != 0 || len(kept) != 0 {
+		t.Errorf("expected empty result for empty input, got dropped=%d kept=%d", dropped, len(kept))
 	}
 }


### PR DESCRIPTION
## What

Adds an **opt-in** DNS rebinding protection layer to the dataplane. When enabled, upstream answers that map a *public* domain name to a **private / loopback / link-local / unspecified** IP are stripped before the response is returned to the client.

Default is **OFF**, so existing behaviour is completely unchanged.

## Why

DNS rebinding is a classic attack: an attacker controls a public domain and returns an internal IP (e.g. `192.168.1.1`, `127.0.0.1`, `169.254.x.x`) so a victim's browser is tricked into making requests to services behind the resolver/gateway. For an on-prem DNS security gateway sitting in front of SMB/school/hospital networks, blocking these answers is a cheap, high-value hardening.

## How

- `filterRebind(answers []dns.RR) (kept []dns.RR, dropped int)` — a **pure** helper in `internal/dnsengine/engine.go`. It drops A/AAAA records whose IP satisfies `IsPrivate() || IsLoopback() || IsLinkLocalUnicast() || IsLinkLocalMulticast() || IsUnspecified()` (stdlib `net.IP` methods). Non-A/AAAA records (CNAME/MX/TXT/…) are always kept.
- `forwardUpstream` runs the upstream `resp.Answer` through the filter only when protection is enabled. If records were dropped it logs a warning; if that leaves **zero** answers for an A/AAAA query it blocks via the existing `respondBlocked(w, r, domain, "rebind")` (returns `0.0.0.0` / `::`) rather than returning an empty reply.
- Config: `DataPlaneConfig.RebindProtection` (`yaml: rebind_protection`), env override `REBIND_PROTECTION` parsed with `strconv.ParseBool`, following the existing env-override pattern. Wired onto the `Engine` struct in `NewDNSEngine`.
- Documented the flag in `configs/config.yaml` (default `false`).

## Tests

Thorough unit tests for the pure helper (no live upstream / network needed):
- Each address class dropped: private (10/172.16/192.168), loopback (v4/v6), link-local unicast (v4/v6), link-local multicast (v4/v6), unspecified (v4/v6), IPv6 ULA.
- Public v4/v6 kept.
- Mixed set: only public records survive, correct drop count.
- Non-A/AAAA records (CNAME/MX/TXT) always preserved.
- All-public set passes through untouched; nil/empty input edge cases.

Verification (all green):
- `gofmt -w`
- `go build ./...`
- `go vet ./internal/dnsengine/...`
- `go test ./...`

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test coverage improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)