### PR TITLE
feat(dataplane): optional per-client query rate limiting (I-046)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -16,6 +16,9 @@ dataplane:
   # Reject upstream answers that map a public name to a private/loopback/
   # link-local IP (DNS rebinding defense). Env override: REBIND_PROTECTION.
   rebind_protection: false
+  # Optional per-client DNS query rate limit (queries/sec per client IP).
+  # 0 disables it (default). Env override: CLIENT_RATE_LIMIT_PER_SEC.
+  client_rate_limit_per_sec: 0
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,10 @@ type DataPlaneConfig struct {
 	// RebindProtection rejects upstream answers that map a public name to a
 	// private/loopback/link-local IP (DNS rebinding defense). Default false.
 	RebindProtection bool `yaml:"rebind_protection"`
+
+	// ClientRateLimitPerSec caps DNS queries accepted per client IP each second.
+	// 0 (the default) disables rate limiting entirely.
+	ClientRateLimitPerSec int `yaml:"client_rate_limit_per_sec"`
 }
 
 type ControlPlaneConfig struct {
@@ -110,6 +114,13 @@ var DefaultConfig = func() *Config {
 			cfg.DataPlane.RebindProtection = b
 		} else {
 			logger.Log.Warnf("Invalid REBIND_PROTECTION value %q: %v", v, err)
+		}
+	}
+	if v := os.Getenv("CLIENT_RATE_LIMIT_PER_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.DataPlane.ClientRateLimitPerSec = n
+		} else {
+			logger.Log.Warnf("Invalid CLIENT_RATE_LIMIT_PER_SEC=%q, ignoring: %v", v, err)
 		}
 	}
 	return cfg

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -50,6 +50,8 @@ type Engine struct {
 	// rebindProtection, when true, strips A/AAAA answers that resolve a public
 	// name to a private/loopback/link-local IP. Default false (unchanged behaviour).
 	rebindProtection bool
+
+	rateLimiter *rateLimiter
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -91,6 +93,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		threatBlockDryRun:    cfg.ThreatBlockDryRun,
 		abusedTLDs:           abusedTLDs,
 		rebindProtection:     cfg.RebindProtection,
+		rateLimiter:          newRateLimiter(cfg.ClientRateLimitPerSec),
 	}, nil
 }
 
@@ -229,6 +232,17 @@ func normalizeDomain(d string) string {
 	return strings.TrimSuffix(strings.ToLower(d), ".")
 }
 
+// clientIPFromAddr extracts the host portion (IP) from a net.Addr so the rate
+// limiter keys on the client IP rather than the ephemeral source port, which
+// changes on every UDP query.
+func clientIPFromAddr(addr net.Addr) string {
+	s := addr.String()
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		return host
+	}
+	return s
+}
+
 // Known private/local DNS suffixes appended by routers via DHCP search domains.
 // When a router advertises a search domain (e.g., "hgu_lan", "home", "local"),
 // Windows/macOS append it to bare hostnames AND sometimes to FQDNs.
@@ -297,6 +311,19 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	if !e.state.acceptQueries.Load() {
+		m := new(dns.Msg)
+		m.SetRcode(r, dns.RcodeRefused)
+		_ = w.WriteMsg(m)
+		return
+	}
+
+	// --- Per-client rate limiting (default OFF; allows all when disabled) ---
+	rlClientIP := ""
+	if addr := w.RemoteAddr(); addr != nil {
+		rlClientIP = clientIPFromAddr(addr)
+	}
+	if !e.rateLimiter.allow(rlClientIP) {
+		logger.Log.Warnf("Rate limit exceeded for client %s, refusing query", rlClientIP)
 		m := new(dns.Msg)
 		m.SetRcode(r, dns.RcodeRefused)
 		_ = w.WriteMsg(m)

--- a/internal/dnsengine/ratelimit.go
+++ b/internal/dnsengine/ratelimit.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"sync"
+	"time"
+)
+
+// Bounds for the per-client rate limiter's memory footprint. Idle clients are
+// evicted lazily so a large, churning client population cannot grow the map
+// without limit.
+const (
+	rateLimitMaxClients = 65536
+	rateLimitIdleEvict  = 10 * time.Second
+)
+
+// clientWindow tracks the fixed one-second window state for a single client IP.
+type clientWindow struct {
+	windowStart time.Time
+	count       int
+	lastSeen    time.Time
+}
+
+// rateLimiter is a thread-safe, per-client-IP fixed-window rate limiter. It
+// allows up to perSec queries per client per second. When perSec <= 0 it is a
+// no-op that allows everything, so it is always safe to construct and call.
+type rateLimiter struct {
+	perSec     int
+	maxClients int
+	idleAfter  time.Duration
+
+	mu      sync.Mutex
+	clients map[string]*clientWindow
+
+	// now is injectable so tests can drive time deterministically without
+	// real sleeps. It defaults to time.Now.
+	now func() time.Time
+}
+
+// newRateLimiter builds a limiter capped at perSec queries per client IP each
+// second. A perSec <= 0 yields an allow-all limiter (rate limiting disabled).
+func newRateLimiter(perSec int) *rateLimiter {
+	return &rateLimiter{
+		perSec:     perSec,
+		maxClients: rateLimitMaxClients,
+		idleAfter:  rateLimitIdleEvict,
+		clients:    make(map[string]*clientWindow),
+		now:        time.Now,
+	}
+}
+
+// allow reports whether a query from clientIP may proceed. It returns true
+// (allow) when rate limiting is disabled (perSec <= 0) or the limiter is nil,
+// so callers need not special-case those states.
+func (rl *rateLimiter) allow(clientIP string) bool {
+	if rl == nil || rl.perSec <= 0 {
+		return true
+	}
+
+	now := rl.now()
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	w, ok := rl.clients[clientIP]
+	if !ok {
+		if len(rl.clients) >= rl.maxClients {
+			rl.evictIdle(now)
+		}
+		w = &clientWindow{windowStart: now}
+		rl.clients[clientIP] = w
+	}
+
+	// Roll to a fresh window once a full second has elapsed.
+	if now.Sub(w.windowStart) >= time.Second {
+		w.windowStart = now
+		w.count = 0
+	}
+
+	w.lastSeen = now
+	if w.count >= rl.perSec {
+		return false
+	}
+	w.count++
+	return true
+}
+
+// evictIdle removes clients that have not been seen within idleAfter. It must
+// be called with rl.mu held. This is best-effort: if every tracked client is
+// active the map may still exceed maxClients, but memory stays bounded by the
+// active client population rather than growing forever.
+func (rl *rateLimiter) evictIdle(now time.Time) {
+	for ip, w := range rl.clients {
+		if now.Sub(w.lastSeen) >= rl.idleAfter {
+			delete(rl.clients, ip)
+		}
+	}
+}

--- a/internal/dnsengine/ratelimit_test.go
+++ b/internal/dnsengine/ratelimit_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// fakeClock is a manually advanced clock for deterministic, sleep-free tests.
+type fakeClock struct {
+	t time.Time
+}
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newTestLimiter(perSec int, clk *fakeClock) *rateLimiter {
+	rl := newRateLimiter(perSec)
+	rl.now = clk.now
+	return rl
+}
+
+func TestRateLimiter_UnderLimitAllowed(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(5, clk)
+
+	for i := 0; i < 5; i++ {
+		if !rl.allow("10.0.0.1") {
+			t.Fatalf("query %d within limit should be allowed", i+1)
+		}
+	}
+}
+
+func TestRateLimiter_OverLimitDenied(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(3, clk)
+
+	for i := 0; i < 3; i++ {
+		if !rl.allow("10.0.0.1") {
+			t.Fatalf("query %d within limit should be allowed", i+1)
+		}
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("query over the limit should be denied")
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("subsequent query over the limit should stay denied")
+	}
+}
+
+func TestRateLimiter_WindowResets(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(2, clk)
+
+	if !rl.allow("10.0.0.1") || !rl.allow("10.0.0.1") {
+		t.Fatal("first two queries should be allowed")
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("third query in the same window should be denied")
+	}
+
+	// Advance past the one-second window; the counter must reset.
+	clk.advance(time.Second)
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("query should be allowed after the window resets")
+	}
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("second query in the new window should be allowed")
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("third query in the new window should be denied")
+	}
+}
+
+func TestRateLimiter_PartialWindowDoesNotReset(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(2, clk)
+
+	if !rl.allow("10.0.0.1") || !rl.allow("10.0.0.1") {
+		t.Fatal("first two queries should be allowed")
+	}
+	// Less than a full second: still the same window, still denied.
+	clk.advance(500 * time.Millisecond)
+	if rl.allow("10.0.0.1") {
+		t.Fatal("query within the same window should be denied")
+	}
+}
+
+func TestRateLimiter_ClientsIndependent(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(1, clk)
+
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("first client's first query should be allowed")
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("first client's second query should be denied")
+	}
+	// A different client has its own budget and is unaffected.
+	if !rl.allow("10.0.0.2") {
+		t.Fatal("second client's first query should be allowed")
+	}
+	if rl.allow("10.0.0.2") {
+		t.Fatal("second client's second query should be denied")
+	}
+}
+
+func TestRateLimiter_DisabledAllowsAll(t *testing.T) {
+	for _, perSec := range []int{0, -1} {
+		clk := &fakeClock{t: time.Unix(0, 0)}
+		rl := newTestLimiter(perSec, clk)
+		for i := 0; i < 1000; i++ {
+			if !rl.allow("10.0.0.1") {
+				t.Fatalf("perSec=%d should allow all queries, denied at %d", perSec, i)
+			}
+		}
+	}
+}
+
+func TestRateLimiter_NilReceiverAllows(t *testing.T) {
+	var rl *rateLimiter
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("nil limiter should allow all queries")
+	}
+}
+
+func TestRateLimiter_EvictsIdleClients(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(1, clk)
+	rl.maxClients = 2
+
+	rl.allow("10.0.0.1")
+	rl.allow("10.0.0.2")
+	if len(rl.clients) != 2 {
+		t.Fatalf("expected 2 tracked clients, got %d", len(rl.clients))
+	}
+
+	// Move well past the idle threshold, then add a new client. The full map
+	// triggers an idle sweep that clears the two stale entries.
+	clk.advance(rateLimitIdleEvict + time.Second)
+	rl.allow("10.0.0.3")
+	if _, ok := rl.clients["10.0.0.1"]; ok {
+		t.Error("idle client 10.0.0.1 should have been evicted")
+	}
+	if _, ok := rl.clients["10.0.0.2"]; ok {
+		t.Error("idle client 10.0.0.2 should have been evicted")
+	}
+	if _, ok := rl.clients["10.0.0.3"]; !ok {
+		t.Error("active client 10.0.0.3 should be tracked")
+	}
+}
+
+// TestProcessDNSQuery_RateLimited exercises the limiter through the engine's
+// request path: the second query from the same client in one window is REFUSED.
+func TestProcessDNSQuery_RateLimited(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	rl := newRateLimiter(1)
+	rl.now = clk.now
+	e.rateLimiter = rl
+
+	// First query is under the limit. With no upstream manager configured the
+	// forward path is not what we assert here; a fresh writer keeps it isolated.
+	w1 := &mockResponseWriter{}
+	func() {
+		defer func() { _ = recover() }() // forwardUpstream has no upstream in tests
+		e.ProcessDNSQuery(w1, newTestQuery("example.com"))
+	}()
+
+	// Second query in the same window must be refused before any forwarding.
+	w2 := &mockResponseWriter{}
+	e.ProcessDNSQuery(w2, newTestQuery("example.com"))
+	if w2.msg == nil {
+		t.Fatal("expected a REFUSED response for the rate-limited query")
+	}
+	if w2.msg.Rcode != dns.RcodeRefused {
+		t.Errorf("expected REFUSED rcode for rate-limited query, got %d", w2.msg.Rcode)
+	}
+}


### PR DESCRIPTION
## What
Adds an **optional, per-client-IP DNS query rate limiter** to the data plane. It caps how many queries a single client IP may make per second and refuses the excess. **Disabled by default** (`0` = off) — zero behavior change unless explicitly configured.

## Why
A single runaway or malware-infected device on the LAN can flood the resolver (DNS tunneling, DGA beaconing, amplification abuse) and degrade service for everyone else. A cheap per-client cap contains the blast radius without touching well-behaved clients.

## How
- **Config**: new `DataPlaneConfig.ClientRateLimitPerSec` (yaml `client_rate_limit_per_sec`, env `CLIENT_RATE_LIMIT_PER_SEC` parsed with `strconv.Atoi`, following the existing env-override pattern). Default `0`.
- **`internal/dnsengine/ratelimit.go`**: a small thread-safe fixed-window limiter keyed by client IP. Bounded memory via lazy eviction of idle clients once a max-map-size threshold is hit. `allow()` is nil-safe and allows everything when `perSec <= 0`. Clock is injectable for deterministic tests.
- **`engine.go`**: wired onto the `Engine` (built in `NewDNSEngine` from cfg). In `ProcessDNSQuery`, immediately after the `acceptQueries` gate, the client IP is derived from `w.RemoteAddr()` (nil-guarded, port stripped so keying is by IP not ephemeral port). On denial it responds `REFUSED` and returns before any forwarding — no success recorded.

## Tests (`ratelimit_test.go`)
- under-limit allowed; over-limit denied (and stays denied)
- window resets after a full second; partial window does not reset
- distinct client IPs are independent
- `perSec <= 0` and nil receiver allow everything
- idle clients are evicted when the map fills
- end-to-end `ProcessDNSQuery` returns `REFUSED` on the over-limit query

All deterministic via an injected fake clock (no real sleeps). `go build ./...`, `go vet ./internal/dnsengine/...`, and `go test ./...` (incl. `-race`) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)