### PR TITLE
feat(dataplane): record block reason in the query log (I-015)

### DIFF
--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -357,7 +357,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			logger.Log.Error("Blocklist check failed: " + err.Error())
 		} else if blocked {
 			logger.Log.Infof("Blocked by blocklist: %s", domainName)
-			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.logQuery(domainName, clientIP, "block", "blocklist", threatResult)
 			e.respondBlocked(w, r, domainName, "blocklist")
 			success = true
 			return
@@ -368,7 +368,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	decision, err := e.policyEngine.Evaluate(domainName)
 	if err != nil {
 		logger.Log.Error("Failed to evaluate policy: " + err.Error())
-		e.logQuery(domainName, clientIP, "error", threatResult)
+		e.logQuery(domainName, clientIP, "error", "", threatResult)
 		m := new(dns.Msg)
 		m.SetRcode(r, dns.RcodeServerFailure)
 		_ = w.WriteMsg(m)
@@ -378,12 +378,12 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	switch decision.Action {
 	case policy.ActionDeny:
 		logger.Log.Infof("Blocking via policy %s", decision.PolicyID)
-		e.logQuery(domainName, clientIP, "block", threatResult)
+		e.logQuery(domainName, clientIP, "block", decision.PolicyID, threatResult)
 		e.respondBlocked(w, r, domainName, decision.PolicyID)
 		success = true
 
 	case policy.ActionRedirect:
-		e.logQuery(domainName, clientIP, "redirect", threatResult)
+		e.logQuery(domainName, clientIP, "redirect", "redirect:"+decision.PolicyID, threatResult)
 		e.respondRedirect(w, r, domainName, decision.RedirectIP)
 		success = true
 
@@ -395,7 +395,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		case threatBlock:
 			logger.Log.Warnf("Blocking suspicious domain %s (score=%.2f >= %.2f, method=%s)",
 				domainName, threatResult.ThreatScore, e.threatBlockThreshold, threatResult.DetectionMethod)
-			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.logQuery(domainName, clientIP, "block", "threat:"+threatResult.DetectionMethod, threatResult)
 			e.respondBlocked(w, r, domainName, "threat:"+threatResult.DetectionMethod)
 			success = true
 			return
@@ -409,23 +409,25 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// still wins and is forwarded normally.
 		if decision.PolicyID == "" && e.isAbusedTLD(domainName) {
 			logger.Log.Infof("Blocking via abused TLD: %s", domainName)
-			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.logQuery(domainName, clientIP, "block", "abused-tld", threatResult)
 			e.respondBlocked(w, r, domainName, "abused-tld")
 			success = true
 			return
 		}
 		action := "allow"
+		reason := ""
 		if threatResult.IsSuspicious {
 			action = "flagged"
+			reason = threatResult.DetectionMethod
 			logger.Log.Warnf("Suspicious domain allowed: %s (score=%.2f, method=%s)", domainName, threatResult.ThreatScore, threatResult.DetectionMethod)
 		}
-		e.logQuery(domainName, clientIP, action, threatResult)
+		e.logQuery(domainName, clientIP, action, reason, threatResult)
 		e.forwardUpstream(w, r, domainName)
 		success = true
 	}
 }
 
-func (e *Engine) logQuery(domain, clientIP, action string, tr threat.Result) {
+func (e *Engine) logQuery(domain, clientIP, action, reason string, tr threat.Result) {
 	if e.queryLog == nil {
 		return
 	}
@@ -433,6 +435,7 @@ func (e *Engine) logQuery(domain, clientIP, action string, tr threat.Result) {
 		Domain:          domain,
 		ClientIP:        clientIP,
 		Action:          action,
+		BlockReason:     reason,
 		IsSuspicious:    tr.IsSuspicious,
 		ThreatScore:     tr.ThreatScore,
 		DetectionMethod: tr.DetectionMethod,

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -3,9 +3,11 @@ package dnsengine
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/lopster568/phantomDNS/internal/metrics"
 	"github.com/lopster568/phantomDNS/internal/policy"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"github.com/lopster568/phantomDNS/internal/threat"
 	"github.com/miekg/dns"
 )
@@ -36,6 +38,37 @@ func (w *mockResponseWriter) Close() error              { return nil }
 func (w *mockResponseWriter) TsigStatus() error         { return nil }
 func (w *mockResponseWriter) TsigTimersOnly(bool)       {}
 func (w *mockResponseWriter) Hijack()                   {}
+
+// mockQueryLog captures saved DNSQuery rows so tests can assert what was persisted.
+// logQuery saves asynchronously, so Save publishes onto a buffered channel.
+type mockQueryLog struct {
+	saved chan *models.DNSQuery
+}
+
+func newMockQueryLog() *mockQueryLog {
+	return &mockQueryLog{saved: make(chan *models.DNSQuery, 4)}
+}
+
+func (m *mockQueryLog) Save(q *models.DNSQuery) error {
+	m.saved <- q
+	return nil
+}
+
+func (m *mockQueryLog) ListRecent(limit int) ([]models.DNSQuery, error) {
+	return nil, nil
+}
+
+// waitSaved blocks until logQuery's goroutine persists a row (or times out).
+func (m *mockQueryLog) waitSaved(t *testing.T) *models.DNSQuery {
+	t.Helper()
+	select {
+	case q := <-m.saved:
+		return q
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for query to be logged")
+		return nil
+	}
+}
 
 func newTestQuery(domain string) *dns.Msg {
 	m := new(dns.Msg)
@@ -621,4 +654,87 @@ func TestFilterRebind_Empty(t *testing.T) {
 	if dropped != 0 || len(kept) != 0 {
 		t.Errorf("expected empty result for empty input, got dropped=%d kept=%d", dropped, len(kept))
 	}
+}
+
+// TestLogQuery_ThreadsBlockReason verifies logQuery persists the reason it is
+// given into DNSQuery.BlockReason (I-015) without touching the threat fields.
+func TestLogQuery_ThreadsBlockReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		reason string
+	}{
+		{"blocklist block", "block", "blocklist"},
+		{"policy block", "block", "block-ads"},
+		{"redirect", "redirect", "redirect:safe-search"},
+		{"plain allow", "allow", ""},
+		{"flagged uses threat method", "flagged", "entropy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mq := newMockQueryLog()
+			e := &Engine{queryLog: mq}
+
+			tr := threat.Result{DetectionMethod: "entropy", Reason: "high entropy"}
+			e.logQuery("example.com", "1.2.3.4", tt.action, tt.reason, tr)
+
+			got := mq.waitSaved(t)
+			if got.BlockReason != tt.reason {
+				t.Errorf("BlockReason = %q, want %q", got.BlockReason, tt.reason)
+			}
+			if got.Action != tt.action {
+				t.Errorf("Action = %q, want %q", got.Action, tt.action)
+			}
+			// Threat fields must be preserved unchanged.
+			if got.DetectionMethod != tr.DetectionMethod || got.ThreatReason != tr.Reason {
+				t.Errorf("threat fields altered: DetectionMethod=%q ThreatReason=%q", got.DetectionMethod, got.ThreatReason)
+			}
+		})
+	}
+}
+
+// TestProcessDNSQuery_LogsBlockReason verifies each blocking call site threads
+// the correct reason string end-to-end through ProcessDNSQuery.
+func TestProcessDNSQuery_LogsBlockReason(t *testing.T) {
+	t.Run("blocklist", func(t *testing.T) {
+		mq := newMockQueryLog()
+		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{"ads.example.com": true}}, nil)
+		e.queryLog = mq
+
+		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("ads.example.com"))
+
+		if got := mq.waitSaved(t); got.BlockReason != "blocklist" {
+			t.Errorf("BlockReason = %q, want %q", got.BlockReason, "blocklist")
+		}
+	})
+
+	t.Run("policy block records policy ID", func(t *testing.T) {
+		policies := []policy.Policy{
+			{ID: "block-ads", Action: "BLOCK", Priority: 100, Domains: []string{"policy-blocked.com"}},
+		}
+		mq := newMockQueryLog()
+		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, policies)
+		e.queryLog = mq
+
+		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("policy-blocked.com"))
+
+		if got := mq.waitSaved(t); got.BlockReason != "block-ads" {
+			t.Errorf("BlockReason = %q, want %q", got.BlockReason, "block-ads")
+		}
+	})
+
+	t.Run("redirect records redirect:policyID", func(t *testing.T) {
+		policies := []policy.Policy{
+			{ID: "safe-search", Action: "REDIRECT", Redirect: "1.2.3.4", Priority: 100, Domains: []string{"redirect-me.com"}},
+		}
+		mq := newMockQueryLog()
+		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, policies)
+		e.queryLog = mq
+
+		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("redirect-me.com"))
+
+		if got := mq.waitSaved(t); got.BlockReason != "redirect:safe-search" {
+			t.Errorf("BlockReason = %q, want %q", got.BlockReason, "redirect:safe-search")
+		}
+	})
 }

--- a/internal/storage/models/dns_query.model.go
+++ b/internal/storage/models/dns_query.model.go
@@ -13,4 +13,5 @@ type DNSQuery struct {
 	ThreatScore     float64   `gorm:"default:0"`
 	DetectionMethod string    `gorm:"default:''"`
 	ThreatReason    string    `gorm:"default:''"`
+	BlockReason     string    `gorm:"default:''"` // why the query was blocked/redirected: "blocklist", a policy ID, "redirect:<policyID>", a threat method, or "" for allow
 }


### PR DESCRIPTION
## What
Records *why* a query was blocked or redirected in the query log. Adds a `BlockReason` field to the `DNSQuery` model and threads the reason through `logQuery` from every decision site in the DNS engine.

## Why
Today `respondBlocked(w, r, domain, reason)` already receives a reason ("blocklist", a policy ID, etc.), but that reason was never persisted — the logged `DNSQuery` row only recorded the coarse `Action` ("block"/"redirect"), so operators could not tell *what* caused a block when auditing the log. This closes that gap.

## How
- **Model**: new `BlockReason string` column on `DNSQuery` (`gorm:"default:''"`), nullable/empty by default — additive and backward-compatible via auto-migrate; existing rows and allow queries carry an empty reason.
- **Engine**: `logQuery` now takes a `reason` argument and stores it in `BlockReason`. Each call site passes the actual reason:
  - `"blocklist"` for a blocklist hit
  - the policy ID for a policy block
  - `"redirect:<policyID>"` for a redirect
  - the threat detection method for flagged (suspicious) queries
  - `""` for plain allow (and the error path)
- Existing threat fields (`IsSuspicious`, `ThreatScore`, `DetectionMethod`, `ThreatReason`) are untouched.

## Tests
- Extended `engine_test.go` with a `mockQueryLog` (channel-based, handles the async `Save`) and two tests:
  - `TestLogQuery_ThreadsBlockReason` — table test asserting each reason maps to `BlockReason` and threat fields are preserved.
  - `TestProcessDNSQuery_LogsBlockReason` — end-to-end through `ProcessDNSQuery` for the blocklist, policy-block, and redirect call sites.
- `gofmt`, `go build ./...`, `go vet ./internal/...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)