### PR TITLE
feat(dataplane): optional SafeSearch + YouTube-Restricted enforcement (I-036)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -19,6 +19,9 @@ dataplane:
   # Optional per-client DNS query rate limit (queries/sec per client IP).
   # 0 disables it (default). Env override: CLIENT_RATE_LIMIT_PER_SEC.
   client_rate_limit_per_sec: 0
+  # Rewrite well-known search/video hosts to their enforced-safe targets
+  # (Google/Bing/DuckDuckGo SafeSearch, YouTube Restricted Mode). Env: SAFE_SEARCH.
+  safe_search: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,11 @@ type DataPlaneConfig struct {
 	// ClientRateLimitPerSec caps DNS queries accepted per client IP each second.
 	// 0 (the default) disables rate limiting entirely.
 	ClientRateLimitPerSec int `yaml:"client_rate_limit_per_sec"`
+
+	// SafeSearch, when true, rewrites well-known search/video hosts to their
+	// enforced-safe CNAME targets (Google/Bing/DuckDuckGo SafeSearch and
+	// YouTube Restricted Mode). Default false = no rewrite.
+	SafeSearch bool `yaml:"safe_search"`
 }
 
 type ControlPlaneConfig struct {
@@ -121,6 +126,11 @@ var DefaultConfig = func() *Config {
 			cfg.DataPlane.ClientRateLimitPerSec = n
 		} else {
 			logger.Log.Warnf("Invalid CLIENT_RATE_LIMIT_PER_SEC=%q, ignoring: %v", v, err)
+		}
+	}
+	if v := os.Getenv("SAFE_SEARCH"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.SafeSearch = b
 		}
 	}
 	return cfg

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -52,6 +52,30 @@ type Engine struct {
 	rebindProtection bool
 
 	rateLimiter *rateLimiter
+
+	safeSearch bool
+}
+
+// safeSearchTargets maps well-known search/video hostnames to their
+// enforced-safe CNAME target. When SafeSearch is enabled, a query for any
+// mapped host on the allow path is answered with a CNAME to its target so the
+// client re-resolves the safe endpoint. These are the vendor-documented
+// SafeSearch / YouTube Restricted Mode hostnames.
+var safeSearchTargets = map[string]string{
+	// Google SafeSearch
+	"google.com":     "forcesafesearch.google.com",
+	"www.google.com": "forcesafesearch.google.com",
+	// Bing strict SafeSearch
+	"bing.com":     "strict.bing.com",
+	"www.bing.com": "strict.bing.com",
+	// DuckDuckGo safe search
+	"duckduckgo.com": "safe.duckduckgo.com",
+	// YouTube Restricted Mode (moderate)
+	"youtube.com":             "restrictmoderate.youtube.com",
+	"www.youtube.com":         "restrictmoderate.youtube.com",
+	"m.youtube.com":           "restrictmoderate.youtube.com",
+	"youtubei.googleapis.com": "restrictmoderate.youtube.com",
+	"youtube.googleapis.com":  "restrictmoderate.youtube.com",
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -94,6 +118,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		abusedTLDs:           abusedTLDs,
 		rebindProtection:     cfg.RebindProtection,
 		rateLimiter:          newRateLimiter(cfg.ClientRateLimitPerSec),
+		safeSearch:           cfg.SafeSearch,
 	}, nil
 }
 
@@ -187,6 +212,26 @@ func filterRebind(answers []dns.RR) (kept []dns.RR, dropped int) {
 		kept = append(kept, rr)
 	}
 	return kept, dropped
+}
+
+// respondSafeSearch answers the query with a CNAME pointing the queried name
+// at its enforced-safe target (e.g. www.google.com -> forcesafesearch.google.com).
+// The client then re-resolves the target through normal resolution.
+func (e *Engine) respondSafeSearch(w dns.ResponseWriter, r *dns.Msg, target string) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	name := r.Question[0].Name
+	rr, err := dns.NewRR(name + " 60 IN CNAME " + dns.Fqdn(target))
+	if err != nil {
+		logger.Log.Error("Failed to create SafeSearch CNAME RR: " + err.Error())
+		m.SetRcode(r, dns.RcodeServerFailure)
+		_ = w.WriteMsg(m)
+		return
+	}
+	m.Answer = append(m.Answer, rr)
+	if err := w.WriteMsg(m); err != nil {
+		logger.Log.Error("Failed to write SafeSearch response: " + err.Error())
+	}
 }
 
 func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string) {
@@ -414,6 +459,20 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			success = true
 			return
 		}
+
+		// SafeSearch enforcement: on the allow path, rewrite well-known search/
+		// video hosts to their enforced-safe target via a CNAME so the client
+		// re-resolves the safe endpoint. Never overrides a block/redirect above.
+		if e.safeSearch {
+			if target, ok := safeSearchTargets[domainName]; ok {
+				logger.Log.Infof("SafeSearch rewrite: %s -> %s", domainName, target)
+				e.logQuery(domainName, clientIP, "allow", "", threatResult)
+				e.respondSafeSearch(w, r, target)
+				success = true
+				return
+			}
+		}
+
 		action := "allow"
 		reason := ""
 		if threatResult.IsSuspicious {

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -738,3 +738,101 @@ func TestProcessDNSQuery_LogsBlockReason(t *testing.T) {
 		}
 	})
 }
+
+// cnameTarget returns the normalized target of the first CNAME answer, or "".
+func cnameTarget(m *dns.Msg) string {
+	if m == nil {
+		return ""
+	}
+	for _, rr := range m.Answer {
+		if c, ok := rr.(*dns.CNAME); ok {
+			return normalizeDomain(c.Target)
+		}
+	}
+	return ""
+}
+
+func TestProcessDNSQuery_SafeSearchRewrite(t *testing.T) {
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{"www.google.com", "forcesafesearch.google.com"},
+		{"google.com", "forcesafesearch.google.com"},
+		{"www.bing.com", "strict.bing.com"},
+		{"duckduckgo.com", "safe.duckduckgo.com"},
+		{"www.youtube.com", "restrictmoderate.youtube.com"},
+		{"m.youtube.com", "restrictmoderate.youtube.com"},
+		{"youtubei.googleapis.com", "restrictmoderate.youtube.com"},
+	}
+	for _, tt := range tests {
+		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+		e.safeSearch = true
+
+		w := &mockResponseWriter{}
+		e.ProcessDNSQuery(w, newTestQuery(tt.query))
+
+		if w.msg == nil {
+			t.Fatalf("%s: expected a response, got nil", tt.query)
+		}
+		if got := cnameTarget(w.msg); got != tt.want {
+			t.Errorf("%s: expected CNAME to %q, got %q (answer=%+v)", tt.query, tt.want, got, w.msg.Answer)
+		}
+	}
+}
+
+func TestProcessDNSQuery_SafeSearchUnmappedHost(t *testing.T) {
+	// SafeSearch on, but an unmapped host must not be rewritten. With an empty
+	// upstream manager the allow path yields SERVFAIL (no network) — the point
+	// is that there is no CNAME rewrite.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.safeSearch = true
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("example.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response")
+	}
+	if got := cnameTarget(w.msg); got != "" {
+		t.Errorf("expected no CNAME rewrite for unmapped host, got CNAME to %q", got)
+	}
+}
+
+func TestProcessDNSQuery_SafeSearchDisabled(t *testing.T) {
+	// SafeSearch disabled (default): a mapped host must not be rewritten.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.safeSearch = false
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("www.google.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response")
+	}
+	if got := cnameTarget(w.msg); got != "" {
+		t.Errorf("expected no CNAME rewrite when SafeSearch disabled, got CNAME to %q", got)
+	}
+}
+
+func TestProcessDNSQuery_SafeSearchDoesNotOverrideBlock(t *testing.T) {
+	// A mapped host that is also blocklisted must still be blocked, not rewritten.
+	bl := &mockBlocklist{blocked: map[string]bool{"www.google.com": true}}
+	e := newTestEngine(bl, nil)
+	e.safeSearch = true
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("www.google.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected block to win over SafeSearch rewrite, got %+v", w.msg.Answer)
+	}
+	if got := cnameTarget(w.msg); got != "" {
+		t.Errorf("expected no CNAME on blocked host, got CNAME to %q", got)
+	}
+}


### PR DESCRIPTION
## What
Adds an opt-in **SafeSearch** mode to the data plane that enforces Google/Bing/DuckDuckGo SafeSearch and YouTube Restricted Mode via DNS answer rewriting. **Default is OFF** — behavior is unchanged unless explicitly enabled.

## Why
Schools, hospitals and family/SMB deployments frequently need enforced safe search and restricted video without endpoint agents. Enforcing it at the DNS gateway is the standard, appliance-friendly mechanism (the same approach used by the major DNS filters), and it requires no client configuration.

## How
- New config `SafeSearch bool` on `DataPlaneConfig` (yaml `safe_search`, env `SAFE_SEARCH`, default `false`), wired onto the engine in `NewDNSEngine`.
- A `safeSearchTargets` map of well-known hostnames to their vendor-documented enforced-safe CNAME targets:
  - `google.com` / `www.google.com` -> `forcesafesearch.google.com`
  - `bing.com` / `www.bing.com` -> `strict.bing.com`
  - `duckduckgo.com` -> `safe.duckduckgo.com`
  - `youtube.com` / `www.youtube.com` / `m.youtube.com` / `youtubei.googleapis.com` / `youtube.googleapis.com` -> `restrictmoderate.youtube.com`
- In `ProcessDNSQuery`, on the **allow path only**, a mapped host is answered with a `CNAME` to its safe target so the client re-resolves the safe endpoint. Blocklist/policy blocks and redirects still take precedence — SafeSearch never overrides a block.
- Additive and self-contained: the rewrite path writes the response directly and needs no upstream.

## Tests
`internal/dnsengine/engine_test.go`:
- Mapped hosts with SafeSearch on -> response contains a CNAME to the expected safe target (table-driven across Google/Bing/DuckDuckGo/YouTube).
- Unmapped host with SafeSearch on -> no CNAME rewrite.
- SafeSearch disabled -> mapped host is not rewritten.
- Mapped host that is also blocklisted -> still blocked, not rewritten.

`gofmt`, `go build ./...`, `go vet ./internal/dnsengine/...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)