### PR TITLE
feat(dataplane): newly-observed-domain detection via local first-seen ledger (I-041)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,14 @@ type DataPlaneConfig struct {
 	// ServeStale, when true, answers from an expired cache entry if the upstream
 	// fails, so a transient upstream/ISP blip does not take DNS down. Default off.
 	ServeStale bool `yaml:"serve_stale"`
+
+	// Newly-observed-domain (NOD) detection. NODWindowHours is the first-seen
+	// window in hours; 0 (the default) disables NOD entirely. When enabled, a
+	// domain first seen on this resolver within the window is treated as newly
+	// observed. NODBlock decides the action: false (default) flags and forwards,
+	// true blocks the query. See internal/dnsengine/nod.go for the ledger.
+	NODWindowHours int  `yaml:"nod_window_hours"`
+	NODBlock       bool `yaml:"nod_block"`
 }
 
 // WatchdogIntervalDuration parses WatchdogInterval into a duration. It returns 0
@@ -283,6 +291,20 @@ var DefaultConfig = func() *Config {
 	}
 	if v := os.Getenv("SERVE_STALE"); v == "true" || v == "1" {
 		cfg.DataPlane.ServeStale = true
+	}
+	if v := os.Getenv("NOD_WINDOW_HOURS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.DataPlane.NODWindowHours = n
+		} else {
+			logger.Log.Warnf("Invalid NOD_WINDOW_HOURS=%q, ignoring: %v", v, err)
+		}
+	}
+	if v := os.Getenv("NOD_BLOCK"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.NODBlock = b
+		} else {
+			logger.Log.Warnf("Invalid NOD_BLOCK=%q, ignoring: %v", v, err)
+		}
 	}
 	return cfg
 }()

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -50,6 +50,12 @@ type Engine struct {
 	// cache holds recent allowed answers for serve-stale; nil when disabled.
 	cache *answerCache
 
+	// Newly-observed-domain (NOD) detection. nodLedger is nil when NOD is
+	// disabled (window <= 0). When set, nodBlock decides whether a newly
+	// observed domain is blocked (true) or merely flagged and forwarded (false).
+	nodLedger *nodLedger
+	nodBlock  bool
+
 	// threatBlockThreshold, when > 0, turns the heuristic threat detector from
 	// log-only into enforcement: a suspicious query with ThreatScore >= threshold
 	// is blocked. threatBlockDryRun logs a would-be block instead of blocking.
@@ -118,6 +124,13 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		}
 	}
 
+	// Newly-observed-domain ledger: only enabled when a positive window is set.
+	var ledger *nodLedger
+	if cfg.NODWindowHours > 0 {
+		ledger = newNODLedger(time.Duration(cfg.NODWindowHours)*time.Hour, nodDefaultMaxEntries, nil)
+		logger.Log.Infof("NOD detection enabled: window=%dh block=%v", cfg.NODWindowHours, cfg.NODBlock)
+	}
+
 	e := &Engine{
 		upstreamManager:      mgr,
 		policyEngine:         pE,
@@ -132,6 +145,8 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		rebindProtection:     cfg.RebindProtection,
 		rateLimiter:          newRateLimiter(cfg.ClientRateLimitPerSec),
 		safeSearch:           cfg.SafeSearch,
+		nodLedger:            ledger,
+		nodBlock:             cfg.NODBlock,
 	}
 	if cfg.ServeStale {
 		e.serveStale = true
@@ -502,6 +517,28 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				e.respondSafeSearch(w, r, target)
 				success = true
 				return
+			}
+		}
+
+		// Newly-observed-domain (NOD) detection runs only on the allow path, so
+		// it never overrides an explicit block/redirect decided above. observe()
+		// records the domain on first sight and reports whether it is new.
+		nodNew := e.nodLedger != nil && e.nodLedger.observe(domainName)
+		if nodNew && e.nodBlock {
+			logger.Log.Infof("Blocking newly-observed domain: %s", domainName)
+			e.logQuery(domainName, clientIP, "block", "nod", threatResult)
+			e.respondBlocked(w, r, domainName, "nod")
+			success = true
+			return
+		}
+		if nodNew {
+			// Flag-only mode: annotate as suspicious and forward normally.
+			threatResult.IsSuspicious = true
+			if threatResult.DetectionMethod == "" {
+				threatResult.DetectionMethod = "nod"
+			}
+			if threatResult.Reason == "" {
+				threatResult.Reason = "newly observed domain (first seen within NOD window)"
 			}
 		}
 

--- a/internal/dnsengine/nod.go
+++ b/internal/dnsengine/nod.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"sync"
+	"time"
+)
+
+// nodDefaultMaxEntries bounds the ledger's memory footprint. Once the ledger is
+// full, the oldest first-seen entries are evicted to make room for new domains.
+const nodDefaultMaxEntries = 100_000
+
+// nodLedger is a bounded, thread-safe record of the first time each domain was
+// observed on THIS resolver instance. It backs newly-observed-domain (NOD)
+// detection: a domain whose first-seen timestamp still falls within the
+// configured window is considered "newly observed".
+//
+// The ledger is in-memory only and does NOT survive a restart: after a restart
+// every domain looks new until the window elapses again. This is an accepted
+// tradeoff for v1 — a persistent backing store can be layered on later without
+// changing this type's API.
+type nodLedger struct {
+	mu         sync.Mutex
+	firstSeen  map[string]time.Time
+	window     time.Duration
+	maxEntries int
+	// now is injectable so tests can drive time deterministically. Defaults to
+	// time.Now when nil is passed to newNODLedger.
+	now func() time.Time
+}
+
+// newNODLedger builds a ledger with the given first-seen window. A maxEntries of
+// zero (or negative) falls back to nodDefaultMaxEntries; a nil now falls back to
+// time.Now.
+func newNODLedger(window time.Duration, maxEntries int, now func() time.Time) *nodLedger {
+	if maxEntries <= 0 {
+		maxEntries = nodDefaultMaxEntries
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &nodLedger{
+		firstSeen:  make(map[string]time.Time),
+		window:     window,
+		maxEntries: maxEntries,
+		now:        now,
+	}
+}
+
+// observe records the domain (on first sight) and reports whether it is "newly
+// observed" — i.e. its first-seen timestamp is within the configured window
+// relative to now. The first time a domain is seen it is always new, since its
+// first-seen timestamp equals now.
+func (l *nodLedger) observe(domain string) (isNew bool) {
+	if domain == "" {
+		return false
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	first, ok := l.firstSeen[domain]
+	if !ok {
+		l.evictIfFullLocked()
+		l.firstSeen[domain] = now
+		return true
+	}
+	return now.Sub(first) < l.window
+}
+
+// size reports the number of tracked domains. Intended for tests and diagnostics.
+func (l *nodLedger) size() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.firstSeen)
+}
+
+// evictIfFullLocked drops the oldest first-seen entry once the ledger reaches
+// its cap, keeping memory bounded by maxEntries. The caller must hold l.mu.
+func (l *nodLedger) evictIfFullLocked() {
+	if len(l.firstSeen) < l.maxEntries {
+		return
+	}
+	// Evict the single oldest entry by first-seen time. The O(n) scan only runs
+	// when the ledger is at capacity, and the map is bounded by maxEntries.
+	var (
+		oldestKey  string
+		oldestTime time.Time
+		found      bool
+	)
+	for k, t := range l.firstSeen {
+		if !found || t.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = t
+			found = true
+		}
+	}
+	if found {
+		delete(l.firstSeen, oldestKey)
+	}
+}

--- a/internal/dnsengine/nod_test.go
+++ b/internal/dnsengine/nod_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// mutableClock returns a now-func plus a pointer to advance it, so tests can
+// drive the ledger deterministically with no real sleeps.
+func mutableClock(start time.Time) (func() time.Time, *time.Time) {
+	cur := start
+	return func() time.Time { return cur }, &cur
+}
+
+// --- Ledger unit tests ---
+
+func TestNODLedger_FirstSightIsNew(t *testing.T) {
+	l := newNODLedger(time.Hour, 0, nil)
+	if !l.observe("example.com") {
+		t.Fatal("first sight of a domain should be new")
+	}
+}
+
+func TestNODLedger_EmptyDomainNeverNew(t *testing.T) {
+	l := newNODLedger(time.Hour, 0, nil)
+	if l.observe("") {
+		t.Error("empty domain should never be reported as new")
+	}
+	if l.size() != 0 {
+		t.Errorf("empty domain should not be recorded, size=%d", l.size())
+	}
+}
+
+func TestNODLedger_WithinWindowStillNew(t *testing.T) {
+	clk, cur := mutableClock(time.Unix(1_700_000_000, 0))
+	l := newNODLedger(time.Hour, 0, clk)
+
+	if !l.observe("shop.example.com") {
+		t.Fatal("first observation should be new")
+	}
+	// 30 minutes later — still inside the 1h window.
+	*cur = cur.Add(30 * time.Minute)
+	if !l.observe("shop.example.com") {
+		t.Error("domain re-seen within the window should still be new")
+	}
+}
+
+func TestNODLedger_NotNewAfterWindow(t *testing.T) {
+	clk, cur := mutableClock(time.Unix(1_700_000_000, 0))
+	l := newNODLedger(time.Hour, 0, clk)
+
+	if !l.observe("late.example.com") {
+		t.Fatal("first observation should be new")
+	}
+	// Advance past the window boundary.
+	*cur = cur.Add(2 * time.Hour)
+	if l.observe("late.example.com") {
+		t.Error("domain first seen before the window elapsed should not be new after it passes")
+	}
+	// Exactly at the window boundary is also NOT new (>= window).
+	clk2, cur2 := mutableClock(time.Unix(1_700_000_000, 0))
+	l2 := newNODLedger(time.Hour, 0, clk2)
+	l2.observe("edge.example.com")
+	*cur2 = cur2.Add(time.Hour)
+	if l2.observe("edge.example.com") {
+		t.Error("domain exactly at the window boundary should not be new")
+	}
+}
+
+func TestNODLedger_BoundedEviction(t *testing.T) {
+	clk, cur := mutableClock(time.Unix(1_700_000_000, 0))
+	// Cap at 2 entries so eviction is easy to force.
+	l := newNODLedger(time.Hour, 2, clk)
+
+	l.observe("a.com") // t0
+	*cur = cur.Add(time.Minute)
+	l.observe("b.com") // t0+1m
+	if l.size() != 2 {
+		t.Fatalf("expected size 2, got %d", l.size())
+	}
+
+	// Third distinct domain must evict the oldest ("a.com") to stay bounded.
+	*cur = cur.Add(time.Minute)
+	l.observe("c.com") // t0+2m
+	if l.size() != 2 {
+		t.Errorf("ledger exceeded cap: size=%d, want 2", l.size())
+	}
+
+	// "a.com" was evicted, so observing it again looks brand new.
+	if !l.observe("a.com") {
+		t.Error("evicted domain should be treated as newly observed again")
+	}
+	// Still bounded after re-inserting.
+	if l.size() > 2 {
+		t.Errorf("ledger exceeded cap after re-insert: size=%d", l.size())
+	}
+}
+
+// --- Engine integration tests (block vs flag vs disabled) ---
+
+// newNODEngine builds an allow-path-safe engine: an empty UpstreamManager makes
+// forwardUpstream return SERVFAIL (nil response, no network I/O), so the flag
+// path is deterministic and does not touch the network.
+func newNODEngine(window time.Duration, block bool, clk func() time.Time) *Engine {
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.upstreamManager = &UpstreamManager{} // no pools -> Exchange returns nil,nil
+	if window > 0 {
+		e.nodLedger = newNODLedger(window, 0, clk)
+	}
+	e.nodBlock = block
+	return e
+}
+
+func TestProcessDNSQuery_NODBlockMode(t *testing.T) {
+	clk, _ := mutableClock(time.Unix(1_700_000_000, 0))
+	e := newNODEngine(time.Hour, true, clk)
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("brand-new.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response for a newly observed domain")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected NOD block (0.0.0.0) in block mode, got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_NODFlagMode(t *testing.T) {
+	clk, _ := mutableClock(time.Unix(1_700_000_000, 0))
+	e := newNODEngine(time.Hour, false, clk)
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("brand-new.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response for a newly observed domain")
+	}
+	// Flag mode must NOT block; the query is forwarded (empty upstream -> SERVFAIL).
+	if isBlockedResponse(w.msg) {
+		t.Error("flag mode should not block a newly observed domain")
+	}
+	if w.msg.Rcode != dns.RcodeServerFailure {
+		t.Errorf("expected forwarded query (SERVFAIL from empty upstream), got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_NODDisabled(t *testing.T) {
+	// Disabled: nodLedger nil even though nodBlock would otherwise block.
+	e := newNODEngine(0, true, nil)
+	if e.nodLedger != nil {
+		t.Fatal("ledger should be nil when NOD is disabled")
+	}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("brand-new.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response")
+	}
+	// With NOD off, a new domain is not blocked; it is forwarded normally.
+	if isBlockedResponse(w.msg) {
+		t.Error("disabled NOD must not block newly observed domains")
+	}
+}
+
+func TestProcessDNSQuery_NODBlockThenAllowedAfterWindow(t *testing.T) {
+	clk, cur := mutableClock(time.Unix(1_700_000_000, 0))
+	e := newNODEngine(time.Hour, true, clk)
+
+	// First sight -> blocked.
+	w1 := &mockResponseWriter{}
+	e.ProcessDNSQuery(w1, newTestQuery("aged.com"))
+	if !isBlockedResponse(w1.msg) {
+		t.Fatal("first sight should be blocked in block mode")
+	}
+
+	// After the window elapses, the same domain is no longer new -> forwarded.
+	*cur = cur.Add(2 * time.Hour)
+	w2 := &mockResponseWriter{}
+	e.ProcessDNSQuery(w2, newTestQuery("aged.com"))
+	if isBlockedResponse(w2.msg) {
+		t.Error("domain past the NOD window should no longer be blocked")
+	}
+}


### PR DESCRIPTION
## What
Opt-in **newly-observed-domain (NOD)** detection. Flags (and optionally blocks) domains that are seen for the *first time* on this resolver within a configurable window. **Default disabled** — zero behaviour change unless turned on.

## Why
A domain no client here has ever queried, suddenly resolved, is a classic signal for DGA C2, fast-flux, phishing kits, and freshly-registered malicious infrastructure. A per-resolver first-seen ledger catches these locally without any external feed, complementing the existing blocklist + entropy/DGA threat heuristics.

## How
- **`internal/dnsengine/nod.go`** — `nodLedger`: a bounded, thread-safe (`sync.Mutex`) map of `domain -> first-seen time`. `observe(domain) (isNew bool)` records `now` on first sight and reports whether first-seen is still within the window. Size-capped (default 100k) with oldest-first eviction to bound memory. Clock is injectable (`now func() time.Time`) for deterministic tests.
- **`internal/config/config.go`** — `NODWindowHours` (`nod_window_hours` / `NOD_WINDOW_HOURS`, default `0` = disabled) and `NODBlock` (`nod_block` / `NOD_BLOCK`, default `false` = flag-only).
- **`internal/dnsengine/engine.go`** — ledger + flag wired onto `Engine` in `NewDNSEngine` (nil/disabled when `window <= 0`). In `ProcessDNSQuery` the check runs **only on the ALLOW path**, so it never overrides an explicit blocklist/policy block or redirect. On a new domain: `NODBlock` -> `respondBlocked(..., "nod")` (0.0.0.0); otherwise mark suspicious (`method=nod`), log a warning, and forward normally.

## Caveat
The ledger is **in-memory only and resets on restart** — after a restart every domain looks new until the window elapses again. Accepted tradeoff for v1; documented in the type doc. A persistent backing store can be added later without changing the `observe` API.

## Tests (`internal/dnsengine/nod_test.go`, deterministic clock, no real sleeps)
- First sight within window = new; re-seen within window still new; first-seen before window elapsed = not new after it passes (incl. exact boundary).
- Bounded-memory eviction: cap enforced, oldest evicted, evicted domain looks new again.
- Engine block vs flag vs disabled modes; blocked-then-allowed-after-window round trip.
- Empty domain never recorded/new.

`gofmt` clean, `go build ./...`, `go vet ./internal/...`, and `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)