### PR TITLE
feat(dataplane): fast-flux detection heuristic, flag-only (I-047)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,16 @@ type DataPlaneConfig struct {
 	// true blocks the query. See internal/dnsengine/nod.go for the ledger.
 	NODWindowHours int  `yaml:"nod_window_hours"`
 	NODBlock       bool `yaml:"nod_block"`
+
+	// FastFluxDetection enables the flag-only fast-flux heuristic (never blocks).
+	// Disabled by default to avoid false positives on CDNs.
+	FastFluxDetection bool `yaml:"fast_flux_detection"`
+	// FastFluxIPThreshold is the number of distinct answer IPs within the sliding
+	// window at or above which a low-TTL domain is flagged (default 8).
+	FastFluxIPThreshold int `yaml:"fast_flux_ip_threshold"`
+	// FastFluxTTLMaxSec is the maximum TTL (seconds) still considered "low" for
+	// fast-flux flagging (default 300).
+	FastFluxTTLMaxSec int `yaml:"fast_flux_ttl_max_sec"`
 }
 
 // WatchdogIntervalDuration parses WatchdogInterval into a duration. It returns 0
@@ -187,6 +197,9 @@ func defaultConfig() *Config {
 			BlocklistHealthInterval:  "1h",
 			WatchdogInterval:         "30s",
 			WatchdogFailureThreshold: 3,
+			FastFluxDetection:        false,
+			FastFluxIPThreshold:      8,
+			FastFluxTTLMaxSec:        300,
 			GRPCServer: GRPCServerConfig{
 				Port:       50051,
 				ListenAddr: "localhost:50051",
@@ -304,6 +317,11 @@ var DefaultConfig = func() *Config {
 			cfg.DataPlane.NODBlock = b
 		} else {
 			logger.Log.Warnf("Invalid NOD_BLOCK=%q, ignoring: %v", v, err)
+		}
+	}
+	if v := os.Getenv("FAST_FLUX_DETECTION"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.FastFluxDetection = b
 		}
 	}
 	return cfg

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -45,6 +45,11 @@ type Engine struct {
 	statistics      repositories.StatisticsRepository
 	threatDetector  *threat.Detector
 
+	// fastFlux is nil when fast-flux detection is disabled (the default). When
+	// set, upstream answers on the allow path are fed to it and tripping domains
+	// are flagged (never blocked).
+	fastFlux *fastFluxTracker
+
 	// serveStale enables answering from an expired cache entry on upstream failure.
 	serveStale bool
 	// cache holds recent allowed answers for serve-stale; nil when disabled.
@@ -152,6 +157,15 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		e.serveStale = true
 		e.cache = newAnswerCache(defaultCacheSize, defaultStaleFor)
 		logger.Log.Info("serve-stale enabled: expired cache answers may be served on upstream failure")
+	}
+	if cfg.FastFluxDetection {
+		e.fastFlux = newFastFluxTracker(
+			cfg.FastFluxIPThreshold,
+			cfg.FastFluxTTLMaxSec,
+			defaultFastFluxWindow,
+			defaultFastFluxMaxDomains,
+			nil,
+		)
 	}
 	return e, nil
 }
@@ -268,7 +282,11 @@ func (e *Engine) respondSafeSearch(w dns.ResponseWriter, r *dns.Msg, target stri
 	}
 }
 
-func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string) {
+// forwardUpstream forwards the query to upstream and writes the response back
+// (subject to rebind-protection filtering). It returns true when fast-flux
+// detection is enabled and the answer trips the heuristic (advisory only — the
+// response is never altered or blocked for fast-flux).
+func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string) bool {
 	resp, err := e.upstreamManager.Exchange(r, 5, 2)
 	if err != nil || resp == nil {
 		if err != nil {
@@ -285,17 +303,27 @@ func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string
 				if werr := w.WriteMsg(ent.reply(r, staleTTL)); werr != nil {
 					logger.Log.Error("Failed to write stale DNS response: " + werr.Error())
 				}
-				return
+				return false
 			}
 		}
 		m := new(dns.Msg)
 		m.SetRcode(r, dns.RcodeServerFailure)
 		_ = w.WriteMsg(m)
-		return
+		return false
 	}
 	// Cache successful answers so they can back a future serve-stale response.
 	if e.serveStale && e.cache != nil && resp.Rcode == dns.RcodeSuccess {
 		e.cache.Put(cacheKey(r.Question[0]), resp)
+	}
+
+	// Fast-flux detection (flag-only, never blocks). Inspect the answer's A/AAAA
+	// records before writing the response back.
+	fastFlux := false
+	if e.fastFlux != nil {
+		if ips, ttl, ok := extractAnswerIPs(resp); ok && e.fastFlux.observe(domain, ips, ttl) {
+			fastFlux = true
+			logger.Log.Warnf("Fast-flux suspected: %s (distinct-IP churn with low TTL within window)", domain)
+		}
 	}
 
 	// DNS rebinding protection: strip answers that map a public name to an
@@ -309,7 +337,7 @@ func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string
 			qtype := r.Question[0].Qtype
 			if len(kept) == 0 && (qtype == dns.TypeA || qtype == dns.TypeAAAA) {
 				e.respondBlocked(w, r, domain, "rebind")
-				return
+				return fastFlux
 			}
 		}
 	}
@@ -317,6 +345,7 @@ func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string
 	if err := w.WriteMsg(resp); err != nil {
 		logger.Log.Error("Failed to write DNS response: " + err.Error())
 	}
+	return fastFlux
 }
 
 // normalizeDomain lowercases and strips the trailing dot from a DNS FQDN.
@@ -549,8 +578,18 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			reason = threatResult.DetectionMethod
 			logger.Log.Warnf("Suspicious domain allowed: %s (score=%.2f, method=%s)", domainName, threatResult.ThreatScore, threatResult.DetectionMethod)
 		}
+		// Forward first so the fast-flux heuristic can inspect the answer, then
+		// log — a tripped domain is flagged (never blocked).
+		if e.forwardUpstream(w, r, domainName) {
+			action = "flagged"
+			if !threatResult.IsSuspicious {
+				threatResult.IsSuspicious = true
+				threatResult.DetectionMethod = "fast-flux"
+				threatResult.Reason = "fast-flux: distinct-IP churn with low TTL"
+			}
+			reason = threatResult.DetectionMethod
+		}
 		e.logQuery(domainName, clientIP, action, reason, threatResult)
-		e.forwardUpstream(w, r, domainName)
 		success = true
 	}
 }

--- a/internal/dnsengine/fastflux.go
+++ b/internal/dnsengine/fastflux.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Fast-flux tracker defaults. The IP-count and TTL thresholds are configurable
+// via config; the sliding window and domain cap are fixed sensible defaults.
+const (
+	defaultFastFluxWindow     = 5 * time.Minute
+	defaultFastFluxMaxDomains = 4096
+	defaultFastFluxIPThresh   = 8
+	defaultFastFluxTTLMaxSec  = 300
+)
+
+// ipRecord tracks the last time a distinct answer IP was seen for a domain and
+// the TTL that came with that answer.
+type ipRecord struct {
+	lastSeen time.Time
+	ttl      uint32
+}
+
+// ffDomainEntry holds the set of distinct answer IPs observed for one domain
+// within the sliding window, keyed by IP string for O(1) dedup.
+type ffDomainEntry struct {
+	ips      map[string]ipRecord
+	lastSeen time.Time
+}
+
+// fastFluxTracker is a bounded, thread-safe, per-domain tracker of the distinct
+// answer IPs seen within a sliding time window along with the minimum TTL
+// observed. It is used to FLAG (never block) domains exhibiting fast-flux
+// behaviour: many distinct low-TTL IPs churning over a short window, classic of
+// botnet / C2 infrastructure. CDNs also rotate IPs but keep the distinct-IP
+// count modest per window, so the threshold is set conservatively.
+//
+// Memory is bounded two ways: the number of tracked domains is capped (oldest
+// idle domain evicted on overflow), and per-domain IP records are pruned once
+// they fall outside the window.
+type fastFluxTracker struct {
+	mu          sync.Mutex
+	domains     map[string]*ffDomainEntry
+	window      time.Duration
+	ipThreshold int
+	ttlMax      uint32
+	maxDomains  int
+	now         func() time.Time
+}
+
+// newFastFluxTracker builds a tracker. Non-positive values fall back to
+// defaults. clock is injectable for deterministic testing; nil means time.Now.
+func newFastFluxTracker(ipThreshold, ttlMaxSec int, window time.Duration, maxDomains int, clock func() time.Time) *fastFluxTracker {
+	if ipThreshold <= 0 {
+		ipThreshold = defaultFastFluxIPThresh
+	}
+	if ttlMaxSec <= 0 {
+		ttlMaxSec = defaultFastFluxTTLMaxSec
+	}
+	if window <= 0 {
+		window = defaultFastFluxWindow
+	}
+	if maxDomains <= 0 {
+		maxDomains = defaultFastFluxMaxDomains
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return &fastFluxTracker{
+		domains:     make(map[string]*ffDomainEntry),
+		window:      window,
+		ipThreshold: ipThreshold,
+		ttlMax:      uint32(ttlMaxSec),
+		maxDomains:  maxDomains,
+		now:         clock,
+	}
+}
+
+// observe records the answer IPs and their (minimum) TTL for a domain and
+// reports whether the domain currently looks like fast-flux: at least
+// ipThreshold distinct IPs seen within the sliding window AND a minimum observed
+// TTL <= ttlMax. It never blocks; the boolean is advisory only.
+//
+// A nil tracker is treated as "disabled" and always returns false, so callers
+// can gate purely on the config without a separate flag.
+func (t *fastFluxTracker) observe(domain string, ips []net.IP, ttl uint32) bool {
+	if t == nil || domain == "" || len(ips) == 0 {
+		return false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+
+	entry := t.domains[domain]
+	if entry == nil {
+		// Enforce the domain cap before inserting a brand-new entry.
+		if len(t.domains) >= t.maxDomains {
+			t.evictOldestLocked()
+		}
+		entry = &ffDomainEntry{ips: make(map[string]ipRecord)}
+		t.domains[domain] = entry
+	}
+
+	for _, ip := range ips {
+		if ip == nil {
+			continue
+		}
+		entry.ips[ip.String()] = ipRecord{lastSeen: now, ttl: ttl}
+	}
+	entry.lastSeen = now
+
+	// Prune IPs whose most recent observation has fallen outside the window and
+	// compute the minimum TTL across the survivors in the same pass.
+	cutoff := now.Add(-t.window)
+	minTTL := ^uint32(0)
+	for k, rec := range entry.ips {
+		if rec.lastSeen.Before(cutoff) {
+			delete(entry.ips, k)
+			continue
+		}
+		if rec.ttl < minTTL {
+			minTTL = rec.ttl
+		}
+	}
+
+	// Everything expired: drop the domain to keep memory bounded.
+	if len(entry.ips) == 0 {
+		delete(t.domains, domain)
+		return false
+	}
+
+	return len(entry.ips) >= t.ipThreshold && minTTL <= t.ttlMax
+}
+
+// evictOldestLocked removes the least-recently-seen domain entry. The caller
+// must hold t.mu.
+func (t *fastFluxTracker) evictOldestLocked() {
+	var oldestKey string
+	var oldest time.Time
+	first := true
+	for k, e := range t.domains {
+		if first || e.lastSeen.Before(oldest) {
+			oldest, oldestKey, first = e.lastSeen, k, false
+		}
+	}
+	if oldestKey != "" {
+		delete(t.domains, oldestKey)
+	}
+}
+
+// extractAnswerIPs pulls A/AAAA record IPs and the minimum TTL from a DNS
+// response. ok is false when the response carries no address records.
+func extractAnswerIPs(resp *dns.Msg) (ips []net.IP, minTTL uint32, ok bool) {
+	if resp == nil {
+		return nil, 0, false
+	}
+	minTTL = ^uint32(0)
+	for _, rr := range resp.Answer {
+		switch rec := rr.(type) {
+		case *dns.A:
+			ips = append(ips, rec.A)
+			if rec.Hdr.Ttl < minTTL {
+				minTTL = rec.Hdr.Ttl
+			}
+		case *dns.AAAA:
+			ips = append(ips, rec.AAAA)
+			if rec.Hdr.Ttl < minTTL {
+				minTTL = rec.Hdr.Ttl
+			}
+		}
+	}
+	if len(ips) == 0 {
+		return nil, 0, false
+	}
+	return ips, minTTL, true
+}

--- a/internal/dnsengine/fastflux_test.go
+++ b/internal/dnsengine/fastflux_test.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// fakeClock (deterministic, manually-advanced) is defined once for the
+// package in ratelimit_test.go and reused here. No real sleeps are used
+// anywhere in this file.
+
+// trackedDomainCount / trackedIPCount are test-only introspection helpers,
+// defined here (same package) so production code carries no test hooks.
+func (t *fastFluxTracker) trackedDomainCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.domains)
+}
+
+func (t *fastFluxTracker) trackedIPCount(domain string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e := t.domains[domain]
+	if e == nil {
+		return 0
+	}
+	return len(e.ips)
+}
+
+// ip is a tiny helper to build a distinct IPv4 for index i (1..254 per octet).
+func ip(i int) net.IP {
+	return net.IPv4(10, byte(i/256), byte(i%256), 1)
+}
+
+func distinctIPs(n int) []net.IP {
+	out := make([]net.IP, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, ip(i))
+	}
+	return out
+}
+
+func TestFastFlux_TripsOnManyDistinctLowTTLIPs(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	tr := newFastFluxTracker(8, 300, 5*time.Minute, 1024, clk.now)
+
+	// Feed 7 distinct IPs one at a time with a low TTL: below the threshold.
+	for i := 0; i < 7; i++ {
+		if tr.observe("flux.example.com", []net.IP{ip(i)}, 60) {
+			t.Fatalf("tripped early at %d distinct IPs (threshold 8)", i+1)
+		}
+		clk.advance(time.Second)
+	}
+
+	// The 8th distinct IP reaches the threshold with TTL 60 <= 300 -> trip.
+	if !tr.observe("flux.example.com", []net.IP{ip(7)}, 60) {
+		t.Fatal("expected fast-flux trip at 8 distinct low-TTL IPs")
+	}
+}
+
+func TestFastFlux_TripsOnSingleAnswerWithManyIPs(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	tr := newFastFluxTracker(8, 300, 5*time.Minute, 1024, clk.now)
+
+	// A single answer carrying 10 distinct low-TTL IPs should trip immediately.
+	if !tr.observe("flux.example.com", distinctIPs(10), 30) {
+		t.Fatal("expected trip on a single answer with 10 distinct low-TTL IPs")
+	}
+}
+
+func TestFastFlux_StableDomainDoesNotTrip(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	tr := newFastFluxTracker(8, 300, 5*time.Minute, 1024, clk.now)
+
+	// A stable domain returns the same 2 IPs many times with a low TTL. Distinct
+	// count stays at 2, well under the threshold: never trips.
+	stable := []net.IP{ip(1), ip(2)}
+	for i := 0; i < 50; i++ {
+		if tr.observe("stable.example.com", stable, 60) {
+			t.Fatalf("stable domain (2 distinct IPs) tripped on iteration %d", i)
+		}
+		clk.advance(2 * time.Second)
+	}
+}
+
+func TestFastFlux_HighTTLDoesNotTrip(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	tr := newFastFluxTracker(8, 300, 5*time.Minute, 1024, clk.now)
+
+	// 12 distinct IPs (over the count threshold) but a high TTL (3600 > 300).
+	// The TTL condition fails, so it must not trip.
+	if tr.observe("slowcdn.example.com", distinctIPs(12), 3600) {
+		t.Fatal("high-TTL domain should not trip even with many distinct IPs")
+	}
+}
+
+func TestFastFlux_DisabledNilTrackerIsOff(t *testing.T) {
+	var tr *fastFluxTracker // nil == disabled (default)
+	if tr.observe("anything.example.com", distinctIPs(50), 1) {
+		t.Fatal("nil tracker (disabled) must never trip")
+	}
+}
+
+func TestFastFlux_WindowExpiryDropsOldIPs(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	window := 5 * time.Minute
+	tr := newFastFluxTracker(8, 300, window, 1024, clk.now)
+
+	// Seed 7 distinct IPs within the window (still below threshold).
+	if tr.observe("flux.example.com", distinctIPs(7), 60) {
+		t.Fatal("did not expect trip with only 7 distinct IPs")
+	}
+
+	// Advance past the window, then observe 1 fresh IP. The 7 old IPs must be
+	// pruned, leaving only the fresh one -> no trip.
+	clk.advance(window + time.Minute)
+	if tr.observe("flux.example.com", []net.IP{ip(100)}, 60) {
+		t.Fatal("expired IPs should have been dropped; single fresh IP must not trip")
+	}
+	if got := tr.trackedIPCount("flux.example.com"); got != 1 {
+		t.Fatalf("expected 1 live IP after window expiry, got %d", got)
+	}
+
+	// Now add 7 more fresh distinct IPs within the window -> 8 fresh total -> trip.
+	if !tr.observe("flux.example.com", distinctIPs(7), 60) {
+		t.Fatal("expected trip once 8 fresh distinct IPs are within the window")
+	}
+}
+
+func TestFastFlux_BoundedMemoryEvictsDomains(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	const cap = 3
+	tr := newFastFluxTracker(8, 300, 5*time.Minute, cap, clk.now)
+
+	// Observe far more distinct domains than the cap; each keeps a live IP.
+	for i := 0; i < 20; i++ {
+		tr.observe(fmt.Sprintf("d%d.example.com", i), []net.IP{ip(i)}, 60)
+		clk.advance(time.Second) // distinct lastSeen for deterministic eviction
+	}
+
+	if got := tr.trackedDomainCount(); got > cap {
+		t.Fatalf("tracked domains %d exceeds cap %d", got, cap)
+	}
+}
+
+func TestExtractAnswerIPs(t *testing.T) {
+	msg := new(dns.Msg)
+	a1, _ := dns.NewRR("flux.example.com. 45 IN A 1.2.3.4")
+	a2, _ := dns.NewRR("flux.example.com. 30 IN A 5.6.7.8")
+	aaaa, _ := dns.NewRR("flux.example.com. 90 IN AAAA ::1")
+	cname, _ := dns.NewRR("flux.example.com. 300 IN CNAME other.example.com.")
+	msg.Answer = []dns.RR{cname, a1, a2, aaaa}
+
+	ips, minTTL, ok := extractAnswerIPs(msg)
+	if !ok {
+		t.Fatal("expected ok with A/AAAA records present")
+	}
+	if len(ips) != 3 {
+		t.Fatalf("expected 3 address records (CNAME ignored), got %d", len(ips))
+	}
+	if minTTL != 30 {
+		t.Fatalf("expected min TTL 30, got %d", minTTL)
+	}
+
+	// No address records -> ok=false.
+	only := new(dns.Msg)
+	only.Answer = []dns.RR{cname}
+	if _, _, ok := extractAnswerIPs(only); ok {
+		t.Fatal("expected ok=false when no A/AAAA records present")
+	}
+
+	if _, _, ok := extractAnswerIPs(nil); ok {
+		t.Fatal("expected ok=false for nil response")
+	}
+}


### PR DESCRIPTION
## What
Adds an opt-in, **flag-only** fast-flux detection heuristic. It flags (never blocks) domains whose upstream answers churn across many distinct IPs with low TTLs over a sliding time window, a classic signal of botnet / C2 (fast-flux) infrastructure.

## Why
Fast-flux domains rapidly rotate a large pool of low-TTL A/AAAA records to keep C2 reachable and evade takedown. Detecting this adds a useful threat signal. Blocking is deliberately **avoided**: legitimate CDNs and large services also rotate IPs, so a hard block would cause false-positive outages. This ships as a flag only, **default OFF**.

## How
- **`internal/dnsengine/fastflux.go`** (new): a bounded, thread-safe, per-domain tracker of distinct answer IPs seen within a sliding window plus the minimum TTL observed. Clock is injectable for deterministic testing. `observe(domain, ips, ttl)` trips when the distinct-IP count within the window `>= FastFluxIPThreshold` **AND** the minimum observed TTL `<= FastFluxTTLMaxSec`. Memory is bounded two ways: the number of tracked domains is capped with oldest-idle eviction, and per-domain IP records outside the window are pruned on each observation.
- **`internal/config/config.go`**: `FastFluxDetection bool` (yaml `fast_flux_detection`, env `FAST_FLUX_DETECTION`, default `false`), plus `FastFluxIPThreshold int` (default `8`) and `FastFluxTTLMaxSec int` (default `300`).
- **`internal/dnsengine/engine.go`**: the tracker is created in `NewDNSEngine` only when enabled (nil == disabled). On the allow path, `forwardUpstream` inspects the successful upstream answer's A/AAAA IPs + TTLs and feeds the tracker before writing the response back **unchanged**. On a trip it logs a warning and marks the query as `flagged` in the query log. The response is never altered and the query is **never blocked**.

Additive, default-off, flag-only. No behavior change unless explicitly enabled.

## Tests
`internal/dnsengine/fastflux_test.go`, deterministic clock, no real sleeps:
- many distinct IPs + low TTL within window -> trips (incremental and single-answer)
- stable domain (few distinct IPs) -> never trips
- high TTL with many distinct IPs -> does not trip
- disabled (nil tracker) -> always off
- window expiry prunes old IPs (verified via live-IP count) then re-trips on fresh IPs
- bounded memory: tracked domains never exceed the cap (oldest-idle eviction)
- `extractAnswerIPs` A/AAAA extraction + min-TTL, ignores CNAME, handles nil

`gofmt -w`, `go build ./...`, `go vet ./internal/...`, and `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)