### PR TITLE
feat(controlplane): query-log pagination + search filters (I-005)

### DIFF
--- a/cmd/controlplane/handlers/analytics.go
+++ b/cmd/controlplane/handlers/analytics.go
@@ -2,9 +2,13 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 )
 
 type QueryLogEntry struct {
@@ -78,21 +82,166 @@ func (h *APIHandler) GetAuditLogs(c *gin.Context) {
 
 	entries := make([]QueryLogEntry, 0, len(queries))
 	for _, q := range queries {
-		entries = append(entries, QueryLogEntry{
-			ID:              q.ID,
-			Domain:          q.Domain,
-			ClientIP:        q.ClientIP,
-			Action:          q.Action,
-			Timestamp:       q.Timestamp,
-			IsSuspicious:    q.IsSuspicious,
-			ThreatScore:     q.ThreatScore,
-			DetectionMethod: q.DetectionMethod,
-			ThreatReason:    q.ThreatReason,
-		})
+		entries = append(entries, toQueryLogEntry(q))
 	}
 
 	c.JSON(http.StatusOK, ResponseQueryLogList{
 		Status: "success",
 		Data:   entries,
+	})
+}
+
+// QueryLogPageInfo carries paging metadata alongside a page of query logs.
+type QueryLogPageInfo struct {
+	Total   int64 `json:"total"`    // total rows matching the filter (ignoring paging)
+	Limit   int   `json:"limit"`    // effective page size after clamping
+	Offset  int   `json:"offset"`   // rows skipped
+	HasMore bool  `json:"has_more"` // whether more rows exist beyond this page
+}
+
+// QueryLogListData is the paginated payload for GetQueryLogs.
+type QueryLogListData struct {
+	Items    []QueryLogEntry  `json:"items"`
+	PageInfo QueryLogPageInfo `json:"page_info"`
+}
+
+// ResponseQueryLogPage is the envelope for a paginated query-log listing.
+type ResponseQueryLogPage struct {
+	Status string           `json:"status"`
+	Data   QueryLogListData `json:"data"`
+	Error  *string          `json:"error"`
+}
+
+// toQueryLogEntry maps a stored DNSQuery row to its API representation.
+func toQueryLogEntry(q models.DNSQuery) QueryLogEntry {
+	return QueryLogEntry{
+		ID:              q.ID,
+		Domain:          q.Domain,
+		ClientIP:        q.ClientIP,
+		Action:          q.Action,
+		Timestamp:       q.Timestamp,
+		IsSuspicious:    q.IsSuspicious,
+		ThreatScore:     q.ThreatScore,
+		DetectionMethod: q.DetectionMethod,
+		ThreatReason:    q.ThreatReason,
+	}
+}
+
+func isValidQueryLogAction(a string) bool {
+	switch a {
+	case "block", "allow", "flagged", "redirect":
+		return true
+	default:
+		return false
+	}
+}
+
+// GetQueryLogs handles GET /analytics/logs
+// Returns a server-side paginated, filterable page of DNS query logs.
+//
+// Query params (all optional):
+//
+//	limit      page size (default 50, max 200)
+//	offset     rows to skip (default 0)
+//	client_ip  exact client IP match
+//	action     one of block | allow | flagged | redirect
+//	domain     case-insensitive substring match on the queried domain
+//	suspicious boolean; when true, only suspicious rows
+//	from, to   RFC3339 timestamps bounding the result window (inclusive)
+func (h *APIHandler) GetQueryLogs(c *gin.Context) {
+	badRequest := func(msg string) {
+		c.JSON(http.StatusBadRequest, ResponseGeneric{Status: "error", Error: &msg})
+	}
+
+	filter := repositories.QueryLogFilter{
+		ClientIP: strings.TrimSpace(c.Query("client_ip")),
+		Domain:   strings.TrimSpace(c.Query("domain")),
+	}
+
+	// limit
+	limit := repositories.DefaultQueryLogPageSize
+	if v := c.Query("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			badRequest("invalid 'limit': must be a positive integer")
+			return
+		}
+		limit = n
+	}
+	limit = repositories.ClampQueryLogPageSize(limit)
+	filter.Limit = limit
+
+	// offset
+	offset := 0
+	if v := c.Query("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			badRequest("invalid 'offset': must be a non-negative integer")
+			return
+		}
+		offset = n
+	}
+	filter.Offset = offset
+
+	// action
+	if v := strings.TrimSpace(c.Query("action")); v != "" {
+		if !isValidQueryLogAction(v) {
+			badRequest("invalid 'action': must be one of block, allow, flagged, redirect")
+			return
+		}
+		filter.Action = v
+	}
+
+	// suspicious
+	if v := c.Query("suspicious"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			badRequest("invalid 'suspicious': must be a boolean")
+			return
+		}
+		filter.SuspiciousOnly = b
+	}
+
+	// time range
+	if v := c.Query("from"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			badRequest("invalid 'from': must be an RFC3339 timestamp")
+			return
+		}
+		filter.From = &t
+	}
+	if v := c.Query("to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			badRequest("invalid 'to': must be an RFC3339 timestamp")
+			return
+		}
+		filter.To = &t
+	}
+
+	queries, total, err := h.Store.QueryLogs.List(filter)
+	if err != nil {
+		errMsg := "failed to fetch query logs"
+		c.JSON(http.StatusInternalServerError, ResponseQueryLogPage{Status: "error", Error: &errMsg})
+		return
+	}
+
+	items := make([]QueryLogEntry, 0, len(queries))
+	for _, q := range queries {
+		items = append(items, toQueryLogEntry(q))
+	}
+
+	c.JSON(http.StatusOK, ResponseQueryLogPage{
+		Status: "success",
+		Data: QueryLogListData{
+			Items: items,
+			PageInfo: QueryLogPageInfo{
+				Total:   total,
+				Limit:   limit,
+				Offset:  offset,
+				HasMore: int64(offset+len(items)) < total,
+			},
+		},
 	})
 }

--- a/cmd/controlplane/handlers/analytics_test.go
+++ b/cmd/controlplane/handlers/analytics_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func setupLogTestHandler(t *testing.T) (*gin.Engine, *gorm.DB) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.DNSQuery{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	h := &APIHandler{
+		Store: repositories.Store{
+			QueryLogs: repositories.NewGormQueryLogRepo(db),
+		},
+	}
+
+	r := gin.New()
+	r.GET("/api/v1/analytics/logs", h.GetQueryLogs)
+	return r, db
+}
+
+func seedHandlerLogs(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	rows := []models.DNSQuery{
+		{Domain: "ads.example.com", ClientIP: "10.0.0.1", Action: "block", IsSuspicious: false},
+		{Domain: "good.org", ClientIP: "10.0.0.1", Action: "allow", IsSuspicious: false},
+		{Domain: "malware.bad", ClientIP: "10.0.0.2", Action: "flagged", IsSuspicious: true},
+		{Domain: "news.example.com", ClientIP: "10.0.0.1", Action: "allow", IsSuspicious: false},
+		{Domain: "phish.evil", ClientIP: "10.0.0.3", Action: "flagged", IsSuspicious: true},
+	}
+	for i := range rows {
+		rows[i].Timestamp = base.Add(time.Duration(i) * time.Minute)
+		if err := db.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("failed to seed row %d: %v", i, err)
+		}
+	}
+}
+
+func doGET(t *testing.T, r *gin.Engine, target string) (*httptest.ResponseRecorder, ResponseQueryLogPage) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var body ResponseQueryLogPage
+	if w.Code == http.StatusOK {
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("failed to decode response: %v (body: %s)", err, w.Body.String())
+		}
+	}
+	return w, body
+}
+
+func TestGetQueryLogs_EnvelopeAndDefaults(t *testing.T) {
+	r, db := setupLogTestHandler(t)
+	seedHandlerLogs(t, db)
+
+	w, body := doGET(t, r, "/api/v1/analytics/logs")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if body.Status != "success" {
+		t.Errorf("expected status success, got %q", body.Status)
+	}
+	if body.Error != nil {
+		t.Errorf("expected nil error, got %v", *body.Error)
+	}
+	if body.Data.PageInfo.Total != 5 {
+		t.Errorf("expected total 5, got %d", body.Data.PageInfo.Total)
+	}
+	if body.Data.PageInfo.Limit != repositories.DefaultQueryLogPageSize {
+		t.Errorf("expected default limit %d, got %d", repositories.DefaultQueryLogPageSize, body.Data.PageInfo.Limit)
+	}
+	if len(body.Data.Items) != 5 {
+		t.Errorf("expected 5 items, got %d", len(body.Data.Items))
+	}
+	if body.Data.PageInfo.HasMore {
+		t.Errorf("expected has_more=false when all rows fit on one page")
+	}
+	// Newest first.
+	if len(body.Data.Items) > 0 && body.Data.Items[0].Domain != "phish.evil" {
+		t.Errorf("expected newest row first, got %q", body.Data.Items[0].Domain)
+	}
+}
+
+func TestGetQueryLogs_PaginationHasMore(t *testing.T) {
+	r, db := setupLogTestHandler(t)
+	seedHandlerLogs(t, db)
+
+	w, body := doGET(t, r, "/api/v1/analytics/logs?limit=2&offset=0")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(body.Data.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(body.Data.Items))
+	}
+	if body.Data.PageInfo.Total != 5 {
+		t.Errorf("expected total 5, got %d", body.Data.PageInfo.Total)
+	}
+	if !body.Data.PageInfo.HasMore {
+		t.Errorf("expected has_more=true on first of multiple pages")
+	}
+
+	// Last page should have has_more=false.
+	_, last := doGET(t, r, "/api/v1/analytics/logs?limit=2&offset=4")
+	if len(last.Data.Items) != 1 {
+		t.Errorf("expected 1 item on last page, got %d", len(last.Data.Items))
+	}
+	if last.Data.PageInfo.HasMore {
+		t.Errorf("expected has_more=false on last page")
+	}
+}
+
+func TestGetQueryLogs_Filters(t *testing.T) {
+	r, db := setupLogTestHandler(t)
+	seedHandlerLogs(t, db)
+
+	cases := []struct {
+		name  string
+		query string
+		total int64
+	}{
+		{"client_ip", "?client_ip=10.0.0.1", 3},
+		{"action", "?action=flagged", 2},
+		{"domain_substring", "?domain=example.com", 2},
+		{"suspicious", "?suspicious=true", 2},
+		{"combined", "?client_ip=10.0.0.1&action=allow", 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, body := doGET(t, r, "/api/v1/analytics/logs"+tc.query)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+			if body.Data.PageInfo.Total != tc.total {
+				t.Errorf("query %q: expected total %d, got %d", tc.query, tc.total, body.Data.PageInfo.Total)
+			}
+		})
+	}
+}
+
+func TestGetQueryLogs_BadParams(t *testing.T) {
+	r, db := setupLogTestHandler(t)
+	seedHandlerLogs(t, db)
+
+	cases := []string{
+		"?limit=abc",
+		"?limit=0",
+		"?limit=-1",
+		"?offset=-1",
+		"?offset=xyz",
+		"?action=bogus",
+		"?suspicious=maybe",
+		"?from=not-a-time",
+		"?to=2024-13-40",
+	}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/logs"+q, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("query %q: expected 400, got %d (body: %s)", q, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestGetQueryLogs_TimeRange(t *testing.T) {
+	r, db := setupLogTestHandler(t)
+	seedHandlerLogs(t, db)
+
+	// Rows are at 12:00..12:04 UTC. Window 12:01..12:03 -> 3 rows.
+	from := "2024-01-01T12:01:00Z"
+	to := "2024-01-01T12:03:00Z"
+	w, body := doGET(t, r, "/api/v1/analytics/logs?from="+from+"&to="+to)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if body.Data.PageInfo.Total != 3 {
+		t.Errorf("expected 3 rows in time window, got %d", body.Data.PageInfo.Total)
+	}
+}
+
+func TestGetQueryLogs_LimitClamped(t *testing.T) {
+	r, db := setupLogTestHandler(t)
+	seedHandlerLogs(t, db)
+
+	// A huge limit must be clamped to MaxQueryLogPageSize in the reported page info.
+	_, body := doGET(t, r, "/api/v1/analytics/logs?limit=100000")
+	if body.Data.PageInfo.Limit != repositories.MaxQueryLogPageSize {
+		t.Errorf("expected clamped limit %d, got %d", repositories.MaxQueryLogPageSize, body.Data.PageInfo.Limit)
+	}
+}

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -60,6 +60,7 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 		{
 			analytics.GET("/summary", apiHandler.GetAnalyticsSummary)
 			analytics.GET("/audits", apiHandler.GetAuditLogs)
+			analytics.GET("/logs", apiHandler.GetQueryLogs)
 		}
 
 		// Device inventory endpoints

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/nrd"
 	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 	"github.com/lopster568/phantomDNS/internal/threat"
 	"github.com/miekg/dns"
 )
@@ -57,6 +58,10 @@ func (m *mockQueryLog) Save(q *models.DNSQuery) error {
 
 func (m *mockQueryLog) ListRecent(limit int) ([]models.DNSQuery, error) {
 	return nil, nil
+}
+
+func (m *mockQueryLog) List(filter repositories.QueryLogFilter) ([]models.DNSQuery, int64, error) {
+	return nil, 0, nil
 }
 
 // waitSaved blocks until logQuery's goroutine persists a row (or times out).

--- a/internal/storage/models/dns_query.model.go
+++ b/internal/storage/models/dns_query.model.go
@@ -7,7 +7,7 @@ type DNSQuery struct {
 	ID              uint      `gorm:"primaryKey"`
 	Domain          string    `gorm:"index;not null;"`
 	ClientIP        string    `gorm:"index;not null;"`
-	Action          string    `gorm:"not null;"` // allow, block, redirect, flagged
+	Action          string    `gorm:"index;not null;"` // allow, block, redirect, flagged
 	Timestamp       time.Time `gorm:"index;"`
 	IsSuspicious    bool      `gorm:"default:false"`
 	ThreatScore     float64   `gorm:"default:0"`

--- a/internal/storage/repositories/query_log.go
+++ b/internal/storage/repositories/query_log.go
@@ -9,10 +9,49 @@ import (
 	"gorm.io/gorm"
 )
 
+// Page-size bounds for paginated query-log reads.
+const (
+	// DefaultQueryLogPageSize is used when no (or an invalid) limit is supplied.
+	DefaultQueryLogPageSize = 50
+	// MaxQueryLogPageSize caps how many rows a single page may return so a
+	// caller cannot ask the database for an unbounded result set.
+	MaxQueryLogPageSize = 200
+)
+
+// QueryLogFilter describes the optional filters and paging window for a
+// server-side query-log listing. Zero-value fields mean "no filter".
+type QueryLogFilter struct {
+	ClientIP       string     // exact match (indexed column)
+	Action         string     // exact match: allow | block | flagged | redirect
+	Domain         string     // case-insensitive substring match
+	SuspiciousOnly bool       // when true, only rows with IsSuspicious = true
+	From           *time.Time // inclusive lower bound on Timestamp
+	To             *time.Time // inclusive upper bound on Timestamp
+	Limit          int        // page size (clamped to [1, MaxQueryLogPageSize])
+	Offset         int        // rows to skip (negative treated as 0)
+}
+
+// ClampQueryLogPageSize normalizes a requested page size into the allowed
+// bounds. Non-positive values fall back to the default; values above the cap
+// are clamped to MaxQueryLogPageSize.
+func ClampQueryLogPageSize(limit int) int {
+	if limit <= 0 {
+		return DefaultQueryLogPageSize
+	}
+	if limit > MaxQueryLogPageSize {
+		return MaxQueryLogPageSize
+	}
+	return limit
+}
+
 // Interface (clean, mockable)
 type QueryLogRepository interface {
 	Save(query *models.DNSQuery) error
 	ListRecent(limit int) ([]models.DNSQuery, error)
+	// List returns a filtered, paginated page of query logs ordered
+	// newest-first, along with the total number of rows matching the filter
+	// (ignoring the paging window) so callers can render page info.
+	List(filter QueryLogFilter) ([]models.DNSQuery, int64, error)
 }
 
 // Implementation
@@ -35,4 +74,46 @@ func (r *GormQueryLogRepo) ListRecent(limit int) ([]models.DNSQuery, error) {
 	var queries []models.DNSQuery
 	err := r.db.Order("timestamp desc").Limit(limit).Find(&queries).Error
 	return queries, err
+}
+
+// List applies the given filters and returns one page of results plus the
+// total match count. Equality filters (client IP, action, timestamp range,
+// suspicious) use indexed columns; the domain filter is a substring LIKE which
+// necessarily scans, so it is applied last and only when requested.
+func (r *GormQueryLogRepo) List(filter QueryLogFilter) ([]models.DNSQuery, int64, error) {
+	limit := ClampQueryLogPageSize(filter.Limit)
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Build the shared WHERE clause once; reuse for both count and page.
+	q := r.db.Model(&models.DNSQuery{})
+	if filter.ClientIP != "" {
+		q = q.Where("client_ip = ?", filter.ClientIP)
+	}
+	if filter.Action != "" {
+		q = q.Where("action = ?", filter.Action)
+	}
+	if filter.SuspiciousOnly {
+		q = q.Where("is_suspicious = ?", true)
+	}
+	if filter.From != nil {
+		q = q.Where("timestamp >= ?", *filter.From)
+	}
+	if filter.To != nil {
+		q = q.Where("timestamp <= ?", *filter.To)
+	}
+	if filter.Domain != "" {
+		q = q.Where("domain LIKE ?", "%"+filter.Domain+"%")
+	}
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var queries []models.DNSQuery
+	err := q.Order("timestamp desc").Limit(limit).Offset(offset).Find(&queries).Error
+	return queries, total, err
 }

--- a/internal/storage/repositories/query_log_list_test.go
+++ b/internal/storage/repositories/query_log_list_test.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package repositories
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// seedQueryLogs inserts a deterministic set of rows with explicit, strictly
+// increasing timestamps so ordering and paging are reproducible. Rows are
+// returned oldest-first (index 0 is the oldest).
+func seedQueryLogs(t *testing.T, db *gorm.DB) []models.DNSQuery {
+	t.Helper()
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	rows := []models.DNSQuery{
+		{Domain: "ads.example.com", ClientIP: "10.0.0.1", Action: "block", IsSuspicious: false},
+		{Domain: "good.org", ClientIP: "10.0.0.1", Action: "allow", IsSuspicious: false},
+		{Domain: "tracker.ads.net", ClientIP: "10.0.0.2", Action: "block", IsSuspicious: false},
+		{Domain: "malware.bad", ClientIP: "10.0.0.2", Action: "flagged", IsSuspicious: true},
+		{Domain: "portal.example.com", ClientIP: "10.0.0.1", Action: "redirect", IsSuspicious: false},
+		{Domain: "phish.evil", ClientIP: "10.0.0.3", Action: "flagged", IsSuspicious: true},
+		{Domain: "cdn.good.org", ClientIP: "10.0.0.2", Action: "allow", IsSuspicious: false},
+		{Domain: "news.example.com", ClientIP: "10.0.0.1", Action: "allow", IsSuspicious: false},
+	}
+	for i := range rows {
+		rows[i].Timestamp = base.Add(time.Duration(i) * time.Minute)
+		if err := db.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("failed to seed row %d: %v", i, err)
+		}
+	}
+	return rows
+}
+
+func TestClampQueryLogPageSize(t *testing.T) {
+	tests := []struct {
+		in   int
+		want int
+	}{
+		{0, DefaultQueryLogPageSize},
+		{-5, DefaultQueryLogPageSize},
+		{1, 1},
+		{50, 50},
+		{MaxQueryLogPageSize, MaxQueryLogPageSize},
+		{MaxQueryLogPageSize + 1, MaxQueryLogPageSize},
+		{100000, MaxQueryLogPageSize},
+	}
+	for _, tt := range tests {
+		if got := ClampQueryLogPageSize(tt.in); got != tt.want {
+			t.Errorf("ClampQueryLogPageSize(%d) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestQueryLogRepo_List_NewestFirst(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	items, total, err := repo.List(QueryLogFilter{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 8 {
+		t.Fatalf("expected total 8, got %d", total)
+	}
+	if len(items) != 8 {
+		t.Fatalf("expected 8 items, got %d", len(items))
+	}
+	// Newest row (seeded last) is "news.example.com".
+	if items[0].Domain != "news.example.com" {
+		t.Errorf("expected newest first (news.example.com), got %q", items[0].Domain)
+	}
+	// Verify strictly descending timestamps.
+	for i := 1; i < len(items); i++ {
+		if items[i-1].Timestamp.Before(items[i].Timestamp) {
+			t.Errorf("results not ordered newest-first at index %d", i)
+		}
+	}
+}
+
+func TestQueryLogRepo_List_Pagination(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	// Page 1: first 3.
+	page1, total, err := repo.List(QueryLogFilter{Limit: 3, Offset: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 8 {
+		t.Fatalf("expected total 8, got %d", total)
+	}
+	if len(page1) != 3 {
+		t.Fatalf("expected 3 items on page 1, got %d", len(page1))
+	}
+
+	// Page 2: next 3.
+	page2, _, err := repo.List(QueryLogFilter{Limit: 3, Offset: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 3 {
+		t.Fatalf("expected 3 items on page 2, got %d", len(page2))
+	}
+
+	// Page 3: remaining 2.
+	page3, _, err := repo.List(QueryLogFilter{Limit: 3, Offset: 6})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page3) != 2 {
+		t.Fatalf("expected 2 items on page 3, got %d", len(page3))
+	}
+
+	// Pages must not overlap.
+	seen := map[uint]bool{}
+	for _, p := range [][]models.DNSQuery{page1, page2, page3} {
+		for _, row := range p {
+			if seen[row.ID] {
+				t.Errorf("row ID %d appeared on more than one page", row.ID)
+			}
+			seen[row.ID] = true
+		}
+	}
+	if len(seen) != 8 {
+		t.Errorf("expected 8 distinct rows across pages, got %d", len(seen))
+	}
+}
+
+func TestQueryLogRepo_List_OffsetBeyondEnd(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	items, total, err := repo.List(QueryLogFilter{Limit: 5, Offset: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 8 {
+		t.Errorf("expected total 8 regardless of offset, got %d", total)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 items past the end, got %d", len(items))
+	}
+}
+
+func TestQueryLogRepo_List_DefaultAndNegativeBounds(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	// Limit 0 -> default page size; negative offset -> treated as 0.
+	items, total, err := repo.List(QueryLogFilter{Limit: 0, Offset: -10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 8 {
+		t.Fatalf("expected total 8, got %d", total)
+	}
+	// Only 8 rows exist, all fit under the default page size.
+	if len(items) != 8 {
+		t.Errorf("expected all 8 rows with default page size, got %d", len(items))
+	}
+}
+
+func TestQueryLogRepo_List_FilterClientIP(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	items, total, err := repo.List(QueryLogFilter{ClientIP: "10.0.0.1", Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 4 {
+		t.Errorf("expected 4 rows for 10.0.0.1, got %d", total)
+	}
+	for _, it := range items {
+		if it.ClientIP != "10.0.0.1" {
+			t.Errorf("unexpected client IP %q in filtered result", it.ClientIP)
+		}
+	}
+}
+
+func TestQueryLogRepo_List_FilterAction(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	cases := map[string]int64{
+		"block":    2,
+		"allow":    3,
+		"flagged":  2,
+		"redirect": 1,
+	}
+	for action, want := range cases {
+		items, total, err := repo.List(QueryLogFilter{Action: action, Limit: 100})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != want {
+			t.Errorf("action %q: expected %d rows, got %d", action, want, total)
+		}
+		for _, it := range items {
+			if it.Action != action {
+				t.Errorf("action %q filter returned row with action %q", action, it.Action)
+			}
+		}
+	}
+}
+
+func TestQueryLogRepo_List_FilterDomainSubstring(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	// "example.com" matches ads/portal/news.example.com -> 3 rows.
+	items, total, err := repo.List(QueryLogFilter{Domain: "example.com", Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Errorf("expected 3 rows matching 'example.com', got %d", total)
+	}
+	for _, it := range items {
+		if !strings.Contains(it.Domain, "example.com") {
+			t.Errorf("row %q does not contain substring 'example.com'", it.Domain)
+		}
+	}
+
+	// "ads" is a substring of ads.example.com and tracker.ads.net -> 2 rows.
+	_, total, err = repo.List(QueryLogFilter{Domain: "ads", Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Errorf("expected 2 rows matching substring 'ads', got %d", total)
+	}
+}
+
+func TestQueryLogRepo_List_FilterSuspiciousOnly(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	items, total, err := repo.List(QueryLogFilter{SuspiciousOnly: true, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Errorf("expected 2 suspicious rows, got %d", total)
+	}
+	for _, it := range items {
+		if !it.IsSuspicious {
+			t.Errorf("suspicious filter returned non-suspicious row %q", it.Domain)
+		}
+	}
+}
+
+func TestQueryLogRepo_List_FilterTimeRange(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	// Inclusive window covering rows at minute 2..4 (3 rows).
+	from := base.Add(2 * time.Minute)
+	to := base.Add(4 * time.Minute)
+
+	items, total, err := repo.List(QueryLogFilter{From: &from, To: &to, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Errorf("expected 3 rows in time window, got %d", total)
+	}
+	for _, it := range items {
+		if it.Timestamp.Before(from) || it.Timestamp.After(to) {
+			t.Errorf("row timestamp %v outside window [%v, %v]", it.Timestamp, from, to)
+		}
+	}
+}
+
+func TestQueryLogRepo_List_CombinedFilters(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedQueryLogs(t, db)
+
+	// client 10.0.0.1 AND action allow -> good.org, news.example.com (2 rows).
+	items, total, err := repo.List(QueryLogFilter{
+		ClientIP: "10.0.0.1",
+		Action:   "allow",
+		Limit:    100,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Errorf("expected 2 rows for combined filter, got %d", total)
+	}
+	for _, it := range items {
+		if it.ClientIP != "10.0.0.1" || it.Action != "allow" {
+			t.Errorf("combined filter returned mismatched row: %+v", it)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds a server-side **paginated, filterable** query-log listing to the control plane.

New endpoint: `GET /api/v1/analytics/logs`

Response (standard envelope):
```json
{
  "status": "success",
  "data": {
    "items": [ /* QueryLogEntry... */ ],
    "page_info": { "total": 1234, "limit": 50, "offset": 0, "has_more": true }
  },
  "error": null
}
```

Query params (all optional): `limit` (default 50, max 200), `offset`, `client_ip`, `action` (`block|allow|flagged|redirect`), `domain` (substring), `suspicious` (bool), `from`/`to` (RFC3339).

## Why

The only read path for query logs was `QueryLogRepository.ListRecent(100)` — a hard cap of the latest 100 rows with no paging or filtering, surfaced via `GET /analytics/audits`. Operators can't page back through history or search by client, action, domain, or time. This adds real pagination and search so the UI query-log view can scale beyond 100 rows.

## How

- **Repository** (`internal/storage/repositories/query_log.go`): new `List(QueryLogFilter) ([]DNSQuery, int64, error)` returning a newest-first page plus the total match count. Filters compose as ANDed `WHERE` clauses; equality filters (client IP, action, time range, suspicious) hit indexed columns, domain uses a substring `LIKE` applied last. Page size is normalized by `ClampQueryLogPageSize` (default 50, hard max 200) so a caller can never request an unbounded result set.
- **Model** (`dns_query.model.go`): added an index to the `Action` column so the action filter is served from an index instead of a table scan.
- **Handler** (`cmd/controlplane/handlers/analytics.go`): `GetQueryLogs` parses and validates each param, returning `400` in the envelope on malformed input, and emits `{items, page_info{total, limit, offset, has_more}}`. Existing `GetAuditLogs` / `/analytics/audits` is left unchanged for backward compatibility; the row->API mapping is factored into a shared `toQueryLogEntry` helper.
- **Route**: registered `analytics.GET("/logs", ...)`.

Note: the pre-existing `.gitignore` `controlplane` entry (meant for the compiled binary) also matches the `cmd/controlplane/` source dir, so the new handler test had to be force-added. Flagging in case maintainers want to tighten that pattern to `/controlplane` separately.

## Tests

- **Repository** (`query_log_list_test.go`): pagination boundaries (multi-page no-overlap, offset past end, default/negative bounds), newest-first ordering, `ClampQueryLogPageSize` boundaries, and one test per filter (client IP, action, domain substring, suspicious-only, time range) plus a combined-filter case, all against a seeded in-memory DB.
- **Handler** (`analytics_test.go`): envelope shape + defaults, `has_more` paging, each filter over HTTP, `400` validation for bad params, time-range window, and limit clamping.
- Full suite green: `gofmt -w`, `go build ./...`, `go vet ./cmd/... ./internal/...`, `go test ./...` all pass. No existing tests modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)