### PR TITLE
feat(dataplane): syslog + webhook event export (I-050)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,11 @@ type DataPlaneConfig struct {
 	// FastFluxTTLMaxSec is the maximum TTL (seconds) still considered "low" for
 	// fast-flux flagging (default 300).
 	FastFluxTTLMaxSec int `yaml:"fast_flux_ttl_max_sec"`
+
+	// Event export targets. Both default empty = export disabled (OFF).
+	// SyslogAddr accepts "udp://host:514" or "tcp://host:514".
+	SyslogAddr      string `yaml:"syslog_addr"`
+	EventWebhookURL string `yaml:"event_webhook_url"`
 }
 
 // WatchdogIntervalDuration parses WatchdogInterval into a duration. It returns 0
@@ -323,6 +328,12 @@ var DefaultConfig = func() *Config {
 		if b, err := strconv.ParseBool(v); err == nil {
 			cfg.DataPlane.FastFluxDetection = b
 		}
+	}
+	if addr := os.Getenv("SYSLOG_ADDR"); addr != "" {
+		cfg.DataPlane.SyslogAddr = addr
+	}
+	if webhook := os.Getenv("EVENT_WEBHOOK_URL"); webhook != "" {
+		cfg.DataPlane.EventWebhookURL = webhook
 	}
 	return cfg
 }()

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -44,6 +44,7 @@ type Engine struct {
 	queryLog        repositories.QueryLogRepository
 	statistics      repositories.StatisticsRepository
 	threatDetector  *threat.Detector
+	exporter        *Exporter
 
 	// fastFlux is nil when fast-flux detection is disabled (the default). When
 	// set, upstream answers on the allow path are fed to it and tripping domains
@@ -136,6 +137,14 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		logger.Log.Infof("NOD detection enabled: window=%dh block=%v", cfg.NODWindowHours, cfg.NODBlock)
 	}
 
+	// Event export is optional and defaults to OFF. A nil exporter is a valid
+	// no-op; a bad target is logged and skipped inside NewExporter.
+	exporter, err := NewExporter(cfg.SyslogAddr, cfg.EventWebhookURL)
+	if err != nil {
+		logger.Log.Warnf("event export disabled: %v", err)
+		exporter = nil
+	}
+
 	e := &Engine{
 		upstreamManager:      mgr,
 		policyEngine:         pE,
@@ -144,6 +153,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		queryLog:             repos.QueryLogs,
 		statistics:           repos.Statistics,
 		threatDetector:       threat.NewDetector(),
+		exporter:             exporter,
 		threatBlockThreshold: cfg.ThreatBlockThreshold,
 		threatBlockDryRun:    cfg.ThreatBlockDryRun,
 		abusedTLDs:           abusedTLDs,
@@ -193,6 +203,7 @@ func (e *Engine) Shutdown() {
 	if e.upstreamManager != nil {
 		e.upstreamManager.Close()
 	}
+	e.exporter.Close() // nil-safe
 }
 
 func (e *Engine) respondBlocked(w dns.ResponseWriter, r *dns.Msg, domain, reason string) {
@@ -595,6 +606,19 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 }
 
 func (e *Engine) logQuery(domain, clientIP, action, reason string, tr threat.Result) {
+	// Export the event to external sinks (syslog/webhook) if enabled.
+	// Non-blocking with drop-on-full; a nil exporter is a no-op.
+	e.exporter.Export(Event{
+		Timestamp:       time.Now().UTC(),
+		Domain:          domain,
+		ClientIP:        clientIP,
+		Action:          action,
+		IsSuspicious:    tr.IsSuspicious,
+		ThreatScore:     tr.ThreatScore,
+		DetectionMethod: tr.DetectionMethod,
+		ThreatReason:    tr.Reason,
+	})
+
 	if e.queryLog == nil {
 		return
 	}

--- a/internal/dnsengine/export.go
+++ b/internal/dnsengine/export.go
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+// Event is a single DNS query event handed to the exporter. It mirrors the
+// fields persisted in the query log so external systems (SIEM, syslog
+// collectors, webhooks) receive the same information as the local store.
+type Event struct {
+	Timestamp       time.Time `json:"timestamp"`
+	Domain          string    `json:"domain"`
+	ClientIP        string    `json:"client_ip"`
+	Action          string    `json:"action"` // allow, block, redirect, flagged, error
+	IsSuspicious    bool      `json:"is_suspicious"`
+	ThreatScore     float64   `json:"threat_score"`
+	DetectionMethod string    `json:"detection_method"`
+	ThreatReason    string    `json:"threat_reason"`
+}
+
+// Sink is a pluggable destination for query events.
+type Sink interface {
+	// Send delivers a single event. Implementations should be self-contained
+	// and must not retain the Event after returning.
+	Send(Event) error
+	// Close releases any resources held by the sink.
+	Close() error
+}
+
+// exportQueueSize bounds the number of pending events. When full, new events
+// are dropped rather than blocking DNS resolution.
+const exportQueueSize = 1024
+
+// Exporter fans query events out to one or more sinks through a bounded,
+// drop-on-full queue drained by a single background worker. This guarantees
+// the hot resolution path (logQuery) never blocks on a slow syslog/webhook
+// target. A nil *Exporter is a valid no-op (export disabled).
+type Exporter struct {
+	queue     chan Event
+	sinks     []Sink
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+	dropped   atomic.Uint64
+}
+
+// NewExporter builds an Exporter from the given targets. Both arguments are
+// optional; if neither is set (both empty) export is disabled and (nil, nil)
+// is returned — callers must treat a nil *Exporter as "off". A target that
+// fails to initialise is logged and skipped rather than failing the engine.
+func NewExporter(syslogAddr, webhookURL string) (*Exporter, error) {
+	var sinks []Sink
+
+	if strings.TrimSpace(syslogAddr) != "" {
+		s, err := newSyslogSink(syslogAddr)
+		if err != nil {
+			logger.Log.Warnf("event export: syslog sink disabled: %v", err)
+		} else {
+			sinks = append(sinks, s)
+			logger.Log.Infof("event export: syslog sink enabled (%s)", syslogAddr)
+		}
+	}
+
+	if strings.TrimSpace(webhookURL) != "" {
+		sinks = append(sinks, newWebhookSink(webhookURL))
+		logger.Log.Infof("event export: webhook sink enabled (%s)", webhookURL)
+	}
+
+	if len(sinks) == 0 {
+		return nil, nil
+	}
+
+	e := &Exporter{
+		queue: make(chan Event, exportQueueSize),
+		sinks: sinks,
+	}
+	e.wg.Add(1)
+	go e.run()
+	return e, nil
+}
+
+// Export enqueues an event for delivery. It never blocks: if the queue is full
+// the event is dropped and the drop counter is incremented. Safe to call on a
+// nil receiver (export disabled).
+func (e *Exporter) Export(ev Event) {
+	if e == nil {
+		return
+	}
+	select {
+	case e.queue <- ev:
+	default:
+		n := e.dropped.Add(1)
+		// Log sparingly to avoid amplifying pressure under sustained overflow.
+		if n == 1 || n%1024 == 0 {
+			logger.Log.Warnf("event export: queue full, dropped %d events", n)
+		}
+	}
+}
+
+// Dropped returns the total number of events dropped due to a full queue.
+func (e *Exporter) Dropped() uint64 {
+	if e == nil {
+		return 0
+	}
+	return e.dropped.Load()
+}
+
+// Close stops the worker, drains in-flight events, and closes all sinks.
+// Safe to call multiple times and on a nil receiver.
+func (e *Exporter) Close() {
+	if e == nil {
+		return
+	}
+	e.closeOnce.Do(func() {
+		close(e.queue)
+		e.wg.Wait()
+		for _, s := range e.sinks {
+			if err := s.Close(); err != nil {
+				logger.Log.Warnf("event export: sink close error: %v", err)
+			}
+		}
+	})
+}
+
+func (e *Exporter) run() {
+	defer e.wg.Done()
+	for ev := range e.queue {
+		for _, s := range e.sinks {
+			if err := s.Send(ev); err != nil {
+				logger.Log.Warnf("event export: sink send failed: %v", err)
+			}
+		}
+	}
+}
+
+// --- syslog sink (RFC 5424) ---
+
+// Facility local0 (16) is the conventional choice for application logs.
+const syslogFacilityLocal0 = 16
+
+// syslogSDID is the RFC 5424 structured-data element ID. 32473 is the
+// enterprise number reserved by RFC 5612 for documentation/examples.
+const syslogSDID = "hydradns@32473"
+
+type syslogSink struct {
+	mu       sync.Mutex
+	conn     net.Conn
+	network  string
+	address  string
+	hostname string
+	appName  string
+	procID   string
+}
+
+// newSyslogSink parses a target of the form "udp://host:514" or
+// "tcp://host:514" (scheme optional, defaults to udp) and dials it.
+func newSyslogSink(addr string) (*syslogSink, error) {
+	network, address, err := parseSyslogAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s %s: %w", network, address, err)
+	}
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "-"
+	}
+	return &syslogSink{
+		conn:     conn,
+		network:  network,
+		address:  address,
+		hostname: host,
+		appName:  "hydradns",
+		procID:   strconv.Itoa(os.Getpid()),
+	}, nil
+}
+
+// parseSyslogAddr splits a syslog target into (network, address). Accepted
+// forms: "udp://host:port", "tcp://host:port", or a bare "host:port"
+// (defaults to udp).
+func parseSyslogAddr(addr string) (network, address string, err error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "", "", fmt.Errorf("empty syslog address")
+	}
+	if strings.Contains(addr, "://") {
+		u, perr := url.Parse(addr)
+		if perr != nil {
+			return "", "", fmt.Errorf("parse syslog addr %q: %w", addr, perr)
+		}
+		network = strings.ToLower(u.Scheme)
+		address = u.Host
+	} else {
+		network = "udp"
+		address = addr
+	}
+	switch network {
+	case "udp", "udp4", "udp6", "tcp", "tcp4", "tcp6":
+	default:
+		return "", "", fmt.Errorf("unsupported syslog network %q (use udp:// or tcp://)", network)
+	}
+	if address == "" {
+		return "", "", fmt.Errorf("missing host:port in syslog address %q", addr)
+	}
+	return network, address, nil
+}
+
+func (s *syslogSink) Send(ev Event) error {
+	line := formatRFC5424(s.hostname, s.appName, s.procID, ev.Timestamp, ev)
+	// Non-transparent framing (RFC 6587): terminate stream messages with LF.
+	if strings.HasPrefix(s.network, "tcp") {
+		line += "\n"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.conn.Write([]byte(line))
+	return err
+}
+
+func (s *syslogSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.conn != nil {
+		return s.conn.Close()
+	}
+	return nil
+}
+
+// severityFor maps an engine action to an RFC 5424 severity level.
+func severityFor(action string) int {
+	switch action {
+	case "error":
+		return 3 // Error
+	case "flagged":
+		return 4 // Warning
+	case "block", "redirect":
+		return 5 // Notice
+	default: // allow and anything else
+		return 6 // Informational
+	}
+}
+
+// formatRFC5424 renders an event as a single RFC 5424 syslog line. It is a
+// pure function of its inputs, which keeps formatting deterministically
+// testable. Any empty header field is emitted as the RFC nil value "-".
+func formatRFC5424(hostname, appName, procID string, t time.Time, ev Event) string {
+	pri := syslogFacilityLocal0*8 + severityFor(ev.Action)
+
+	ts := t.UTC().Format(time.RFC3339)
+	if t.IsZero() {
+		ts = "-"
+	}
+	hostname = nilIfEmpty(hostname)
+	appName = nilIfEmpty(appName)
+	procID = nilIfEmpty(procID)
+	msgID := "DNSQUERY"
+
+	// Values are escaped with escapeSD and wrapped in literal double quotes.
+	// Do not use %q here: it would double-escape the already-escaped values.
+	sd := fmt.Sprintf(
+		`[%s domain="%s" client="%s" action="%s" suspicious="%s" score="%s" method="%s" reason="%s"]`,
+		syslogSDID,
+		escapeSD(ev.Domain),
+		escapeSD(ev.ClientIP),
+		escapeSD(ev.Action),
+		strconv.FormatBool(ev.IsSuspicious),
+		strconv.FormatFloat(ev.ThreatScore, 'f', 2, 64),
+		escapeSD(ev.DetectionMethod),
+		escapeSD(ev.ThreatReason),
+	)
+
+	msg := fmt.Sprintf("dns query domain=%s client=%s action=%s", ev.Domain, ev.ClientIP, ev.Action)
+
+	return fmt.Sprintf("<%d>1 %s %s %s %s %s %s %s",
+		pri, ts, hostname, appName, procID, msgID, sd, msg)
+}
+
+func nilIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// escapeSD escapes the three characters RFC 5424 requires to be escaped inside
+// a structured-data PARAM-VALUE: '"', '\', and ']'.
+func escapeSD(s string) string {
+	return strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`]`, `\]`,
+	).Replace(s)
+}
+
+// --- webhook sink (POST JSON) ---
+
+type webhookSink struct {
+	url    string
+	client *http.Client
+}
+
+func newWebhookSink(target string) *webhookSink {
+	return &webhookSink{
+		url: target,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+func (h *webhookSink) Send(ev Event) error {
+	body, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, h.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "hydradns-exporter")
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post webhook: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (h *webhookSink) Close() error { return nil }

--- a/internal/dnsengine/export_test.go
+++ b/internal/dnsengine/export_test.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sampleEvent() Event {
+	return Event{
+		Timestamp:       time.Date(2026, 7, 20, 12, 30, 0, 0, time.UTC),
+		Domain:          "evil.com",
+		ClientIP:        "10.0.0.1:5353",
+		Action:          "block",
+		IsSuspicious:    true,
+		ThreatScore:     0.95,
+		DetectionMethod: "entropy",
+		ThreatReason:    "high entropy",
+	}
+}
+
+func TestSeverityFor(t *testing.T) {
+	cases := map[string]int{
+		"allow":    6,
+		"flagged":  4,
+		"block":    5,
+		"redirect": 5,
+		"error":    3,
+		"unknown":  6,
+	}
+	for action, want := range cases {
+		if got := severityFor(action); got != want {
+			t.Errorf("severityFor(%q) = %d, want %d", action, got, want)
+		}
+	}
+}
+
+func TestEscapeSD(t *testing.T) {
+	// RFC 5424 requires escaping of '"', '\' and ']' inside PARAM-VALUE.
+	in := `a"b\c]d`
+	want := `a\"b\\c\]d`
+	if got := escapeSD(in); got != want {
+		t.Errorf("escapeSD(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestFormatRFC5424(t *testing.T) {
+	ev := sampleEvent()
+	line := formatRFC5424("box-1", "hydradns", "42", ev.Timestamp, ev)
+
+	// PRI = facility(local0=16)*8 + severity(block=5) = 133, version 1.
+	if !strings.HasPrefix(line, "<133>1 ") {
+		t.Errorf("expected PRI/version prefix <133>1, got line: %s", line)
+	}
+
+	wantSubstrings := []string{
+		"2026-07-20T12:30:00Z",         // RFC3339 timestamp
+		" box-1 hydradns 42 DNSQUERY ", // HOSTNAME APP-NAME PROCID MSGID
+		"[hydradns@32473 ",             // structured-data element id
+		`domain="evil.com"`,
+		`client="10.0.0.1:5353"`,
+		`action="block"`,
+		`suspicious="true"`,
+		`score="0.95"`,
+		`method="entropy"`,
+		`reason="high entropy"`,
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(line, s) {
+			t.Errorf("RFC5424 line missing %q\nline: %s", s, line)
+		}
+	}
+}
+
+func TestFormatRFC5424_NilFieldsAndZeroTime(t *testing.T) {
+	// Empty header fields must render as the RFC nil value "-".
+	ev := Event{Action: "allow"} // zero timestamp
+	line := formatRFC5424("", "", "", ev.Timestamp, ev)
+
+	// PRI = 16*8 + 6 (allow) = 134.
+	if !strings.HasPrefix(line, "<134>1 - - - - DNSQUERY ") {
+		t.Errorf("expected nil header fields, got: %s", line)
+	}
+}
+
+func TestFormatRFC5424_EscapesStructuredData(t *testing.T) {
+	ev := sampleEvent()
+	ev.ThreatReason = `bad "quote" and ] bracket`
+	line := formatRFC5424("h", "a", "1", ev.Timestamp, ev)
+	if !strings.Contains(line, `reason="bad \"quote\" and \] bracket"`) {
+		t.Errorf("structured-data value not escaped: %s", line)
+	}
+}
+
+func TestParseSyslogAddr(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantNet  string
+		wantAddr string
+		wantErr  bool
+	}{
+		{"udp://host:514", "udp", "host:514", false},
+		{"tcp://1.2.3.4:601", "tcp", "1.2.3.4:601", false},
+		{"host:514", "udp", "host:514", false}, // bare defaults to udp
+		{"http://host:514", "", "", true},      // unsupported network
+		{"", "", "", true},                     // empty
+	}
+	for _, c := range cases {
+		gotNet, gotAddr, err := parseSyslogAddr(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseSyslogAddr(%q) expected error, got nil", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSyslogAddr(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if gotNet != c.wantNet || gotAddr != c.wantAddr {
+			t.Errorf("parseSyslogAddr(%q) = (%q,%q), want (%q,%q)", c.in, gotNet, gotAddr, c.wantNet, c.wantAddr)
+		}
+	}
+}
+
+func TestWebhookSink_Send_PostsValidJSON(t *testing.T) {
+	type received struct {
+		contentType string
+		body        []byte
+	}
+	got := make(chan received, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		b, _ := io.ReadAll(r.Body)
+		got <- received{contentType: r.Header.Get("Content-Type"), body: b}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := newWebhookSink(srv.URL)
+	ev := sampleEvent()
+	if err := sink.Send(ev); err != nil {
+		t.Fatalf("webhook Send failed: %v", err)
+	}
+
+	select {
+	case r := <-got:
+		if r.contentType != "application/json" {
+			t.Errorf("expected application/json, got %q", r.contentType)
+		}
+		var decoded Event
+		if err := json.Unmarshal(r.body, &decoded); err != nil {
+			t.Fatalf("webhook body is not valid JSON: %v (body=%s)", err, r.body)
+		}
+		if decoded.Domain != ev.Domain || decoded.Action != ev.Action || decoded.ThreatScore != ev.ThreatScore {
+			t.Errorf("decoded event mismatch: %+v", decoded)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("webhook server did not receive request")
+	}
+}
+
+func TestWebhookSink_Send_ErrorOnBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	sink := newWebhookSink(srv.URL)
+	if err := sink.Send(sampleEvent()); err == nil {
+		t.Fatal("expected error on 500 response, got nil")
+	}
+}
+
+func TestNewExporter_DisabledIsNil(t *testing.T) {
+	exp, err := NewExporter("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exp != nil {
+		t.Fatal("expected nil exporter when both targets are empty")
+	}
+	// nil exporter must be a safe no-op.
+	exp.Export(sampleEvent())
+	exp.Close()
+	if exp.Dropped() != 0 {
+		t.Errorf("expected 0 dropped on nil exporter, got %d", exp.Dropped())
+	}
+}
+
+func TestExporter_DropsWhenFullWithoutBlocking(t *testing.T) {
+	// White-box: build an exporter with a tiny queue and NO running worker,
+	// so nothing drains it. Export must never block and must drop overflow.
+	exp := &Exporter{queue: make(chan Event, 2)}
+
+	const total = 10
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < total; i++ {
+			exp.Export(sampleEvent())
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Export blocked when queue was full")
+	}
+
+	// 2 fit in the buffer, the remaining 8 are dropped.
+	if got := exp.Dropped(); got != total-2 {
+		t.Errorf("expected %d drops, got %d", total-2, got)
+	}
+}
+
+func TestExporter_WebhookEndToEnd(t *testing.T) {
+	got := make(chan Event, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev Event
+		_ = json.NewDecoder(r.Body).Decode(&ev)
+		got <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exp, err := NewExporter("", srv.URL)
+	if err != nil {
+		t.Fatalf("NewExporter error: %v", err)
+	}
+	if exp == nil {
+		t.Fatal("expected non-nil exporter when webhook is configured")
+	}
+	defer exp.Close()
+
+	want := sampleEvent()
+	exp.Export(want)
+
+	select {
+	case ev := <-got:
+		if ev.Domain != want.Domain || ev.Action != want.Action {
+			t.Errorf("received event mismatch: %+v", ev)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("exporter did not deliver event to webhook")
+	}
+}
+
+func TestSyslogSink_UDP_WritesRFC5424(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	defer pc.Close()
+
+	sink, err := newSyslogSink("udp://" + pc.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("newSyslogSink: %v", err)
+	}
+	defer sink.Close()
+
+	if err := sink.Send(sampleEvent()); err != nil {
+		t.Fatalf("syslog Send: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	_ = pc.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("read udp datagram: %v", err)
+	}
+	line := string(buf[:n])
+
+	for _, want := range []string{"<133>1 ", "[hydradns@32473 ", `domain="evil.com"`, `action="block"`} {
+		if !strings.Contains(line, want) {
+			t.Errorf("syslog datagram missing %q\nline: %s", want, line)
+		}
+	}
+}


### PR DESCRIPTION
## What
Adds an **optional, default-OFF** event exporter that streams DNS query events to external systems:
- **Syslog (RFC 5424)** over UDP or TCP (`SYSLOG_ADDR`, e.g. `udp://host:514`)
- **Generic webhook** via JSON POST (`EVENT_WEBHOOK_URL`)

Both config values default empty, so export stays off unless explicitly enabled.

## Why
Operators (SMBs/schools/hospitals) want DNS query/threat events in their existing SIEM or syslog collector without scraping the local SQLite query log. This gives a standard, pluggable egress path for security telemetry.

## How
- New `internal/dnsengine/export.go`: an `Exporter` with pluggable `Sink`s (syslog + webhook).
- Delivery goes through a **bounded (1024), drop-on-full queue** drained by a single background worker, so a slow/unreachable sink can never stall resolution. `Export` uses a non-blocking `select`/`default` and increments a dropped counter; a `nil *Exporter` is a valid no-op (disabled).
- Hooked into the existing `logQuery` dataplane path — each query event (domain, client, action, threat fields) is fed to the exporter when enabled.
- RFC 5424 lines are built by a pure `formatRFC5424` function (facility local0, severity mapped from action, structured-data element `hydradns@32473`, proper `"` / `\` / `]` escaping).
- Config: `SYSLOG_ADDR` and `EVENT_WEBHOOK_URL` added to `DataPlaneConfig` (YAML + env), wired in `NewDNSEngine`, closed on `Engine.Shutdown` (nil-safe).

## Tests
Deterministic, no sleeps for correctness:
- RFC 5424 field formatting, PRI/severity mapping, nil-field rendering, structured-data escaping.
- Webhook POSTs valid JSON with `application/json` (httptest target); error on non-2xx.
- `parseSyslogAddr` scheme handling; UDP syslog line verified over a real loopback socket.
- Disabled (both empty) = nil exporter, no-op.
- Queue drops overflow when full **without blocking** (white-box, worker-less queue).

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)