### PR TITLE
feat(threat): typosquat/homoglyph detection against a brand watchlist (I-042)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -43,6 +43,12 @@ dataplane:
   # WATCHDOG_INTERVAL / WATCHDOG_FAILURE_THRESHOLD env vars.
   watchdog_interval: "30s"
   watchdog_failure_threshold: 3
+  # Typosquat / homoglyph detection against a protected-brand watchlist.
+  # Empty list (default) = OFF. Also settable via env: TYPOSQUAT_BRANDS
+  # (comma-separated) and TYPOSQUAT_BLOCK (true/false).
+  # typosquat_brands:
+  #   - "paypal.com"
+  # typosquat_block: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/willf/bloom v2.0.3+incompatible
 	golang.org/x/crypto v0.40.0
+	golang.org/x/net v0.42.0
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.9
 	gopkg.in/yaml.v3 v3.0.1
@@ -60,7 +61,6 @@ require (
 	go.uber.org/mock v0.5.0 // indirect
 	golang.org/x/arch v0.20.0 // indirect
 	golang.org/x/mod v0.25.0 // indirect
-	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.27.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,12 @@ type DataPlaneConfig struct {
 	// SyslogAddr accepts "udp://host:514" or "tcp://host:514".
 	SyslogAddr      string `yaml:"syslog_addr"`
 	EventWebhookURL string `yaml:"event_webhook_url"`
+
+	// TyposquatBrands is the protected-brand watchlist for typosquat/homoglyph
+	// detection (registrable domains, e.g. "paypal.com"). Empty => feature OFF.
+	TyposquatBrands []string `yaml:"typosquat_brands"`
+	// TyposquatBlock blocks typosquat hits instead of only flagging them.
+	TyposquatBlock bool `yaml:"typosquat_block"`
 }
 
 // WatchdogIntervalDuration parses WatchdogInterval into a duration. It returns 0
@@ -335,6 +341,15 @@ var DefaultConfig = func() *Config {
 	if webhook := os.Getenv("EVENT_WEBHOOK_URL"); webhook != "" {
 		cfg.DataPlane.EventWebhookURL = webhook
 	}
+	if brands := os.Getenv("TYPOSQUAT_BRANDS"); brands != "" {
+		cfg.DataPlane.TyposquatBrands = splitAndTrim(brands)
+	}
+	if block := os.Getenv("TYPOSQUAT_BLOCK"); block != "" {
+		switch strings.ToLower(strings.TrimSpace(block)) {
+		case "1", "true", "yes", "on":
+			cfg.DataPlane.TyposquatBlock = true
+		}
+	}
 	return cfg
 }()
 
@@ -374,6 +389,18 @@ func applyTLSEnv(t *TLSConfig) {
 	if t.SelfSignedDir == "" {
 		t.SelfSignedDir = DefaultSelfSignedDir
 	}
+}
+
+// splitAndTrim splits a comma-separated list, trimming whitespace and dropping
+// empty entries.
+func splitAndTrim(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if v := strings.TrimSpace(p); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func configPath() string {

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -145,6 +145,11 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		exporter = nil
 	}
 
+	// Typosquat/homoglyph detector: an empty brand watchlist is a no-op inside
+	// Analyze, so this is always safe to construct.
+	detector := threat.NewDetectorWithBrands(cfg.TyposquatBrands)
+	detector.SetTyposquatBlock(cfg.TyposquatBlock)
+
 	e := &Engine{
 		upstreamManager:      mgr,
 		policyEngine:         pE,
@@ -152,7 +157,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		metrics:              qm,
 		queryLog:             repos.QueryLogs,
 		statistics:           repos.Statistics,
-		threatDetector:       threat.NewDetector(),
+		threatDetector:       detector,
 		exporter:             exporter,
 		threatBlockThreshold: cfg.ThreatBlockThreshold,
 		threatBlockDryRun:    cfg.ThreatBlockDryRun,
@@ -585,6 +590,14 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		action := "allow"
 		reason := ""
 		if threatResult.IsSuspicious {
+			// Opt-in blocking (e.g. typosquat block mode): drop instead of forward.
+			if threatResult.Block {
+				logger.Log.Warnf("Suspicious domain blocked: %s (score=%.2f, method=%s)", domainName, threatResult.ThreatScore, threatResult.DetectionMethod)
+				e.logQuery(domainName, clientIP, "block", threatResult.DetectionMethod, threatResult)
+				e.respondBlocked(w, r, domainName, threatResult.DetectionMethod)
+				success = true
+				return
+			}
 			action = "flagged"
 			reason = threatResult.DetectionMethod
 			logger.Log.Warnf("Suspicious domain allowed: %s (score=%.2f, method=%s)", domainName, threatResult.ThreatScore, threatResult.DetectionMethod)

--- a/internal/threat/detector.go
+++ b/internal/threat/detector.go
@@ -10,28 +10,62 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"golang.org/x/net/idna"
 )
 
 // Result contains the detection output for a domain.
 type Result struct {
 	IsSuspicious    bool    `json:"is_suspicious"`
 	ThreatScore     float64 `json:"threat_score"`     // 0.0 to 1.0
-	DetectionMethod string  `json:"detection_method"` // e.g. "entropy", "dga_pattern", "length"
+	DetectionMethod string  `json:"detection_method"` // e.g. "entropy", "dga_pattern", "length", "typosquat"
 	Reason          string  `json:"reason"`
+	// Block indicates the caller should block (not merely flag) this domain.
+	// Only set for typosquat hits when the detector is configured to block.
+	Block bool `json:"block,omitempty"`
+}
+
+// brandEntry is a precomputed protected brand used for typosquat comparison.
+type brandEntry struct {
+	domain string // full registrable domain, lowercased, e.g. "paypal.com"
+	label  string // registrable label (SLD), lowercased, e.g. "paypal"
+	tld    string // public-suffix portion, e.g. "com" or "co.uk"
 }
 
 // Detector performs heuristic threat analysis on domain names.
 type Detector struct {
 	entropyThreshold float64
 	lengthThreshold  int
+
+	// Typosquat / homoglyph detection against a protected-brand watchlist.
+	// Empty brands => the check is a no-op (feature OFF by default).
+	brands          []brandEntry
+	typoMaxDistance int  // max Damerau/Levenshtein distance to flag (registrable label)
+	blockTyposquat  bool // when true, typosquat hits are marked to block, not just flag
 }
 
-// NewDetector creates a detector with sensible defaults.
+// NewDetector creates a detector with sensible defaults and no protected brands.
 func NewDetector() *Detector {
+	return NewDetectorWithBrands(nil)
+}
+
+// NewDetectorWithBrands creates a detector configured with a typosquat watchlist.
+// brands is a list of protected registrable domains (e.g. "paypal.com").
+// An empty/nil list leaves typosquat detection OFF; all other heuristics run
+// exactly as before.
+func NewDetectorWithBrands(brands []string) *Detector {
 	return &Detector{
 		entropyThreshold: 3.7, // high entropy = random-looking = suspicious
 		lengthThreshold:  50,  // very long domains are often DGA
+		brands:           normalizeBrands(brands),
+		typoMaxDistance:  2,
 	}
+}
+
+// SetTyposquatBlock controls whether typosquat hits are marked to block
+// (Result.Block == true) instead of only flagged as suspicious.
+func (d *Detector) SetTyposquatBlock(block bool) {
+	d.blockTyposquat = block
 }
 
 // Analyze runs all heuristics on a normalized domain name and returns a result.
@@ -50,7 +84,12 @@ func (d *Detector) Analyze(domain string) Result {
 		analysisTarget = longestLabel(parts[:len(parts)-1])
 	}
 
-	// Run detectors in order of confidence
+	// Run detectors in order of confidence. Typosquat runs first so a
+	// watchlist lookalike is reported as "typosquat" rather than being masked
+	// by a generic heuristic. It is a no-op when no brands are configured.
+	if r := d.checkTyposquat(domain); r.IsSuspicious {
+		return r
+	}
 	if r := d.checkDGAPattern(analysisTarget, domain); r.IsSuspicious {
 		return r
 	}
@@ -244,4 +283,217 @@ func longestLabel(labels []string) string {
 func formatFloat(f float64) string {
 	s := fmt.Sprintf("%.2f", f)
 	return s
+}
+
+// --- Typosquat / homoglyph detection -----------------------------------------
+
+// twoLevelTLDs is a small set of common two-label public suffixes so the
+// registrable label (SLD) is extracted correctly (e.g. "foo" in "foo.co.uk").
+// It is intentionally not exhaustive; unknown suffixes fall back to the last
+// two labels, which is correct for the overwhelming majority of TLDs.
+var twoLevelTLDs = map[string]bool{
+	"co.uk": true, "org.uk": true, "ac.uk": true, "gov.uk": true,
+	"co.in": true, "co.jp": true, "co.kr": true, "co.za": true,
+	"com.au": true, "net.au": true, "org.au": true,
+	"com.br": true, "com.cn": true, "com.sg": true, "com.mx": true, "com.tr": true,
+}
+
+// confusables maps visually-confusable runes to their Latin ASCII skeleton.
+// It covers digit lookalikes, a capital that mimics a lowercase letter, and
+// the common Latin-lookalike Cyrillic/Greek letters used in homograph attacks.
+// Runes not present here fall through to unicode.ToLower.
+var confusables = map[rune]string{
+	// digit -> letter lookalikes
+	'0': "o", '1': "l", '3': "e", '4': "a", '5': "s",
+	// capital that mimics a lowercase letter
+	'I': "l",
+	// Cyrillic -> Latin (lowercase)
+	'а': "a", 'е': "e", 'о': "o", 'р': "p", 'с': "c",
+	'х': "x", 'у': "y", 'і': "i", 'ѕ': "s", 'ԁ': "d",
+	'к': "k", 'г': "r",
+	// Cyrillic capitals -> Latin (lowercase)
+	'А': "a", 'Е': "e", 'О': "o", 'Р': "p", 'С': "c",
+	'Х': "x", 'В': "b", 'М': "m", 'Н': "h", 'Т': "t",
+	// Greek -> Latin (lowercase)
+	'ο': "o", 'α': "a", 'ν': "v", 'ρ': "p", 'ι': "i",
+	'κ': "k", 'μ': "u",
+}
+
+// confusableSkeleton reduces a label to a lowercase ASCII "skeleton" by mapping
+// confusable runes to their Latin equivalents. This is what lets "paypa1",
+// "paypaI" and the Cyrillic "pаypal" all collapse to "paypal".
+func confusableSkeleton(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if repl, ok := confusables[r]; ok {
+			b.WriteString(repl)
+			continue
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}
+
+// decodePunycodeDomain decodes IDN (xn--) labels to their Unicode form so
+// homograph attacks encoded as punycode can be normalized. On any decode error
+// the original domain is returned unchanged.
+func decodePunycodeDomain(domain string) string {
+	if !strings.Contains(domain, "xn--") {
+		return domain
+	}
+	if u, err := idna.Punycode.ToUnicode(domain); err == nil {
+		return u
+	}
+	return domain
+}
+
+// registrableParts returns the registrable label (SLD) and public-suffix
+// portion of a domain, e.g. ("paypal", "com") or ("foo", "co.uk"). The label
+// preserves its original case (needed to catch capital-letter homoglyphs); the
+// tld is lowercased. Returns empty strings when there is no registrable label.
+func registrableParts(domain string) (label, tld string) {
+	domain = strings.TrimSuffix(domain, ".")
+	parts := strings.Split(domain, ".")
+	if len(parts) < 2 {
+		return "", ""
+	}
+	if len(parts) >= 3 {
+		lastTwo := strings.ToLower(parts[len(parts)-2] + "." + parts[len(parts)-1])
+		if twoLevelTLDs[lastTwo] {
+			return parts[len(parts)-3], lastTwo
+		}
+	}
+	return parts[len(parts)-2], strings.ToLower(parts[len(parts)-1])
+}
+
+// normalizeBrands turns raw watchlist entries into precomputed brand entries,
+// dropping blanks and anything without a registrable label.
+func normalizeBrands(brands []string) []brandEntry {
+	var out []brandEntry
+	for _, raw := range brands {
+		b := strings.TrimSuffix(strings.TrimSpace(strings.ToLower(raw)), ".")
+		if b == "" {
+			continue
+		}
+		label, tld := registrableParts(b)
+		if label == "" || tld == "" {
+			continue
+		}
+		out = append(out, brandEntry{
+			domain: label + "." + tld,
+			label:  label,
+			tld:    tld,
+		})
+	}
+	return out
+}
+
+// checkTyposquat flags a domain that is a near-lookalike of a protected brand
+// on the watchlist. It decodes punycode, applies confusable/homoglyph
+// normalization, and compares the registrable label to each brand using
+// Damerau/Levenshtein edit distance. The exact brand (and its subdomains) is
+// never flagged. No-op when the watchlist is empty.
+func (d *Detector) checkTyposquat(domain string) Result {
+	if len(d.brands) == 0 {
+		return Result{}
+	}
+	// Preserve the existing CDN/infrastructure allowlist behaviour.
+	if isInfraDomain(domain) {
+		return Result{}
+	}
+
+	decoded := decodePunycodeDomain(domain)
+	label, tld := registrableParts(decoded)
+	if label == "" {
+		return Result{}
+	}
+	fullReg := strings.ToLower(label) + "." + tld
+	lowerLabel := strings.ToLower(label)
+	skel := confusableSkeleton(label)
+	if skel == "" {
+		return Result{}
+	}
+
+	for _, b := range d.brands {
+		// Never flag the exact brand itself (or its subdomains, which share the
+		// registrable domain).
+		if fullReg == b.domain {
+			continue
+		}
+
+		if skel == b.label {
+			// Skeleton collapses onto the brand. If the raw ASCII label already
+			// equals the brand label this is just a different TLD (not a
+			// lookalike) — skip it. Otherwise it is a confusable/homoglyph.
+			if lowerLabel != b.label {
+				return d.typosquatResult(domain, b.domain, "homoglyph/confusable lookalike")
+			}
+			continue
+		}
+
+		dist := damerauLevenshtein(skel, b.label)
+		if dist >= 1 && dist <= d.typoMaxDistance {
+			return d.typosquatResult(domain, b.domain, fmt.Sprintf("edit distance %d from brand label", dist))
+		}
+	}
+	return Result{}
+}
+
+func (d *Detector) typosquatResult(domain, brand, why string) Result {
+	return Result{
+		IsSuspicious:    true,
+		ThreatScore:     0.85,
+		DetectionMethod: "typosquat",
+		Reason:          fmt.Sprintf("lookalike of protected brand %q (%s)", brand, why),
+		Block:           d.blockTyposquat,
+	}
+}
+
+// damerauLevenshtein returns the optimal string alignment (Damerau/Levenshtein)
+// edit distance between a and b, counting insertions, deletions, substitutions
+// and adjacent transpositions each as a single edit.
+func damerauLevenshtein(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+	la, lb := len(ra), len(rb)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev2 := make([]int, lb+1)
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+			if i > 1 && j > 1 && ra[i-1] == rb[j-2] && ra[i-2] == rb[j-1] {
+				if t := prev2[j-2] + 1; t < curr[j] {
+					curr[j] = t
+				}
+			}
+		}
+		prev2, prev, curr = prev, curr, prev2
+	}
+	return prev[lb]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
 }

--- a/internal/threat/detector_test.go
+++ b/internal/threat/detector_test.go
@@ -88,6 +88,93 @@ func TestDetector_DeepSubdomains(t *testing.T) {
 	}
 }
 
+func TestDetector_Typosquat_Flagged(t *testing.T) {
+	d := NewDetectorWithBrands([]string{"paypal.com"})
+
+	// xn--pypal-4ve.com decodes to "pаypal.com" where the second character is a
+	// Cyrillic 'а' (U+0430) — a classic IDN homograph attack.
+	cases := []string{
+		"paypa1.com",        // digit '1' for 'l'
+		"paypaI.com",        // capital 'I' for 'l'
+		"paypall.com",       // inserted letter (edit distance 1)
+		"payppal.com",       // doubled letter (edit distance 1)
+		"xn--pypal-4ve.com", // punycode Cyrillic homograph
+	}
+
+	for _, domain := range cases {
+		r := d.Analyze(domain)
+		if !r.IsSuspicious {
+			t.Errorf("typosquat %q not flagged", domain)
+			continue
+		}
+		if r.DetectionMethod != "typosquat" {
+			t.Errorf("typosquat %q: expected method typosquat, got %s", domain, r.DetectionMethod)
+		}
+		if r.Block {
+			t.Errorf("typosquat %q: expected flag-only (Block=false) in default mode", domain)
+		}
+	}
+}
+
+func TestDetector_Typosquat_ExactBrandNotFlagged(t *testing.T) {
+	d := NewDetectorWithBrands([]string{"paypal.com"})
+
+	// The exact brand and its subdomains must never be flagged as typosquat.
+	for _, domain := range []string{"paypal.com", "www.paypal.com", "api.paypal.com"} {
+		r := d.Analyze(domain)
+		if r.IsSuspicious && r.DetectionMethod == "typosquat" {
+			t.Errorf("exact brand %q flagged as typosquat: %s", domain, r.Reason)
+		}
+	}
+}
+
+func TestDetector_Typosquat_UnrelatedNotFlagged(t *testing.T) {
+	d := NewDetectorWithBrands([]string{"paypal.com"})
+
+	for _, domain := range []string{"google.com", "example.com", "github.com", "amazon.com"} {
+		r := d.Analyze(domain)
+		if r.IsSuspicious && r.DetectionMethod == "typosquat" {
+			t.Errorf("unrelated domain %q flagged as typosquat: %s", domain, r.Reason)
+		}
+	}
+}
+
+func TestDetector_Typosquat_EmptyWatchlistOff(t *testing.T) {
+	// Default detector has no brands => typosquat detection is OFF.
+	d := NewDetector()
+	for _, domain := range []string{"paypa1.com", "paypaI.com", "xn--pypal-4ve.com"} {
+		r := d.Analyze(domain)
+		if r.DetectionMethod == "typosquat" {
+			t.Errorf("empty watchlist should not run typosquat, but %q was flagged", domain)
+		}
+	}
+
+	// Explicit empty/blank list is also OFF.
+	d2 := NewDetectorWithBrands([]string{"", "  "})
+	if r := d2.Analyze("paypa1.com"); r.DetectionMethod == "typosquat" {
+		t.Error("blank watchlist entries should be ignored (feature OFF)")
+	}
+}
+
+func TestDetector_Typosquat_BlockVsFlag(t *testing.T) {
+	// Flag mode (default): suspicious but not marked to block.
+	flag := NewDetectorWithBrands([]string{"paypal.com"})
+	if r := flag.Analyze("paypa1.com"); !r.IsSuspicious || r.Block {
+		t.Errorf("flag mode: want suspicious && !Block, got suspicious=%v block=%v", r.IsSuspicious, r.Block)
+	}
+
+	// Block mode: same hit, but marked to block.
+	block := NewDetectorWithBrands([]string{"paypal.com"})
+	block.SetTyposquatBlock(true)
+	if r := block.Analyze("paypa1.com"); !r.IsSuspicious || !r.Block {
+		t.Errorf("block mode: want suspicious && Block, got suspicious=%v block=%v", r.IsSuspicious, r.Block)
+	}
+	// Block mode must not affect non-typosquat traffic.
+	if r := block.Analyze("google.com"); r.IsSuspicious {
+		t.Errorf("block mode: unrelated domain flagged: %s", r.Reason)
+	}
+}
+
 func TestShannonEntropy(t *testing.T) {
 	// "aaaa" has 0 entropy
 	e := shannonEntropy("aaaa")


### PR DESCRIPTION
## What
Adds typosquat / homoglyph detection to the threat detector (`internal/threat/detector.go`), which already runs on every DNS query via `Analyze`. A queried domain that is a near-lookalike of a configured **protected brand** is flagged (method `"typosquat"`), and optionally blocked.

**OFF by default** — an empty brand watchlist makes the check a no-op, and all existing heuristics run exactly as before.

## Why
Homograph/typosquat domains (`paypa1.com`, `paypaI.com`, IDN `xn--` Cyrillic lookalikes) are a common phishing vector that entropy/DGA heuristics miss, because the labels look perfectly "normal". Matching against a small, operator-supplied brand watchlist catches them with near-zero false positives.

## How
- **Registrable label** comparison using **Damerau/Levenshtein** edit distance (`<= 2`), with a small two-level public-suffix table (`co.uk`, `com.au`, …) for correct SLD extraction.
- **Confusable/homoglyph skeleton** normalization: digit lookalikes (`0→o`, `1→l`, `3→e`, `4→a`, `5→s`), capital `I→l`, and common Latin-lookalike Cyrillic/Greek letters.
- **Punycode (IDN `xn--`) decoding** via `golang.org/x/net/idna` so homograph attacks encoded as punycode are normalized before comparison.
- **Never flags the exact brand** or its subdomains; **keeps the existing CDN/infra allowlist** behaviour.
- Config: `TYPOSQUAT_BRANDS` (comma-separated, env + yaml) and `TYPOSQUAT_BLOCK` (bool, default `false`).
- Wired into `NewDNSEngine` minimally via new `threat.NewDetectorWithBrands([]string)` + `SetTyposquatBlock(bool)`. In block mode a hit is dropped (`respondBlocked`) instead of forwarded; flag mode logs it as `flagged` and forwards.

## Tests
`internal/threat/detector_test.go` covers the required scenarios (all green, plus full `go test ./...`):
- `paypa1.com` / `paypaI.com` / `xn--pypal-4ve.com` (Cyrillic homograph) flagged against brand `paypal.com`
- exact `paypal.com` (and subdomains) **not** flagged
- unrelated domains (`google.com`, …) **not** flagged
- empty / blank watchlist = OFF
- block vs flag mode (`Result.Block`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)