### PR TITLE
feat(controlplane): wire policies handlers to real storage + CRUD (P0.1, I-004)

### DIFF
--- a/cmd/controlplane/handlers/config_test.go
+++ b/cmd/controlplane/handlers/config_test.go
@@ -53,7 +53,7 @@ func newConfigTestServer(t *testing.T) (*gin.Engine, *repositories.Store) {
 	store := repositories.NewStore(db)
 	// DataPlaneClient and Inventory are nil: import persists and skips the
 	// best-effort reload; handlers must treat a nil Inventory as empty.
-	h := NewAPIHandler(*store, nil, nil)
+	h := NewAPIHandler(*store, nil, nil, nil)
 
 	r := gin.New()
 	api := r.Group("/api/v1")

--- a/cmd/controlplane/handlers/dns_test.go
+++ b/cmd/controlplane/handlers/dns_test.go
@@ -39,7 +39,7 @@ func newTestResolverHandler(t *testing.T) (*gin.Engine, *APIHandler) {
 
 	// DataPlaneClient is nil: handlers persist-only, apply is a no-op (documented).
 	store := repositories.Store{Resolvers: repositories.NewResolverRepo(db)}
-	h := NewAPIHandler(store, nil, nil)
+	h := NewAPIHandler(store, nil, nil, nil)
 
 	r := gin.New()
 	dns := r.Group("/api/v1/dns")

--- a/cmd/controlplane/handlers/handlers.go
+++ b/cmd/controlplane/handlers/handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	client "github.com/lopster568/phantomDNS/internal/grpc/controlplane"
 	"github.com/lopster568/phantomDNS/internal/inventory"
+	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 )
 
@@ -13,16 +14,24 @@ type APIHandler struct {
 	// Inventory is the passive LAN device inventory. It may be nil when the
 	// feature is disabled; handlers must treat that as an empty inventory.
 	Inventory *inventory.Inventory
+	// PolicyEngine holds the in-process policy snapshot. Mutating policy
+	// handlers reload it immediately after persisting so changes take effect
+	// without waiting for the dataplane's periodic DB poll. Optional: when
+	// nil, storage remains the source of truth and the dataplane picks up
+	// changes on its next reload.
+	PolicyEngine *policy.Engine
 }
 
 func NewAPIHandler(
 	store repositories.Store,
 	dataPlaneClient *client.Client,
 	deviceInventory *inventory.Inventory,
+	policyEngine *policy.Engine,
 ) *APIHandler {
 	return &APIHandler{
 		Store:           store,
 		DataPlaneClient: dataPlaneClient,
 		Inventory:       deviceInventory,
+		PolicyEngine:    policyEngine,
 	}
 }

--- a/cmd/controlplane/handlers/policies.go
+++ b/cmd/controlplane/handlers/policies.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 	"gorm.io/gorm"
 )
 
@@ -18,6 +20,7 @@ type Policy struct {
 	Action      string   `json:"action"`
 	RedirectIP  string   `json:"redirect_ip,omitempty"`
 	Domains     []string `json:"domains"`
+	Regexes     []string `json:"regexes"`
 	Priority    int      `json:"priority"`
 	Enabled     bool     `json:"enabled"`
 }
@@ -49,13 +52,33 @@ type CreatePolicyRequest struct {
 	Action      string   `json:"action" binding:"required"`
 	RedirectIP  string   `json:"redirect_ip"`
 	Domains     []string `json:"domains" binding:"required"`
+	Regexes     []string `json:"regexes"`
 	Priority    int      `json:"priority"`
 }
 
+// UpdatePolicyRequest carries an edit. Every field is a pointer so a nil value
+// means "leave unchanged" — this lets a single handler serve both PUT (full
+// replace, client sends every field) and PATCH (partial edit, client sends a
+// subset). This is the inline-edit path (I-004).
+type UpdatePolicyRequest struct {
+	Name        *string   `json:"name"`
+	Description *string   `json:"description"`
+	Category    *string   `json:"category"`
+	Action      *string   `json:"action"`
+	RedirectIP  *string   `json:"redirect_ip"`
+	Domains     *[]string `json:"domains"`
+	Regexes     *[]string `json:"regexes"`
+	Priority    *int      `json:"priority"`
+	Enabled     *bool     `json:"enabled"`
+}
+
 func policyFromModel(m models.Policy) Policy {
-	var domains []string
+	var domains, regexes []string
 	if m.Domains != "" {
 		_ = json.Unmarshal([]byte(m.Domains), &domains)
+	}
+	if m.Regexes != "" {
+		_ = json.Unmarshal([]byte(m.Regexes), &regexes)
 	}
 	return Policy{
 		ID:          m.ID,
@@ -65,23 +88,43 @@ func policyFromModel(m models.Policy) Policy {
 		Action:      m.Action,
 		RedirectIP:  m.RedirectIP,
 		Domains:     domains,
+		Regexes:     regexes,
 		Priority:    m.Priority,
 		Enabled:     m.Enabled,
 	}
 }
 
+// reloadPolicyEngine rebuilds the in-process policy snapshot from storage so
+// mutations take effect immediately. It is best-effort and nil-safe: storage
+// is the source of truth, and the dataplane also reloads from the same DB on
+// its own schedule, so a transient failure here never loses a change.
+func (h *APIHandler) reloadPolicyEngine() {
+	if h.PolicyEngine == nil {
+		return
+	}
+	stored, err := h.Store.Policies.List()
+	if err != nil {
+		return
+	}
+	engPolicies := make([]policy.Policy, 0, len(stored))
+	for _, m := range stored {
+		engPolicies = append(engPolicies, repositories.ToEnginePolicy(m))
+	}
+	_ = h.PolicyEngine.LoadPolicies(engPolicies)
+}
+
 // ListPolicies handles GET /policies
 func (h *APIHandler) ListPolicies(c *gin.Context) {
-	models, err := h.Store.Policies.List()
+	stored, err := h.Store.Policies.List()
 	if err != nil {
 		errMsg := "failed to fetch policies"
 		c.JSON(http.StatusInternalServerError, ResponsePolicyList{Status: "error", Error: &errMsg})
 		return
 	}
 
-	var list []Policy
+	list := make([]Policy, 0, len(stored))
 	activeCount := 0
-	for _, m := range models {
+	for _, m := range stored {
 		p := policyFromModel(m)
 		list = append(list, p)
 		if p.Enabled {
@@ -124,6 +167,7 @@ func (h *APIHandler) CreatePolicy(c *gin.Context) {
 	}
 
 	domainsJSON, _ := json.Marshal(req.Domains)
+	regexesJSON, _ := json.Marshal(req.Regexes)
 
 	m := &models.Policy{
 		ID:          req.ID,
@@ -133,15 +177,102 @@ func (h *APIHandler) CreatePolicy(c *gin.Context) {
 		Action:      req.Action,
 		RedirectIP:  req.RedirectIP,
 		Domains:     string(domainsJSON),
+		Regexes:     string(regexesJSON),
 		Priority:    req.Priority,
 		Enabled:     true,
 	}
+
+	// Validate against the same rules the engine enforces (action enum, etc.)
+	// so we never persist a policy the engine would reject.
+	ep := repositories.ToEnginePolicy(*m)
+	if err := policy.ValidatePolicy(&ep); err != nil {
+		errMsg := err.Error()
+		c.JSON(http.StatusBadRequest, ResponsePolicySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
 	if err := h.Store.Policies.Create(m); err != nil {
 		errMsg := "failed to create policy"
 		c.JSON(http.StatusInternalServerError, ResponsePolicySingle{Status: "error", Error: &errMsg})
 		return
 	}
+
+	// Persisted — now apply to the running engine snapshot.
+	h.reloadPolicyEngine()
+
 	c.JSON(http.StatusCreated, ResponsePolicySingle{
+		Status: "success",
+		Data:   policyFromModel(*m),
+	})
+}
+
+// UpdatePolicy handles PUT /policies/:id and PATCH /policies/:id.
+// It loads the existing policy, applies only the fields present in the request,
+// re-validates, persists, and reloads the engine. This is the inline-edit
+// feature (I-004).
+func (h *APIHandler) UpdatePolicy(c *gin.Context) {
+	m, err := h.Store.Policies.GetByID(c.Param("id"))
+	if err != nil {
+		errMsg := "policy not found"
+		c.JSON(http.StatusNotFound, ResponsePolicySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	var req UpdatePolicyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errMsg := err.Error()
+		c.JSON(http.StatusBadRequest, ResponsePolicySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	if req.Name != nil {
+		m.Name = *req.Name
+	}
+	if req.Description != nil {
+		m.Description = *req.Description
+	}
+	if req.Category != nil {
+		m.Category = *req.Category
+	}
+	if req.Action != nil {
+		m.Action = *req.Action
+	}
+	if req.RedirectIP != nil {
+		m.RedirectIP = *req.RedirectIP
+	}
+	if req.Domains != nil {
+		domainsJSON, _ := json.Marshal(*req.Domains)
+		m.Domains = string(domainsJSON)
+	}
+	if req.Regexes != nil {
+		regexesJSON, _ := json.Marshal(*req.Regexes)
+		m.Regexes = string(regexesJSON)
+	}
+	if req.Priority != nil {
+		m.Priority = *req.Priority
+	}
+	if req.Enabled != nil {
+		m.Enabled = *req.Enabled
+	}
+
+	// Validate the merged result before persisting.
+	ep := repositories.ToEnginePolicy(*m)
+	if err := policy.ValidatePolicy(&ep); err != nil {
+		errMsg := err.Error()
+		c.JSON(http.StatusBadRequest, ResponsePolicySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	if err := h.Store.Policies.Update(m); err != nil {
+		errMsg := "failed to update policy"
+		c.JSON(http.StatusInternalServerError, ResponsePolicySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	// Persisted — apply the edit to the running engine snapshot.
+	h.reloadPolicyEngine()
+
+	c.JSON(http.StatusOK, ResponsePolicySingle{
 		Status: "success",
 		Data:   policyFromModel(*m),
 	})
@@ -159,5 +290,9 @@ func (h *APIHandler) DeletePolicy(c *gin.Context) {
 		c.JSON(status, ResponseGeneric{Status: "error", Error: &errMsg})
 		return
 	}
+
+	// Persisted — apply the removal to the running engine snapshot.
+	h.reloadPolicyEngine()
+
 	c.JSON(http.StatusOK, ResponseGeneric{Status: "success", Data: map[string]interface{}{}})
 }

--- a/cmd/controlplane/handlers/policies_test.go
+++ b/cmd/controlplane/handlers/policies_test.go
@@ -1,0 +1,265 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/lopster568/phantomDNS/internal/policy"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// setupPolicyTest builds a Gin router wired to a real APIHandler backed by a
+// temp in-memory SQLite store and a real policy engine, mirroring the routes
+// registered in cmd/controlplane/routes/router.go.
+func setupPolicyTest(t *testing.T) (*gin.Engine, *APIHandler) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Policy{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	h := &APIHandler{
+		Store:        *repositories.NewStore(db),
+		PolicyEngine: policy.NewPolicyEngine(),
+	}
+
+	r := gin.New()
+	g := r.Group("/api/v1/policies")
+	g.GET("", h.ListPolicies)
+	g.POST("", h.CreatePolicy)
+	g.GET("/:id", h.GetPolicy)
+	g.PUT("/:id", h.UpdatePolicy)
+	g.PATCH("/:id", h.UpdatePolicy)
+	g.DELETE("/:id", h.DeletePolicy)
+	return r, h
+}
+
+func doReq(t *testing.T, r *gin.Engine, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestPolicyCRUDLifecycle walks create -> list -> get -> update -> delete,
+// asserting both storage persistence and that the running policy engine
+// reflects every change.
+func TestPolicyCRUDLifecycle(t *testing.T) {
+	r, h := setupPolicyTest(t)
+
+	// --- Create ---
+	create := CreatePolicyRequest{
+		ID:       "block-ads",
+		Name:     "Block Ads",
+		Action:   "BLOCK",
+		Domains:  []string{"ads.example.com"},
+		Priority: 100,
+	}
+	w := doReq(t, r, http.MethodPost, "/api/v1/policies", create)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d body=%s", w.Code, w.Body.String())
+	}
+	var created ResponsePolicySingle
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.Status != "success" || created.Data.ID != "block-ads" {
+		t.Fatalf("unexpected create envelope: %+v", created)
+	}
+
+	// Persisted?
+	stored, err := h.Store.Policies.GetByID("block-ads")
+	if err != nil {
+		t.Fatalf("expected policy persisted: %v", err)
+	}
+	if stored.Action != "BLOCK" {
+		t.Fatalf("expected stored action BLOCK, got %s", stored.Action)
+	}
+
+	// Engine reflects the new BLOCK rule?
+	if d, _ := h.PolicyEngine.Evaluate("ads.example.com"); d.Action != policy.ActionDeny {
+		t.Fatalf("engine: expected Deny for ads.example.com, got %v", d.Action)
+	}
+
+	// --- List ---
+	w = doReq(t, r, http.MethodGet, "/api/v1/policies", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", w.Code)
+	}
+	var list ResponsePolicyList
+	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if list.Data.TotalPolicies != 1 || list.Data.ActivePolicies != 1 {
+		t.Fatalf("unexpected list counts: %+v", list.Data)
+	}
+
+	// --- Get ---
+	w = doReq(t, r, http.MethodGet, "/api/v1/policies/block-ads", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d", w.Code)
+	}
+
+	// --- Update (PUT): flip action BLOCK -> ALLOW ---
+	newAction := "ALLOW"
+	w = doReq(t, r, http.MethodPut, "/api/v1/policies/block-ads", map[string]interface{}{
+		"action": newAction,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	stored, _ = h.Store.Policies.GetByID("block-ads")
+	if stored.Action != "ALLOW" {
+		t.Fatalf("expected stored action ALLOW after update, got %s", stored.Action)
+	}
+	// Engine now allows the same domain.
+	if d, _ := h.PolicyEngine.Evaluate("ads.example.com"); d.Action != policy.ActionAllow {
+		t.Fatalf("engine: expected Allow after update, got %v", d.Action)
+	}
+
+	// --- Delete ---
+	w = doReq(t, r, http.MethodDelete, "/api/v1/policies/block-ads", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete: expected 200, got %d", w.Code)
+	}
+	if _, err := h.Store.Policies.GetByID("block-ads"); err == nil {
+		t.Fatal("expected policy gone after delete")
+	}
+	// Engine reflects removal (default Allow).
+	if d, _ := h.PolicyEngine.Evaluate("ads.example.com"); d.Action != policy.ActionAllow {
+		t.Fatalf("engine: expected Allow after delete, got %v", d.Action)
+	}
+}
+
+// TestPolicyPatchPartialAndRegexes verifies PATCH only touches provided fields,
+// that regexes round-trip through storage, and that a domain change is applied
+// to the engine.
+func TestPolicyPatchPartialAndRegexes(t *testing.T) {
+	r, h := setupPolicyTest(t)
+
+	create := CreatePolicyRequest{
+		ID:         "redir",
+		Name:       "Redirect Test",
+		Action:     "REDIRECT",
+		RedirectIP: "10.0.0.1",
+		Domains:    []string{"old.example.com"},
+		Regexes:    []string{`.*\.tracker\.com$`},
+		Priority:   50,
+	}
+	w := doReq(t, r, http.MethodPost, "/api/v1/policies", create)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	// Regexes persisted and returned.
+	var created ResponsePolicySingle
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	if len(created.Data.Regexes) != 1 || created.Data.Regexes[0] != `.*\.tracker\.com$` {
+		t.Fatalf("regexes not returned: %+v", created.Data.Regexes)
+	}
+
+	// Engine blocks/redirects the initial domain.
+	if d, _ := h.PolicyEngine.Evaluate("old.example.com"); d.Action != policy.ActionRedirect {
+		t.Fatalf("engine: expected Redirect for old.example.com, got %v", d.Action)
+	}
+
+	// PATCH only the domains — name/action/priority must stay intact.
+	w = doReq(t, r, http.MethodPatch, "/api/v1/policies/redir", map[string]interface{}{
+		"domains": []string{"new.example.com"},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	stored, _ := h.Store.Policies.GetByID("redir")
+	if stored.Name != "Redirect Test" || stored.Action != "REDIRECT" || stored.Priority != 50 {
+		t.Fatalf("patch clobbered untouched fields: %+v", stored)
+	}
+
+	// Engine now matches the new domain, not the old one.
+	if d, _ := h.PolicyEngine.Evaluate("new.example.com"); d.Action != policy.ActionRedirect {
+		t.Fatalf("engine: expected Redirect for new.example.com, got %v", d.Action)
+	}
+	if d, _ := h.PolicyEngine.Evaluate("old.example.com"); d.Action != policy.ActionAllow {
+		t.Fatalf("engine: expected Allow for old.example.com after domain change, got %v", d.Action)
+	}
+}
+
+func TestPolicyGetNotFound(t *testing.T) {
+	r, _ := setupPolicyTest(t)
+	w := doReq(t, r, http.MethodGet, "/api/v1/policies/nope", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPolicyUpdateNotFound(t *testing.T) {
+	r, _ := setupPolicyTest(t)
+	w := doReq(t, r, http.MethodPatch, "/api/v1/policies/nope", map[string]interface{}{"priority": 5})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPolicyDeleteNotFound(t *testing.T) {
+	r, _ := setupPolicyTest(t)
+	w := doReq(t, r, http.MethodDelete, "/api/v1/policies/nope", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPolicyCreateInvalidAction(t *testing.T) {
+	r, _ := setupPolicyTest(t)
+	w := doReq(t, r, http.MethodPost, "/api/v1/policies", CreatePolicyRequest{
+		ID:      "bad",
+		Name:    "Bad",
+		Action:  "NUKE",
+		Domains: []string{"x.com"},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid action, got %d", w.Code)
+	}
+}
+
+func TestPolicyUpdateInvalidAction(t *testing.T) {
+	r, h := setupPolicyTest(t)
+	doReq(t, r, http.MethodPost, "/api/v1/policies", CreatePolicyRequest{
+		ID: "ok", Name: "OK", Action: "BLOCK", Domains: []string{"x.com"},
+	})
+	w := doReq(t, r, http.MethodPatch, "/api/v1/policies/ok", map[string]interface{}{"action": "NUKE"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid action on update, got %d", w.Code)
+	}
+	// Rejected update must not have mutated storage.
+	stored, err := h.Store.Policies.GetByID("ok")
+	if err != nil {
+		t.Fatalf("expected policy still present: %v", err)
+	}
+	if stored.Action != "BLOCK" {
+		t.Fatalf("expected action unchanged (BLOCK), got %s", stored.Action)
+	}
+}

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/config"
 	client "github.com/lopster568/phantomDNS/internal/grpc/controlplane"
 	"github.com/lopster568/phantomDNS/internal/inventory"
+	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/db"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 	"github.com/lopster568/phantomDNS/internal/tlsutil"
@@ -63,8 +64,24 @@ func main() {
 		}
 	}
 
+	// Initialize the in-process policy engine and seed it from storage. Policy
+	// handlers reload this snapshot immediately after each mutation so edits
+	// take effect without waiting for the dataplane's periodic DB poll. The
+	// dataplane runs its own engine over the same DB and remains authoritative
+	// for DNS resolution.
+	policyEngine := policy.NewPolicyEngine()
+	if stored, err := repos.Policies.List(); err != nil {
+		log.Printf("failed to load policies into engine: %v", err)
+	} else {
+		engPolicies := make([]policy.Policy, 0, len(stored))
+		for _, m := range stored {
+			engPolicies = append(engPolicies, repositories.ToEnginePolicy(m))
+		}
+		_ = policyEngine.LoadPolicies(engPolicies)
+	}
+
 	// Initialize Gin router
-	apiHandler := handlers.NewAPIHandler(*repos, c, deviceInventory)
+	apiHandler := handlers.NewAPIHandler(*repos, c, deviceInventory, policyEngine)
 	r := gin.Default()
 	r.Use(middlewares.Logger())
 

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -43,6 +43,8 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 			policies.GET("", apiHandler.ListPolicies)
 			policies.POST("", apiHandler.CreatePolicy)
 			policies.GET("/:id", apiHandler.GetPolicy)
+			policies.PUT("/:id", apiHandler.UpdatePolicy)
+			policies.PATCH("/:id", apiHandler.UpdatePolicy)
 			policies.DELETE("/:id", apiHandler.DeletePolicy)
 		}
 

--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -3,7 +3,6 @@ package main
 // SPDX-License-Identifier: GPL-3.0-or-later
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"os"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	"github.com/lopster568/phantomDNS/internal/nrd"
 	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/db"
-	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 	"github.com/lopster568/phantomDNS/internal/watchdog"
 )
@@ -300,28 +298,11 @@ func reloadPolicies(engine *policy.Engine, filePolicies []policy.Policy, repo re
 		logger.Log.Errorf("Failed to load policies from DB: %v", err)
 	} else {
 		for _, dbp := range dbPolicies {
-			all = append(all, dbPolicyToEngine(dbp))
+			all = append(all, repositories.ToEnginePolicy(dbp))
 		}
 	}
 
 	if err := engine.LoadPolicies(all); err != nil {
 		logger.Log.Errorf("Failed to reload policy snapshot: %v", err)
-	}
-}
-
-func dbPolicyToEngine(m models.Policy) policy.Policy {
-	var domains []string
-	if m.Domains != "" {
-		_ = json.Unmarshal([]byte(m.Domains), &domains)
-	}
-	return policy.Policy{
-		ID:       m.ID,
-		Name:     m.Name,
-		Action:   m.Action,
-		Domains:  domains,
-		Priority: m.Priority,
-		Enabled:  m.Enabled,
-		Category: m.Category,
-		Redirect: m.RedirectIP,
 	}
 }

--- a/internal/storage/models/policy.model.go
+++ b/internal/storage/models/policy.model.go
@@ -11,6 +11,7 @@ type Policy struct {
 	Action      string `gorm:"not null"` // BLOCK, ALLOW, REDIRECT
 	RedirectIP  string
 	Domains     string `gorm:"type:text"` // JSON array stored as text
+	Regexes     string `gorm:"type:text"` // JSON array stored as text
 	Priority    int    `gorm:"default:0"`
 	Enabled     bool   `gorm:"default:true"`
 	CreatedAt   time.Time

--- a/internal/storage/repositories/policy.go
+++ b/internal/storage/repositories/policy.go
@@ -2,9 +2,39 @@
 package repositories
 
 import (
+	"encoding/json"
+
+	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"gorm.io/gorm"
 )
+
+// ToEnginePolicy converts a stored policy model into the in-memory policy
+// used by the evaluation engine. Domains and Regexes are persisted as JSON
+// text and decoded here. This is the single conversion used by both the
+// dataplane (poll-based reload) and the control plane (immediate reload),
+// so the two never drift.
+func ToEnginePolicy(m models.Policy) policy.Policy {
+	var domains, regexes []string
+	if m.Domains != "" {
+		_ = json.Unmarshal([]byte(m.Domains), &domains)
+	}
+	if m.Regexes != "" {
+		_ = json.Unmarshal([]byte(m.Regexes), &regexes)
+	}
+	return policy.Policy{
+		ID:          m.ID,
+		Name:        m.Name,
+		Description: m.Description,
+		Category:    m.Category,
+		Action:      m.Action,
+		Redirect:    m.RedirectIP,
+		Enabled:     m.Enabled,
+		Priority:    m.Priority,
+		Domains:     domains,
+		Regexes:     regexes,
+	}
+}
 
 type PolicyRepository interface {
 	List() ([]models.Policy, error)


### PR DESCRIPTION
## What

Completes the control-plane policy handlers: full CRUD (create / list / get / edit / delete) backed by the real `internal/storage` layer and the real `internal/policy` engine, replacing the last mock-era gaps. Adds the missing **edit** path (PUT + PATCH) that powers inline editing (I-004), first-class **regex** support, and immediate application of every mutation to the running policy engine.

## Why

`handlers/policies.go` had no edit endpoint, no regex support, and never applied changes to the policy engine, so an operator could not modify a policy after creation and engine state only converged via the dataplane's periodic DB poll. This closes P0.1 (solid core: real storage + engine) and unblocks I-004 (inline edit).

## How

- **Edit (I-004):** new `UpdatePolicy` handler serves both `PUT /policies/:id` (full replace) and `PATCH /policies/:id` (partial). The request uses pointer fields so a nil value means "leave unchanged", letting one handler cover both verbs. It loads the existing policy, merges provided fields, re-validates, persists, and reloads the engine.
- **Apply to running engine:** `APIHandler` now holds an optional `*policy.Engine`. After every create/update/delete the handler rebuilds the snapshot from storage via `LoadPolicies` (atomic snapshot swap), so changes take effect immediately. It is nil-safe: storage stays the source of truth and the dataplane keeps reloading from the same DB on its own schedule (it remains authoritative for DNS resolution).
- **Regexes:** new `Regexes` JSON-text column on `models.Policy`, plus API request/response fields and conversions.
- **Validation:** create and update both run `policy.ValidatePolicy` against the engine-shaped policy before persisting, so we never store a policy the engine would reject (e.g. an unknown action).
- **Reuse over reimplementation:** the model to engine mapping is consolidated into `repositories.ToEnginePolicy`, now used by both the control plane and the dataplane (removing the duplicate `dbPolicyToEngine`).
- Routes: registered `PUT` and `PATCH` on `/policies/:id`. Standard `{status,data,error}` envelope and status codes (201 create, 200 ok, 400 bad request, 404 not found, 500 storage error).

## Tests

New `cmd/controlplane/handlers/policies_test.go` (httptest + Gin, temp in-memory sqlite):

- Full CRUD lifecycle asserting **both** storage persistence and that the policy **engine reflects** each change (BLOCK enforced, flip to ALLOW, removal on delete).
- PATCH partial edit leaves untouched fields intact; regexes round-trip; domain change re-points the engine.
- 404s for get/update/delete of a missing policy; 400 for invalid action on create and update; rejected update does not mutate storage.

All green: `gofmt`, `go build ./...`, `go vet ./cmd/... ./internal/...`, `go test ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
