### PR TITLE
feat(controlplane): wire blocklists handlers to real storage + CRUD (P0.1, I-004)

### DIFF
--- a/cmd/controlplane/handlers/blocklists.go
+++ b/cmd/controlplane/handlers/blocklists.go
@@ -1,11 +1,25 @@
 package handlers
 
 import (
+	"context"
+	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/blocklist"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+const (
+	// blocklistFetchWait bounds how long a create/update request blocks while the
+	// initial fetch/parse/store runs. If the fetch takes longer (large or slow list),
+	// the request returns and entries keep populating in the background.
+	blocklistFetchWait = 30 * time.Second
+	// blocklistFetchBudget caps the total time a background fetch may run so a slow or
+	// unreachable source can never leak a goroutine indefinitely.
+	blocklistFetchBudget = 2 * time.Minute
 )
 
 // Blocklist represents a blocklist source in API responses
@@ -47,6 +61,16 @@ type CreateBlocklistRequest struct {
 	Category string `json:"category"`
 }
 
+// UpdateBlocklistRequest carries partial edits. Nil fields are left unchanged, which
+// enables the inline-edit flow (I-004) and a simple enable/disable toggle.
+type UpdateBlocklistRequest struct {
+	Name     *string `json:"name"`
+	URL      *string `json:"url"`
+	Format   *string `json:"format"`
+	Category *string `json:"category"`
+	Enabled  *bool   `json:"enabled"`
+}
+
 func blocklistFromSource(src models.BlocklistSource, count int64) Blocklist {
 	return Blocklist{
 		ID:           src.ID,
@@ -59,6 +83,46 @@ func blocklistFromSource(src models.BlocklistSource, count int64) Blocklist {
 		CreatedAt:    src.CreatedAt,
 		UpdatedAt:    src.UpdatedAt,
 	}
+}
+
+// isHTTPURL guards against SSRF by only allowing http(s) blocklist sources, matching
+// the validation used during initial setup.
+func isHTTPURL(u string) bool {
+	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
+}
+
+// refreshSource runs the real fetch/parse/store engine for a source in the background.
+// It returns a channel that receives the fetch error when it completes. The fetch runs
+// against context.Background() (not the request context) so it keeps populating entries
+// even after the HTTP handler has returned.
+func (h *APIHandler) refreshSource(src models.BlocklistSource) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), blocklistFetchBudget)
+		defer cancel()
+		engine := blocklist.NewEngine(h.Store.Blocklist)
+		done <- engine.UpdateSource(ctx, src, src.ETag)
+	}()
+	return done
+}
+
+// waitForCount blocks up to blocklistFetchWait for a refresh to finish, then returns the
+// current persisted entry count for the source. If the fetch is still running it returns
+// the count so far while the fetch continues in the background.
+func (h *APIHandler) waitForCount(id string, done <-chan error) int64 {
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Printf("blocklist refresh failed for %s: %v", id, err)
+		}
+	case <-time.After(blocklistFetchWait):
+		log.Printf("blocklist refresh for %s still running; domains will populate in background", id)
+	}
+	count, err := h.Store.Blocklist.CountEntriesBySource(id)
+	if err != nil {
+		return 0
+	}
+	return count
 }
 
 // ListBlocklists handles GET /blocklists
@@ -117,6 +181,19 @@ func (h *APIHandler) CreateBlocklist(c *gin.Context) {
 		return
 	}
 
+	if !isHTTPURL(req.URL) {
+		errMsg := "url must use http:// or https://"
+		c.JSON(http.StatusBadRequest, ResponseBlocklistSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	// Reject duplicate IDs with a clear 409 rather than a 500 from the DB layer.
+	if _, err := h.Store.Blocklist.GetSource(req.ID); err == nil {
+		errMsg := "blocklist with this id already exists"
+		c.JSON(http.StatusConflict, ResponseBlocklistSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
 	src := &models.BlocklistSource{
 		ID:        req.ID,
 		Name:      req.Name,
@@ -132,14 +209,117 @@ func (h *APIHandler) CreateBlocklist(c *gin.Context) {
 		return
 	}
 
+	// Trigger the real fetch/parse/store so domains_count is actually populated
+	// instead of the previous hard-coded 0 (P0.1, I-004).
+	count := h.waitForCount(src.ID, h.refreshSource(*src))
+
+	// Reload to pick up ETag/UpdatedAt written by the engine.
+	if updated, err := h.Store.Blocklist.GetSource(src.ID); err == nil {
+		src = updated
+	}
+
 	c.JSON(http.StatusCreated, ResponseBlocklistSingle{
 		Status: "success",
-		Data:   blocklistFromSource(*src, 0),
+		Data:   blocklistFromSource(*src, count),
+	})
+}
+
+// UpdateBlocklist handles PUT/PATCH /blocklists/:id — inline edit and enable/disable toggle.
+func (h *APIHandler) UpdateBlocklist(c *gin.Context) {
+	id := c.Param("id")
+	src, err := h.Store.Blocklist.GetSource(id)
+	if err != nil {
+		errMsg := "blocklist not found"
+		c.JSON(http.StatusNotFound, ResponseBlocklistSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	var req UpdateBlocklistRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errMsg := err.Error()
+		c.JSON(http.StatusBadRequest, ResponseBlocklistSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	wasEnabled := src.Enabled
+	sourceChanged := false // URL or format changed → entries must be re-fetched
+
+	if req.Name != nil {
+		src.Name = *req.Name
+	}
+	if req.URL != nil {
+		if !isHTTPURL(*req.URL) {
+			errMsg := "url must use http:// or https://"
+			c.JSON(http.StatusBadRequest, ResponseBlocklistSingle{Status: "error", Error: &errMsg})
+			return
+		}
+		if *req.URL != src.URL {
+			sourceChanged = true
+		}
+		src.URL = *req.URL
+	}
+	if req.Format != nil {
+		if *req.Format != src.Format {
+			sourceChanged = true
+		}
+		src.Format = *req.Format
+	}
+	if req.Category != nil {
+		src.Category = *req.Category
+	}
+	if req.Enabled != nil {
+		src.Enabled = *req.Enabled
+	}
+
+	// A refresh is needed when the source is (re)enabled or its URL/format changed.
+	needsRefresh := src.Enabled && (!wasEnabled || sourceChanged)
+	if needsRefresh {
+		// Drop the stored ETag so the conditional fetch does not short-circuit with 304.
+		src.ETag = ""
+	}
+
+	if err := h.Store.Blocklist.UpdateSource(src); err != nil {
+		errMsg := "failed to update blocklist source"
+		c.JSON(http.StatusInternalServerError, ResponseBlocklistSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	// Reconcile the dataplane checker (which reads entries live from the DB) with the
+	// new desired state.
+	var count int64
+	switch {
+	case !src.Enabled:
+		// Disabled: drop its entries so the dataplane stops blocking them.
+		if wasEnabled {
+			if err := h.Store.Blocklist.DeleteEntriesBySource(id); err != nil {
+				log.Printf("failed to clear entries for disabled blocklist %s: %v", id, err)
+			}
+		}
+		count = 0
+	case needsRefresh:
+		// Clear any stale entries, then (re)fetch/parse/store.
+		if err := h.Store.Blocklist.DeleteEntriesBySource(id); err != nil {
+			log.Printf("failed to clear stale entries for blocklist %s: %v", id, err)
+		}
+		count = h.waitForCount(id, h.refreshSource(*src))
+	default:
+		count, _ = h.Store.Blocklist.CountEntriesBySource(id)
+	}
+
+	if updated, err := h.Store.Blocklist.GetSource(id); err == nil {
+		src = updated
+	}
+
+	c.JSON(http.StatusOK, ResponseBlocklistSingle{
+		Status: "success",
+		Data:   blocklistFromSource(*src, count),
 	})
 }
 
 // DeleteBlocklist handles DELETE /blocklists/:id
 func (h *APIHandler) DeleteBlocklist(c *gin.Context) {
+	// DeleteSource cascades to the source's entries + snapshots, so the dataplane's live
+	// blocklist view stops matching those domains immediately.
 	if err := h.Store.Blocklist.DeleteSource(c.Param("id")); err != nil {
 		errMsg := "blocklist not found"
 		c.JSON(http.StatusNotFound, ResponseGeneric{Status: "error", Error: &errMsg})

--- a/cmd/controlplane/handlers/blocklists_test.go
+++ b/cmd/controlplane/handlers/blocklists_test.go
@@ -1,0 +1,343 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"gorm.io/gorm"
+	glog "gorm.io/gorm/logger"
+)
+
+// hostsBody is a small hosts-format blocklist with three real domains (comments and
+// non-blocking lines are ignored by the parser).
+const hostsBody = `# test blocklist
+0.0.0.0 ads.example.com
+0.0.0.0 tracker.example.com
+0.0.0.0 malware.example.net
+1.2.3.4 ignored.example.com
+`
+
+// newTestHandler builds an APIHandler backed by a fresh in-memory sqlite DB.
+// MaxOpenConns(1) keeps the background fetch goroutine and the handler on a single
+// connection so they share the same in-memory database.
+func newTestHandler(t *testing.T) *APIHandler {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: glog.Default.LogMode(glog.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("failed to get sql db: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(
+		&models.BlocklistSource{},
+		&models.BlocklistSnapshot{},
+		&models.BlocklistEntry{},
+	); err != nil {
+		t.Fatalf("migrate failed: %v", err)
+	}
+	return NewAPIHandler(*repositories.NewStore(db), nil, nil, nil)
+}
+
+func newTestRouter(h *APIHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := r.Group("/api/v1/blocklists")
+	g.GET("", h.ListBlocklists)
+	g.POST("", h.CreateBlocklist)
+	g.GET("/:id", h.GetBlocklist)
+	g.PUT("/:id", h.UpdateBlocklist)
+	g.PATCH("/:id", h.UpdateBlocklist)
+	g.DELETE("/:id", h.DeleteBlocklist)
+	return r
+}
+
+func newHostsServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"v1"`)
+		_, _ = w.Write([]byte(hostsBody))
+	}))
+}
+
+func doRawJSON(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr *bytes.Reader
+	if body != "" {
+		rdr = bytes.NewReader([]byte(body))
+	} else {
+		rdr = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func decodeSingle(t *testing.T, w *httptest.ResponseRecorder) ResponseBlocklistSingle {
+	t.Helper()
+	var resp ResponseBlocklistSingle
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode single response: %v (body=%s)", err, w.Body.String())
+	}
+	return resp
+}
+
+func TestListBlocklists_Empty(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+
+	w := doRawJSON(t, r, http.MethodGet, "/api/v1/blocklists", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ResponseBlocklistList
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "success" {
+		t.Errorf("expected status success, got %q", resp.Status)
+	}
+	if resp.Data.TotalBlocklists != 0 {
+		t.Errorf("expected 0 blocklists, got %d", resp.Data.TotalBlocklists)
+	}
+}
+
+func TestCreateBlocklist_FetchesAndPersistsDomains(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+	srv := newHostsServer()
+	defer srv.Close()
+
+	body := `{"id":"test","name":"Test List","url":"` + srv.URL + `","format":"hosts","category":"ads"}`
+	w := doRawJSON(t, r, http.MethodPost, "/api/v1/blocklists", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d (body=%s)", w.Code, w.Body.String())
+	}
+
+	resp := decodeSingle(t, w)
+	if resp.Status != "success" {
+		t.Errorf("expected status success, got %q", resp.Status)
+	}
+	if resp.Error != nil {
+		t.Errorf("expected nil error, got %v", *resp.Error)
+	}
+	// The real engine should have fetched/parsed the 3 blocking domains.
+	if resp.Data.DomainsCount != 3 {
+		t.Errorf("expected domains_count 3 after fetch, got %d", resp.Data.DomainsCount)
+	}
+	if !resp.Data.Enabled {
+		t.Error("expected new blocklist to be enabled")
+	}
+
+	// Persistence: a fresh GET must reflect the stored source + count.
+	wg := doRawJSON(t, r, http.MethodGet, "/api/v1/blocklists/test", "")
+	if wg.Code != http.StatusOK {
+		t.Fatalf("expected 200 on get, got %d", wg.Code)
+	}
+	got := decodeSingle(t, wg)
+	if got.Data.DomainsCount != 3 {
+		t.Errorf("expected persisted domains_count 3, got %d", got.Data.DomainsCount)
+	}
+	if got.Data.Name != "Test List" {
+		t.Errorf("expected name 'Test List', got %q", got.Data.Name)
+	}
+
+	// The dataplane checker (live DB query) must now block the fetched domains.
+	blocked, _ := h.Store.Blocklist.IsBlocked("ads.example.com")
+	if !blocked {
+		t.Error("expected ads.example.com to be blocked after create")
+	}
+}
+
+func TestCreateBlocklist_RejectsNonHTTPURL(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+
+	body := `{"id":"bad","name":"Bad","url":"ftp://evil.example","format":"hosts"}`
+	w := doRawJSON(t, r, http.MethodPost, "/api/v1/blocklists", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-http url, got %d", w.Code)
+	}
+	resp := decodeSingle(t, w)
+	if resp.Status != "error" || resp.Error == nil {
+		t.Error("expected error envelope for bad url")
+	}
+}
+
+func TestCreateBlocklist_RejectsDuplicate(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+	srv := newHostsServer()
+	defer srv.Close()
+
+	body := `{"id":"dup","name":"Dup","url":"` + srv.URL + `","format":"hosts"}`
+	if w := doRawJSON(t, r, http.MethodPost, "/api/v1/blocklists", body); w.Code != http.StatusCreated {
+		t.Fatalf("first create expected 201, got %d", w.Code)
+	}
+	w := doRawJSON(t, r, http.MethodPost, "/api/v1/blocklists", body)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate create expected 409, got %d", w.Code)
+	}
+}
+
+func TestGetBlocklist_NotFound(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+
+	w := doRawJSON(t, r, http.MethodGet, "/api/v1/blocklists/missing", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	resp := decodeSingle(t, w)
+	if resp.Status != "error" || resp.Error == nil {
+		t.Error("expected error envelope for missing blocklist")
+	}
+}
+
+func TestUpdateBlocklist_InlineEdit(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+	srv := newHostsServer()
+	defer srv.Close()
+
+	create := `{"id":"edit","name":"Old","url":"` + srv.URL + `","format":"hosts","category":"ads"}`
+	if w := doRawJSON(t, r, http.MethodPost, "/api/v1/blocklists", create); w.Code != http.StatusCreated {
+		t.Fatalf("create expected 201, got %d", w.Code)
+	}
+
+	// Rename + recategorize without touching the URL (no re-fetch).
+	edit := `{"name":"New Name","category":"tracking"}`
+	w := doRawJSON(t, r, http.MethodPatch, "/api/v1/blocklists/edit", edit)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	resp := decodeSingle(t, w)
+	if resp.Status != "success" {
+		t.Errorf("expected success, got %q", resp.Status)
+	}
+	if resp.Data.Name != "New Name" || resp.Data.Category != "tracking" {
+		t.Errorf("edit not applied: name=%q category=%q", resp.Data.Name, resp.Data.Category)
+	}
+	// Domains kept (URL unchanged).
+	if resp.Data.DomainsCount != 3 {
+		t.Errorf("expected domains preserved (3), got %d", resp.Data.DomainsCount)
+	}
+
+	// Persistence check.
+	got := decodeSingle(t, doRawJSON(t, r, http.MethodGet, "/api/v1/blocklists/edit", ""))
+	if got.Data.Name != "New Name" || got.Data.Category != "tracking" {
+		t.Errorf("edit not persisted: name=%q category=%q", got.Data.Name, got.Data.Category)
+	}
+}
+
+func TestUpdateBlocklist_ToggleDisableThenEnable(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+	srv := newHostsServer()
+	defer srv.Close()
+
+	create := `{"id":"toggle","name":"Toggle","url":"` + srv.URL + `","format":"hosts"}`
+	if w := doRawJSON(t, r, http.MethodPost, "/api/v1/blocklists", create); w.Code != http.StatusCreated {
+		t.Fatalf("create expected 201, got %d", w.Code)
+	}
+	if blocked, _ := h.Store.Blocklist.IsBlocked("ads.example.com"); !blocked {
+		t.Fatal("expected domain blocked after create")
+	}
+
+	// Disable: entries must be cleared so the dataplane stops blocking.
+	w := doRawJSON(t, r, http.MethodPatch, "/api/v1/blocklists/toggle", `{"enabled":false}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("disable expected 200, got %d", w.Code)
+	}
+	resp := decodeSingle(t, w)
+	if resp.Data.Enabled {
+		t.Error("expected enabled=false after disable")
+	}
+	if resp.Data.DomainsCount != 0 {
+		t.Errorf("expected 0 domains after disable, got %d", resp.Data.DomainsCount)
+	}
+	if blocked, _ := h.Store.Blocklist.IsBlocked("ads.example.com"); blocked {
+		t.Error("expected domain NOT blocked after disable")
+	}
+
+	// Re-enable: entries must be re-fetched.
+	w = doRawJSON(t, r, http.MethodPatch, "/api/v1/blocklists/toggle", `{"enabled":true}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("enable expected 200, got %d", w.Code)
+	}
+	resp = decodeSingle(t, w)
+	if !resp.Data.Enabled {
+		t.Error("expected enabled=true after re-enable")
+	}
+	if resp.Data.DomainsCount != 3 {
+		t.Errorf("expected 3 domains re-fetched after enable, got %d", resp.Data.DomainsCount)
+	}
+	if blocked, _ := h.Store.Blocklist.IsBlocked("ads.example.com"); !blocked {
+		t.Error("expected domain blocked again after re-enable")
+	}
+}
+
+func TestUpdateBlocklist_NotFound(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+
+	w := doRawJSON(t, r, http.MethodPut, "/api/v1/blocklists/nope", `{"name":"x"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDeleteBlocklist(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+	srv := newHostsServer()
+	defer srv.Close()
+
+	create := `{"id":"del","name":"Del","url":"` + srv.URL + `","format":"hosts"}`
+	if w := doRawJSON(t, r, http.MethodPost, "/api/v1/blocklists", create); w.Code != http.StatusCreated {
+		t.Fatalf("create expected 201, got %d", w.Code)
+	}
+
+	w := doRawJSON(t, r, http.MethodDelete, "/api/v1/blocklists/del", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete expected 200, got %d", w.Code)
+	}
+	var resp ResponseGeneric
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "success" {
+		t.Errorf("expected success, got %q", resp.Status)
+	}
+
+	// Gone + entries cascaded.
+	if wg := doRawJSON(t, r, http.MethodGet, "/api/v1/blocklists/del", ""); wg.Code != http.StatusNotFound {
+		t.Errorf("expected 404 after delete, got %d", wg.Code)
+	}
+	if blocked, _ := h.Store.Blocklist.IsBlocked("ads.example.com"); blocked {
+		t.Error("expected domain NOT blocked after delete")
+	}
+}
+
+func TestDeleteBlocklist_NotFound(t *testing.T) {
+	h := newTestHandler(t)
+	r := newTestRouter(h)
+
+	w := doRawJSON(t, r, http.MethodDelete, "/api/v1/blocklists/ghost", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -54,6 +54,8 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 			blocklists.GET("", apiHandler.ListBlocklists)
 			blocklists.POST("", apiHandler.CreateBlocklist)
 			blocklists.GET("/:id", apiHandler.GetBlocklist)
+			blocklists.PUT("/:id", apiHandler.UpdateBlocklist)
+			blocklists.PATCH("/:id", apiHandler.UpdateBlocklist)
 			blocklists.DELETE("/:id", apiHandler.DeleteBlocklist)
 		}
 

--- a/internal/blocklist/bundle/seed_test.go
+++ b/internal/blocklist/bundle/seed_test.go
@@ -47,7 +47,9 @@ func (m *mockBlocklistRepo) GetSource(string) (*models.BlocklistSource, error) {
 	return nil, nil
 }
 func (m *mockBlocklistRepo) CreateSource(*models.BlocklistSource) error { return nil }
+func (m *mockBlocklistRepo) UpdateSource(*models.BlocklistSource) error { return nil }
 func (m *mockBlocklistRepo) DeleteSource(string) error                  { return nil }
+func (m *mockBlocklistRepo) DeleteEntriesBySource(string) error         { return nil }
 func (m *mockBlocklistRepo) CountEntriesBySource(string) (int64, error) {
 	return 0, nil
 }

--- a/internal/blocklist/fetcher/http_client.go
+++ b/internal/blocklist/fetcher/http_client.go
@@ -64,7 +64,12 @@ func (h *HTTPFetcher) Fetch(ctx context.Context, src parser.SourceConfig, knownE
 
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = 2 * time.Minute
-	if err := backoff.Retry(op, bo); err != nil {
+	// Wrap the caller's context so retries stop as soon as it is canceled or
+	// its deadline expires, instead of running the full backoff schedule (up
+	// to MaxElapsedTime) regardless of the caller's own timeout. Without this,
+	// a dead feed retried for close to 2 minutes even when the caller asked
+	// for a much shorter timeout.
+	if err := backoff.Retry(op, backoff.WithContext(bo, ctx)); err != nil {
 		return nil, "", err
 	}
 	return body, etag, nil

--- a/internal/blocklist/fetcher/http_client_test.go
+++ b/internal/blocklist/fetcher/http_client_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package fetcher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/blocklist/parser"
+)
+
+// TestFetch_HonorsCallerContextTimeout guards against a regression where
+// backoff.Retry ran the full exponential-backoff schedule (up to
+// bo.MaxElapsedTime, ~2 minutes) regardless of the caller's own context
+// deadline. A dead/erroring feed must stop retrying as soon as the caller's
+// context is done, not run for the backoff's own full budget.
+func TestFetch_HonorsCallerContextTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always fail so the retry loop keeps going until the context (or the
+		// backoff budget) gives up.
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	h := NewHTTPFetcher()
+	src := parser.SourceConfig{ID: "test", URL: srv.URL, Enabled: true}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, _, err := h.Fetch(ctx, src, "")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a permanently-failing feed")
+	}
+	// Give generous headroom over the 300ms deadline for scheduling jitter,
+	// but this must be nowhere near the 2-minute backoff MaxElapsedTime that
+	// the bug would otherwise run for.
+	if elapsed > 5*time.Second {
+		t.Fatalf("Fetch ignored the caller's context deadline: took %s (expected well under 5s)", elapsed)
+	}
+}

--- a/internal/storage/repositories/blocklist.go
+++ b/internal/storage/repositories/blocklist.go
@@ -18,7 +18,9 @@ type BlocklistRepository interface {
 	ListSources() ([]models.BlocklistSource, error)
 	GetSource(id string) (*models.BlocklistSource, error)
 	CreateSource(src *models.BlocklistSource) error
+	UpdateSource(src *models.BlocklistSource) error
 	DeleteSource(id string) error
+	DeleteEntriesBySource(sourceID string) error
 	CountEntriesBySource(sourceID string) (int64, error)
 	CountEntriesGroupedBySource() (map[string]int64, error)
 	GetRecentSnapshots(sourceID string, limit int) ([]models.BlocklistSnapshot, error)
@@ -116,6 +118,37 @@ func (r *BlocklistRepo) GetSource(id string) (*models.BlocklistSource, error) {
 
 func (r *BlocklistRepo) CreateSource(src *models.BlocklistSource) error {
 	return r.db.Create(src).Error
+}
+
+// UpdateSource persists changes to an existing blocklist source's metadata.
+// It uses Save (full-field update) so a false Enabled toggle is not skipped as a
+// zero value the way a struct-based Updates would be.
+func (r *BlocklistRepo) UpdateSource(src *models.BlocklistSource) error {
+	src.UpdatedAt = time.Now()
+	result := r.db.Save(src)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// DeleteEntriesBySource removes all entries and snapshots for a source while keeping
+// the source row. Used when a source is disabled or re-fetched so the dataplane's live
+// blocklist view (which queries entries directly) reflects the change immediately.
+func (r *BlocklistRepo) DeleteEntriesBySource(sourceID string) error {
+	tx := r.db.Begin()
+	defer tx.Rollback() // no-op after commit
+
+	if err := tx.Where("source_id = ?", sourceID).Delete(&models.BlocklistEntry{}).Error; err != nil {
+		return err
+	}
+	if err := tx.Where("source_id = ?", sourceID).Delete(&models.BlocklistSnapshot{}).Error; err != nil {
+		return err
+	}
+	return tx.Commit().Error
 }
 
 func (r *BlocklistRepo) DeleteSource(id string) error {


### PR DESCRIPTION
## What

Wire the control-plane blocklists handlers to the real storage layer and blocklist engine, and complete the CRUD surface.

## Why

The blocklists API only supported list/create/get/delete, create never fetched anything (so `domains_count` stayed `0`, per the roadmap), and there was no edit path for the UI's inline-edit flow (I-004). This closes P0.1 (real storage/engine wiring) and I-004 (inline edit).

## How

- **Create now runs the real engine** (`internal/blocklist`): after persisting the source, it triggers the actual fetch/parse/store (ETag/SHA256) so `domains_count` is populated from parsed entries instead of a hard-coded `0`. The fetch runs on a background context with a bounded handler wait (30s) and a hard fetch budget (2m), so a slow/unreachable source can never block the request or leak a goroutine.
- **New `PUT`/`PATCH /blocklists/:id`** for inline edit + enable/disable toggle. Partial (pointer-field) semantics: nil fields are untouched. Toggling reconciles the dataplane's live blocklist view — disable clears the source's entries so it stops blocking; re-enable (and URL/format changes) clears the stale ETag and re-fetches.
- **Delete** already cascades entries/snapshots via the repository, so the dataplane (which queries entries directly from the shared DB) stops matching those domains immediately.
- New repository methods `UpdateSource` (Save-based so a `false` Enabled toggle isn't dropped as a zero value) and `DeleteEntriesBySource`.
- Defensive touches consistent with the setup handler: `http(s)`-only URL guard (SSRF) and a `409` on duplicate id. Standard `{status,data,error}` envelope and proper status codes throughout.

## Tests

`cmd/controlplane/handlers/blocklists_test.go` — httptest + Gin handler tests against in-memory sqlite (served a real hosts-format list via `httptest.Server`):
- list (empty), create (asserts fetch populates `domains_count` + persistence + dataplane `IsBlocked`), get (+404), update inline edit (persistence), toggle disable→enable (entries cleared then re-fetched, verified via `IsBlocked`), delete (+cascade, +404), plus bad-URL/duplicate/not-found error envelopes.
- `go build ./...`, `go vet ./cmd/... ./internal/...`, and `go test ./...` (incl. `-race`) all green; no existing tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
