### PR TITLE
feat: opt-in heartbeat status reporting, metadata-only (I-009)

### DIFF
--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/diskhealth"
 	"github.com/lopster568/phantomDNS/internal/dnsengine"
 	dataplanegrpc "github.com/lopster568/phantomDNS/internal/grpc/dataplane"
+	"github.com/lopster568/phantomDNS/internal/heartbeat"
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"github.com/lopster568/phantomDNS/internal/metrics/promexport"
 	"github.com/lopster568/phantomDNS/internal/policy"
@@ -151,6 +152,15 @@ func main() {
 			logger.Log.Errorf("metrics server failed: %v", err)
 		}
 	}()
+
+	// 6c. Heartbeat reporter — opt-in, metadata-only fleet status reporting.
+	// Started only when HEARTBEAT_URL is configured; non-blocking and never fatal.
+	hb := heartbeat.New(heartbeat.Config{
+		URL:      config.DefaultConfig.DataPlane.HeartbeatURL,
+		Interval: config.DefaultConfig.DataPlane.HeartbeatInterval,
+		DBPath:   dbPath,
+	}, engine.Metrics(), engine, repos.Blocklist)
+	hb.Start(context.Background())
 
 	// 7. Attach blocklist checker and start DNS server
 	engine.AttachBlocklistChecker(repos.Blocklist)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,11 @@ type DataPlaneConfig struct {
 	TyposquatBrands []string `yaml:"typosquat_brands"`
 	// TyposquatBlock blocks typosquat hits instead of only flagging them.
 	TyposquatBlock bool `yaml:"typosquat_block"`
+
+	// Heartbeat is opt-in, metadata-only fleet status reporting. It is disabled
+	// when HeartbeatURL is empty.
+	HeartbeatURL      string `yaml:"heartbeat_url"`
+	HeartbeatInterval string `yaml:"heartbeat_interval"`
 }
 
 // WatchdogIntervalDuration parses WatchdogInterval into a duration. It returns 0
@@ -349,6 +354,12 @@ var DefaultConfig = func() *Config {
 		case "1", "true", "yes", "on":
 			cfg.DataPlane.TyposquatBlock = true
 		}
+	}
+	if url := os.Getenv("HEARTBEAT_URL"); url != "" {
+		cfg.DataPlane.HeartbeatURL = url
+	}
+	if interval := os.Getenv("HEARTBEAT_INTERVAL"); interval != "" {
+		cfg.DataPlane.HeartbeatInterval = interval
 	}
 	return cfg
 }()

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -495,6 +495,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		} else if blocked {
 			logger.Log.Infof("Blocked by blocklist: %s", domainName)
 			e.logQuery(domainName, clientIP, "block", "blocklist", threatResult)
+			e.metrics.RecordBlocked()
 			e.respondBlocked(w, r, domainName, "blocklist")
 			success = true
 			return
@@ -516,6 +517,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	case policy.ActionDeny:
 		logger.Log.Infof("Blocking via policy %s", decision.PolicyID)
 		e.logQuery(domainName, clientIP, "block", decision.PolicyID, threatResult)
+		e.metrics.RecordBlocked()
 		e.respondBlocked(w, r, domainName, decision.PolicyID)
 		success = true
 

--- a/internal/heartbeat/heartbeat.go
+++ b/internal/heartbeat/heartbeat.go
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package heartbeat provides opt-in, metadata-only status reporting for
+// managed/fleet deployments.
+//
+// When a heartbeat URL is configured, a background reporter periodically POSTs
+// an aggregate health snapshot to that URL. The payload contains ONLY
+// operational metadata (uptime, QPS, blocked percentage, disk headroom,
+// blocklist freshness, engine accepting-queries state) and never any DNS query
+// contents or domain names, preserving the data-custody promise. The reporter
+// is non-blocking and its failures are logged, never fatal.
+package heartbeat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"path/filepath"
+	"runtime/debug"
+	"syscall"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/dnsengine"
+	"github.com/lopster568/phantomDNS/internal/logger"
+	"github.com/lopster568/phantomDNS/internal/metrics"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+const (
+	// DefaultInterval is used when the configured interval is empty or invalid.
+	DefaultInterval = 60 * time.Second
+	// defaultHTTPTimeout bounds each POST so a slow collector never stalls the loop.
+	defaultHTTPTimeout = 10 * time.Second
+)
+
+// MetricsSource exposes the rolling query metrics used for QPS and blocked%.
+type MetricsSource interface {
+	Aggregate() metrics.AggregatedMetrics
+	Window() time.Duration
+}
+
+// EngineStatusSource exposes the DNS engine runtime status.
+type EngineStatusSource interface {
+	Status() dnsengine.Status
+}
+
+// BlocklistSource exposes blocklist source metadata for freshness reporting.
+// Only source metadata is read; no domains or entries are ever touched.
+type BlocklistSource interface {
+	ListSources() ([]models.BlocklistSource, error)
+}
+
+// Status is the metadata-only health snapshot POSTed to the heartbeat URL.
+//
+// It deliberately carries NO domain names, client IPs, or query contents — only
+// aggregate operational metadata suitable for fleet monitoring.
+type Status struct {
+	Status           string     `json:"status"` // "healthy" | "degraded"
+	Healthy          bool       `json:"healthy"`
+	Version          string     `json:"version,omitempty"`
+	UptimeSeconds    int64      `json:"uptime_seconds"`
+	AcceptingQueries bool       `json:"accepting_queries"`
+	QPS              float64    `json:"qps"`
+	BlockedPercent   float64    `json:"blocked_percent"`
+	WindowQueries    uint64     `json:"window_queries"`
+	WindowSeconds    int64      `json:"window_seconds"`
+	DiskFreeBytes    uint64     `json:"disk_free_bytes"`
+	DiskTotalBytes   uint64     `json:"disk_total_bytes"`
+	BlocklistUpdated *time.Time `json:"blocklist_last_update,omitempty"`
+	BlocklistAgeSec  *int64     `json:"blocklist_age_seconds,omitempty"`
+	ReportedAt       time.Time  `json:"reported_at"`
+}
+
+// Config holds the heartbeat wiring. URL empty means disabled.
+type Config struct {
+	URL      string
+	Interval string // duration string (e.g. "60s"); falls back to DefaultInterval
+	DBPath   string
+	Version  string // optional; resolved from build info when empty
+}
+
+// Reporter periodically assembles and POSTs a Status snapshot.
+type Reporter struct {
+	url       string
+	interval  time.Duration
+	version   string
+	dbPath    string
+	startedAt time.Time
+
+	metrics   MetricsSource
+	engine    EngineStatusSource
+	blocklist BlocklistSource
+
+	client    *http.Client
+	now       func() time.Time
+	diskUsage func(path string) (free, total uint64, err error)
+}
+
+// New builds a Reporter from cfg and the supplied data sources. It never
+// returns an error; when cfg.URL is empty the returned reporter is disabled and
+// Start becomes a no-op.
+func New(cfg Config, m MetricsSource, e EngineStatusSource, bl BlocklistSource) *Reporter {
+	interval := DefaultInterval
+	if cfg.Interval != "" {
+		if d, err := time.ParseDuration(cfg.Interval); err == nil && d > 0 {
+			interval = d
+		} else {
+			logger.Log.Warnf("heartbeat: invalid interval %q, using %s", cfg.Interval, DefaultInterval)
+		}
+	}
+
+	version := cfg.Version
+	if version == "" {
+		version = buildVersion()
+	}
+
+	return &Reporter{
+		url:       cfg.URL,
+		interval:  interval,
+		version:   version,
+		dbPath:    cfg.DBPath,
+		startedAt: time.Now(),
+		metrics:   m,
+		engine:    e,
+		blocklist: bl,
+		client:    &http.Client{Timeout: defaultHTTPTimeout},
+		now:       time.Now,
+		diskUsage: diskUsage,
+	}
+}
+
+// Enabled reports whether a heartbeat URL is configured.
+func (r *Reporter) Enabled() bool {
+	return r.url != ""
+}
+
+// Start launches the background reporter when enabled. It is a no-op (returning
+// immediately, spawning nothing) when heartbeat is disabled. The loop runs
+// until ctx is cancelled; reporting failures are logged, never fatal.
+func (r *Reporter) Start(ctx context.Context) {
+	if !r.Enabled() {
+		logger.Log.Info("heartbeat: disabled (HEARTBEAT_URL not set)")
+		return
+	}
+
+	logger.Log.Infof("heartbeat: enabled, reporting to %s every %s", r.url, r.interval)
+	ticker := time.NewTicker(r.interval)
+	go func() {
+		defer ticker.Stop()
+		r.loop(ctx, ticker.C)
+	}()
+}
+
+// loop sends an initial snapshot, then one per tick, until ctx is cancelled.
+// The tick channel is injectable so the cadence can be driven deterministically
+// in tests.
+func (r *Reporter) loop(ctx context.Context, tick <-chan time.Time) {
+	// Send an initial snapshot immediately so fleet views populate on boot.
+	if err := r.reportOnce(ctx); err != nil {
+		logger.Log.Warnf("heartbeat: report failed: %v", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick:
+			if err := r.reportOnce(ctx); err != nil {
+				logger.Log.Warnf("heartbeat: report failed: %v", err)
+			}
+		}
+	}
+}
+
+// reportOnce assembles the current Status and POSTs it as JSON.
+func (r *Reporter) reportOnce(ctx context.Context) error {
+	status := r.Collect()
+
+	body, err := json.Marshal(status)
+	if err != nil {
+		return fmt.Errorf("marshal status: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post heartbeat: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("heartbeat collector returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// Collect assembles the current metadata-only Status from the wired sources.
+func (r *Reporter) Collect() Status {
+	agg := r.metrics.Aggregate()
+	window := r.metrics.Window()
+	accepting := r.engine.Status().AcceptingQueries
+
+	free, total, err := r.diskUsage(dbDir(r.dbPath))
+	if err != nil {
+		logger.Log.Warnf("heartbeat: disk usage for %q failed: %v", r.dbPath, err)
+		free, total = 0, 0
+	}
+
+	return buildStatus(inputs{
+		now:              r.now(),
+		startedAt:        r.startedAt,
+		version:          r.version,
+		agg:              agg,
+		window:           window,
+		acceptingQueries: accepting,
+		diskFree:         free,
+		diskTotal:        total,
+		blocklistUpdated: r.blocklistLastUpdate(),
+	})
+}
+
+// blocklistLastUpdate returns the most recent blocklist source update time, or
+// the zero time when unavailable. Only source metadata is read.
+func (r *Reporter) blocklistLastUpdate() time.Time {
+	if r.blocklist == nil {
+		return time.Time{}
+	}
+	sources, err := r.blocklist.ListSources()
+	if err != nil {
+		logger.Log.Warnf("heartbeat: list blocklist sources failed: %v", err)
+		return time.Time{}
+	}
+	var latest time.Time
+	for _, s := range sources {
+		if s.UpdatedAt.After(latest) {
+			latest = s.UpdatedAt
+		}
+	}
+	return latest
+}
+
+// inputs bundles the raw values buildStatus turns into a Status. Keeping this
+// pure makes field mapping deterministic and unit-testable.
+type inputs struct {
+	now              time.Time
+	startedAt        time.Time
+	version          string
+	agg              metrics.AggregatedMetrics
+	window           time.Duration
+	acceptingQueries bool
+	diskFree         uint64
+	diskTotal        uint64
+	blocklistUpdated time.Time // zero => unknown
+}
+
+func buildStatus(in inputs) Status {
+	windowSecs := in.window.Seconds()
+
+	var qps float64
+	if windowSecs > 0 {
+		qps = float64(in.agg.Total) / windowSecs
+	}
+
+	var blockedPct float64
+	if in.agg.Total > 0 {
+		blockedPct = float64(in.agg.Blocked) / float64(in.agg.Total) * 100
+	}
+
+	statusStr := "healthy"
+	if !in.acceptingQueries {
+		statusStr = "degraded"
+	}
+
+	s := Status{
+		Status:           statusStr,
+		Healthy:          in.acceptingQueries,
+		Version:          in.version,
+		UptimeSeconds:    int64(in.now.Sub(in.startedAt).Seconds()),
+		AcceptingQueries: in.acceptingQueries,
+		QPS:              round2(qps),
+		BlockedPercent:   round2(blockedPct),
+		WindowQueries:    in.agg.Total,
+		WindowSeconds:    int64(windowSecs),
+		DiskFreeBytes:    in.diskFree,
+		DiskTotalBytes:   in.diskTotal,
+		ReportedAt:       in.now,
+	}
+
+	if !in.blocklistUpdated.IsZero() {
+		updated := in.blocklistUpdated
+		age := int64(in.now.Sub(updated).Seconds())
+		s.BlocklistUpdated = &updated
+		s.BlocklistAgeSec = &age
+	}
+
+	return s
+}
+
+// diskUsage returns free (available to unprivileged users) and total bytes for
+// the filesystem backing path.
+func diskUsage(path string) (free, total uint64, err error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return 0, 0, err
+	}
+	bsize := uint64(st.Bsize)
+	return st.Bavail * bsize, st.Blocks * bsize, nil
+}
+
+// dbDir returns the directory holding the DB file so Statfs targets an existing
+// path even before the DB file itself is created.
+func dbDir(dbPath string) string {
+	if dbPath == "" {
+		return "."
+	}
+	dir := filepath.Dir(dbPath)
+	if dir == "" {
+		return "."
+	}
+	return dir
+}
+
+// buildVersion resolves a best-effort build version, falling back to "dev".
+func buildVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return "dev"
+}
+
+// round2 rounds to two decimal places to keep the JSON payload tidy.
+func round2(f float64) float64 {
+	return math.Round(f*100) / 100
+}

--- a/internal/heartbeat/heartbeat_test.go
+++ b/internal/heartbeat/heartbeat_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/dnsengine"
+	"github.com/lopster568/phantomDNS/internal/metrics"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+// --- Fakes ---
+
+type fakeMetrics struct {
+	agg    metrics.AggregatedMetrics
+	window time.Duration
+	calls  int32
+}
+
+func (f *fakeMetrics) Aggregate() metrics.AggregatedMetrics {
+	atomic.AddInt32(&f.calls, 1)
+	return f.agg
+}
+func (f *fakeMetrics) Window() time.Duration { return f.window }
+
+type fakeEngine struct{ status dnsengine.Status }
+
+func (f fakeEngine) Status() dnsengine.Status { return f.status }
+
+type fakeBlocklist struct {
+	sources []models.BlocklistSource
+	err     error
+}
+
+func (f fakeBlocklist) ListSources() ([]models.BlocklistSource, error) {
+	return f.sources, f.err
+}
+
+func fixedDisk(free, total uint64) func(string) (uint64, uint64, error) {
+	return func(string) (uint64, uint64, error) { return free, total, nil }
+}
+
+// --- buildStatus ---
+
+func TestBuildStatus_Fields(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	in := inputs{
+		now:              now,
+		startedAt:        now.Add(-time.Hour),
+		version:          "v1.2.3",
+		agg:              metrics.AggregatedMetrics{Total: 600, Blocked: 150, Errors: 6},
+		window:           5 * time.Minute,
+		acceptingQueries: true,
+		diskFree:         1000,
+		diskTotal:        4000,
+		blocklistUpdated: now.Add(-10 * time.Minute),
+	}
+
+	s := buildStatus(in)
+
+	if s.Status != "healthy" || !s.Healthy {
+		t.Errorf("status=%q healthy=%v, want healthy/true", s.Status, s.Healthy)
+	}
+	if s.Version != "v1.2.3" {
+		t.Errorf("version=%q, want v1.2.3", s.Version)
+	}
+	if s.UptimeSeconds != 3600 {
+		t.Errorf("uptime=%d, want 3600", s.UptimeSeconds)
+	}
+	if s.QPS != 2.0 { // 600 queries / 300s
+		t.Errorf("qps=%v, want 2.0", s.QPS)
+	}
+	if s.BlockedPercent != 25.0 { // 150 / 600
+		t.Errorf("blocked%%=%v, want 25.0", s.BlockedPercent)
+	}
+	if s.WindowQueries != 600 || s.WindowSeconds != 300 {
+		t.Errorf("window queries=%d seconds=%d, want 600/300", s.WindowQueries, s.WindowSeconds)
+	}
+	if !s.AcceptingQueries {
+		t.Error("expected AcceptingQueries true")
+	}
+	if s.DiskFreeBytes != 1000 || s.DiskTotalBytes != 4000 {
+		t.Errorf("disk free=%d total=%d, want 1000/4000", s.DiskFreeBytes, s.DiskTotalBytes)
+	}
+	if s.BlocklistAgeSec == nil || *s.BlocklistAgeSec != 600 {
+		t.Errorf("blocklist age=%v, want 600", s.BlocklistAgeSec)
+	}
+	if s.BlocklistUpdated == nil || !s.BlocklistUpdated.Equal(now.Add(-10*time.Minute)) {
+		t.Errorf("blocklist updated=%v, want %v", s.BlocklistUpdated, now.Add(-10*time.Minute))
+	}
+	if !s.ReportedAt.Equal(now) {
+		t.Errorf("reportedAt=%v, want %v", s.ReportedAt, now)
+	}
+}
+
+func TestBuildStatus_DegradedAndZeroQueries(t *testing.T) {
+	now := time.Now()
+	s := buildStatus(inputs{
+		now:              now,
+		startedAt:        now,
+		agg:              metrics.AggregatedMetrics{}, // no queries
+		window:           5 * time.Minute,
+		acceptingQueries: false, // not accepting -> degraded
+	})
+
+	if s.Status != "degraded" || s.Healthy {
+		t.Errorf("status=%q healthy=%v, want degraded/false", s.Status, s.Healthy)
+	}
+	if s.QPS != 0 || s.BlockedPercent != 0 {
+		t.Errorf("qps=%v blocked%%=%v, want 0/0 for empty window", s.QPS, s.BlockedPercent)
+	}
+	if s.BlocklistUpdated != nil || s.BlocklistAgeSec != nil {
+		t.Error("expected nil blocklist fields when no update time is known")
+	}
+}
+
+// --- Disabled reporter is a no-op ---
+
+func TestReporter_DisabledIsNoop(t *testing.T) {
+	fm := &fakeMetrics{window: 5 * time.Minute}
+	r := New(Config{URL: ""}, fm, fakeEngine{}, fakeBlocklist{})
+
+	if r.Enabled() {
+		t.Fatal("reporter with empty URL should be disabled")
+	}
+
+	// Start must return immediately and spawn nothing, so the metrics source is
+	// never queried.
+	r.Start(context.Background())
+	if got := atomic.LoadInt32(&fm.calls); got != 0 {
+		t.Errorf("disabled reporter queried metrics %d times, want 0", got)
+	}
+}
+
+// --- reportOnce POSTs valid, metadata-only JSON ---
+
+func TestReporter_ReportOnce_PostsValidJSON(t *testing.T) {
+	var (
+		gotMethod      string
+		gotContentType string
+		gotBody        []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotMethod = req.Method
+		gotContentType = req.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(req.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	blUpdated := time.Now().Add(-5 * time.Minute)
+	r := newTestReporter(srv.URL, &fakeMetrics{
+		window: 5 * time.Minute,
+		agg:    metrics.AggregatedMetrics{Total: 300, Blocked: 30},
+	}, fakeEngine{status: dnsengine.Status{AcceptingQueries: true}},
+		fakeBlocklist{sources: []models.BlocklistSource{{UpdatedAt: blUpdated}}})
+
+	if err := r.reportOnce(context.Background()); err != nil {
+		t.Fatalf("reportOnce: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method=%q, want POST", gotMethod)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("content-type=%q, want application/json", gotContentType)
+	}
+
+	var got Status
+	if err := json.Unmarshal(gotBody, &got); err != nil {
+		t.Fatalf("body is not valid JSON: %v (%s)", err, gotBody)
+	}
+	if got.Status != "healthy" || !got.AcceptingQueries {
+		t.Errorf("payload status=%q accepting=%v, want healthy/true", got.Status, got.AcceptingQueries)
+	}
+	if got.QPS != 1.0 { // 300 / 300s
+		t.Errorf("payload qps=%v, want 1.0", got.QPS)
+	}
+	if got.BlockedPercent != 10.0 { // 30 / 300
+		t.Errorf("payload blocked%%=%v, want 10.0", got.BlockedPercent)
+	}
+	if got.DiskFreeBytes != 2048 {
+		t.Errorf("payload disk free=%d, want 2048", got.DiskFreeBytes)
+	}
+
+	// Data-custody guard: the payload must carry no domain-level data.
+	var generic map[string]any
+	if err := json.Unmarshal(gotBody, &generic); err != nil {
+		t.Fatalf("generic unmarshal: %v", err)
+	}
+	for k := range generic {
+		if strings.Contains(strings.ToLower(k), "domain") || strings.Contains(strings.ToLower(k), "client") {
+			t.Errorf("payload leaks per-record field %q; must be metadata-only", k)
+		}
+	}
+}
+
+// --- loop cadence is driven by the injected ticker ---
+
+func TestReporter_Loop_ReportsPerTick(t *testing.T) {
+	var count int32
+	done := make(chan struct{}, 16)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&count, 1)
+		w.WriteHeader(http.StatusOK)
+		done <- struct{}{}
+	}))
+	defer srv.Close()
+
+	r := newTestReporter(srv.URL, &fakeMetrics{window: 5 * time.Minute},
+		fakeEngine{status: dnsengine.Status{AcceptingQueries: true}}, fakeBlocklist{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tick := make(chan time.Time)
+	go r.loop(ctx, tick)
+
+	// Initial snapshot on start.
+	<-done
+	// Two ticks -> two more reports. Synchronising on `done` keeps the test
+	// deterministic without sleeps.
+	tick <- time.Now()
+	<-done
+	tick <- time.Now()
+	<-done
+
+	cancel()
+
+	if got := atomic.LoadInt32(&count); got != 3 {
+		t.Errorf("reports=%d, want 3 (initial + 2 ticks)", got)
+	}
+}
+
+func TestBuildVersion_NonEmpty(t *testing.T) {
+	if v := buildVersion(); v == "" {
+		t.Error("buildVersion returned empty string")
+	}
+}
+
+// newTestReporter builds a Reporter with injected clock and disk stat so tests
+// stay deterministic and independent of the host filesystem.
+func newTestReporter(url string, m MetricsSource, e EngineStatusSource, bl BlocklistSource) *Reporter {
+	return &Reporter{
+		url:       url,
+		interval:  time.Hour,
+		version:   "test",
+		dbPath:    "/tmp/does-not-matter.db",
+		startedAt: time.Now().Add(-time.Minute),
+		metrics:   m,
+		engine:    e,
+		blocklist: bl,
+		client:    &http.Client{Timeout: defaultHTTPTimeout},
+		now:       time.Now,
+		diskUsage: fixedDisk(2048, 8192),
+	}
+}

--- a/internal/metrics/query_metrics.go
+++ b/internal/metrics/query_metrics.go
@@ -10,8 +10,9 @@ import (
 type metricsSlice struct {
 	startUnix int64 // unix timestamp (seconds) for slice start
 
-	total  atomic.Uint64
-	errors atomic.Uint64
+	total   atomic.Uint64
+	errors  atomic.Uint64
+	blocked atomic.Uint64
 
 	latency [BucketCount]atomic.Uint64
 }
@@ -30,8 +31,9 @@ const (
 )
 
 type AggregatedMetrics struct {
-	Total  uint64
-	Errors uint64
+	Total   uint64
+	Errors  uint64
+	Blocked uint64
 
 	Buckets [BucketCount]uint64
 }
@@ -88,6 +90,19 @@ func (m *QueryMetrics) Record(elapsed time.Duration, success bool) {
 	s.latency[b].Add(1)
 }
 
+// RecordBlocked increments the blocked-query counter for the current window
+// slice. It tracks queries denied by the blocklist or a deny policy so that a
+// rolling blocked percentage can be derived alongside total/error counts.
+func (m *QueryMetrics) RecordBlocked() {
+	s := m.currentSlice()
+	s.blocked.Add(1)
+}
+
+// Window returns the rolling window duration the metrics are aggregated over.
+func (m *QueryMetrics) Window() time.Duration {
+	return m.windowSize
+}
+
 func (m *QueryMetrics) Aggregate() AggregatedMetrics {
 	var out AggregatedMetrics
 
@@ -103,6 +118,7 @@ func (m *QueryMetrics) Aggregate() AggregatedMetrics {
 
 		out.Total += s.total.Load()
 		out.Errors += s.errors.Load()
+		out.Blocked += s.blocked.Load()
 
 		for b := 0; b < int(BucketCount); b++ {
 			out.Buckets[b] += s.latency[b].Load()


### PR DESCRIPTION
## What
Adds an **opt-in, metadata-only heartbeat reporter** (`internal/heartbeat`) for managed/fleet monitoring. When configured, a background goroutine on the data plane periodically POSTs an aggregate status snapshot to a remote URL.

## Why
Fleet operators need to know an appliance is alive and healthy without ever seeing what it resolves. The payload carries **only operational metadata** — no domain names, no client IPs, no query contents — preserving the data-custody promise. Disabled by default; it does nothing unless a URL is set.

## How
- **New component** `internal/heartbeat`: a `Reporter` that assembles a `Status` from existing sources and POSTs it as JSON.
  - Status fields: `status` (healthy/degraded), `healthy`, `uptime_seconds`, `version` (best-effort from build info, else `dev`), `qps` + `blocked_percent` (from `internal/metrics`), `disk_free_bytes`/`disk_total_bytes` (`syscall.Statfs` on the DB dir), `blocklist_last_update`/`blocklist_age_seconds` (latest blocklist source `UpdatedAt`), `accepting_queries` (engine status).
  - Config via env: `HEARTBEAT_URL` (disabled when empty) and `HEARTBEAT_INTERVAL` (default `60s`), surfaced through `config.DataPlaneConfig`.
  - Started at boot **only when configured**; non-blocking; each POST is bounded by a 10s HTTP timeout; failures are logged, never fatal.
- **Metrics**: added a rolling `blocked` counter to `internal/metrics` (`RecordBlocked`, `AggregatedMetrics.Blocked`, `Window()` accessor) so blocked% is derived from the same window as QPS. The DNS engine now records a blocked query on blocklist hits and deny-policy decisions.
- **Wiring**: the reporter is constructed and started in `cmd/dataplane/main.go` after the engine is up.

## Tests
`internal/heartbeat/heartbeat_test.go` (deterministic, no long sleeps):
- `buildStatus` returns the expected fields (QPS, blocked%, uptime, disk, blocklist age, healthy/degraded, zero-query case).
- Reporter is a **no-op when the URL is empty** (never queries its sources).
- When set, it **POSTs valid JSON** to an `httptest` server with `Content-Type: application/json`, and a data-custody guard asserts no `domain`/`client` keys leak.
- Loop **cadence is driven by an injected ticker** (initial snapshot + one report per tick), synchronised via a channel.

All green: `gofmt`, `go build ./...`, `go vet ./...`, `go test -race ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)