### PR TITLE
feat(controlplane): optional HTTPS via provided or self-signed cert (I-007)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/inventory"
 	"github.com/lopster568/phantomDNS/internal/storage/db"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"github.com/lopster568/phantomDNS/internal/tlsutil"
 
 	"github.com/gin-gonic/gin"
 )
@@ -58,5 +59,40 @@ func main() {
 	r.Use(middlewares.Auth(repos.Auth))
 
 	routes.RegisterRoutes(r, apiHandler)
-	r.Run(config.DefaultConfig.ControlPlane.ListenAddr)
+
+	serve(r, config.DefaultConfig.ControlPlane)
+}
+
+// serve starts the control-plane HTTP API, using TLS when configured. HTTP is
+// the default so existing deployments are unaffected. Public ACME cannot issue
+// certificates for private-LAN names, so TLS is served either from an
+// operator-provided cert/key pair or from a self-signed cert generated and
+// persisted on first boot.
+func serve(r *gin.Engine, cfg config.ControlPlaneConfig) {
+	addr := cfg.ListenAddr
+
+	switch cfg.TLS.Mode() {
+	case config.TLSModeProvided:
+		log.Printf("control-plane serving HTTPS on %s (operator-provided certificate)", addr)
+		if err := r.RunTLS(addr, cfg.TLS.CertFile, cfg.TLS.KeyFile); err != nil {
+			log.Fatalf("control-plane TLS server failed: %v", err)
+		}
+
+	case config.TLSModeSelfSigned:
+		hosts := tlsutil.HostsForListenAddr(addr)
+		certFile, keyFile, err := tlsutil.EnsureSelfSigned(cfg.TLS.SelfSignedDir, hosts)
+		if err != nil {
+			log.Fatalf("failed to prepare self-signed certificate: %v", err)
+		}
+		log.Printf("control-plane serving HTTPS on %s (self-signed certificate at %s)", addr, certFile)
+		if err := r.RunTLS(addr, certFile, keyFile); err != nil {
+			log.Fatalf("control-plane TLS server failed: %v", err)
+		}
+
+	default:
+		log.Printf("control-plane serving HTTP on %s (TLS disabled)", addr)
+		if err := r.Run(addr); err != nil {
+			log.Fatalf("control-plane server failed: %v", err)
+		}
+	}
 }

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -33,3 +33,13 @@ dataplane:
 
 controlplane:
   listen_addr: "0.0.0.0:8080"
+  # Optional HTTPS for the control-plane API. HTTP is the default (TLS off).
+  # Public ACME cannot issue for private-LAN names, so use either an
+  # operator-provided cert/key pair, or an auto-generated self-signed cert.
+  # tls:
+  #   # Provided cert/key (both must be set to serve HTTPS):
+  #   cert_file: "/etc/hydra/tls/server.crt"  # env: TLS_CERT_FILE
+  #   key_file: "/etc/hydra/tls/server.key"   # env: TLS_KEY_FILE
+  #   # Or auto-generate a self-signed cert on first boot:
+  #   auto_self_signed: false                 # env: TLS_AUTO_SELF_SIGNED
+  #   self_signed_dir: "/app/data/tls"        # env: TLS_SELF_SIGNED_DIR

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,8 +58,76 @@ type DataPlaneConfig struct {
 }
 
 type ControlPlaneConfig struct {
-	ListenAddr string `yaml:"listen_addr"`
+	ListenAddr string    `yaml:"listen_addr"`
+	TLS        TLSConfig `yaml:"tls"`
 }
+
+// TLSConfig controls how the control-plane HTTP API is served.
+//
+// Selection precedence (see Mode):
+//  1. CertFile+KeyFile both set  -> serve HTTPS with the operator-provided cert.
+//  2. AutoSelfSigned true        -> generate/persist a self-signed cert, serve HTTPS.
+//  3. otherwise                  -> plain HTTP (the default, no regression).
+//
+// Public ACME cannot issue certificates for private-LAN names, hence the
+// operator-provided and self-signed options instead of automatic ACME.
+type TLSConfig struct {
+	// CertFile / KeyFile point to an operator-provided certificate and private
+	// key (PEM). When both are set, TLS is served using them.
+	CertFile string `yaml:"cert_file"`
+	KeyFile  string `yaml:"key_file"`
+	// AutoSelfSigned generates a self-signed certificate on first boot when no
+	// cert/key pair is provided.
+	AutoSelfSigned bool `yaml:"auto_self_signed"`
+	// SelfSignedDir is where the generated self-signed cert/key are persisted so
+	// they survive restarts.
+	SelfSignedDir string `yaml:"self_signed_dir"`
+}
+
+// TLSMode is the resolved serving mode for the control-plane HTTP API.
+type TLSMode int
+
+const (
+	// TLSModeDisabled serves plain HTTP (the default).
+	TLSModeDisabled TLSMode = iota
+	// TLSModeProvided serves HTTPS using an operator-provided cert/key.
+	TLSModeProvided
+	// TLSModeSelfSigned serves HTTPS using a generated, persisted self-signed cert.
+	TLSModeSelfSigned
+)
+
+func (m TLSMode) String() string {
+	switch m {
+	case TLSModeProvided:
+		return "provided"
+	case TLSModeSelfSigned:
+		return "self-signed"
+	default:
+		return "disabled"
+	}
+}
+
+// Mode resolves how TLS should be served. A fully provided cert/key pair always
+// wins; a partial pair (only one of the two) is ignored and falls through to the
+// self-signed or disabled path so a misconfiguration never silently breaks boot.
+func (t TLSConfig) Mode() TLSMode {
+	if t.CertFile != "" && t.KeyFile != "" {
+		return TLSModeProvided
+	}
+	if t.AutoSelfSigned {
+		return TLSModeSelfSigned
+	}
+	return TLSModeDisabled
+}
+
+// Enabled reports whether the control-plane API should be served over TLS.
+func (t TLSConfig) Enabled() bool {
+	return t.Mode() != TLSModeDisabled
+}
+
+// DefaultSelfSignedDir is used when AutoSelfSigned is enabled but no directory
+// was configured.
+const DefaultSelfSignedDir = "/app/data/tls"
 
 func defaultConfig() *Config {
 	return &Config{
@@ -75,6 +143,9 @@ func defaultConfig() *Config {
 		},
 		ControlPlane: ControlPlaneConfig{
 			ListenAddr: "0.0.0.0:8080",
+			TLS: TLSConfig{
+				SelfSignedDir: DefaultSelfSignedDir,
+			},
 		},
 	}
 }
@@ -153,6 +224,7 @@ var DefaultConfig = func() *Config {
 	if cfg.DataPlane.MetricsAddr == "" {
 		cfg.DataPlane.MetricsAddr = "0.0.0.0:9153"
 	}
+	applyTLSEnv(&cfg.ControlPlane.TLS)
 	return cfg
 }()
 
@@ -168,6 +240,30 @@ func parseAbusedTLDs(v string) []string {
 		}
 	}
 	return tlds
+}
+
+// applyTLSEnv overlays TLS_* environment variables onto the control-plane TLS
+// config and fills in the self-signed directory default when unset.
+func applyTLSEnv(t *TLSConfig) {
+	if v := os.Getenv("TLS_CERT_FILE"); v != "" {
+		t.CertFile = v
+	}
+	if v := os.Getenv("TLS_KEY_FILE"); v != "" {
+		t.KeyFile = v
+	}
+	if v := os.Getenv("TLS_AUTO_SELF_SIGNED"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			t.AutoSelfSigned = b
+		} else {
+			logger.Log.Warnf("invalid TLS_AUTO_SELF_SIGNED value %q, ignoring", v)
+		}
+	}
+	if v := os.Getenv("TLS_SELF_SIGNED_DIR"); v != "" {
+		t.SelfSignedDir = v
+	}
+	if t.SelfSignedDir == "" {
+		t.SelfSignedDir = DefaultSelfSignedDir
+	}
 }
 
 func configPath() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,3 +27,129 @@ func TestParseAbusedTLDs(t *testing.T) {
 		})
 	}
 }
+
+func TestTLSConfigMode(t *testing.T) {
+	tests := []struct {
+		name string
+		tls  TLSConfig
+		want TLSMode
+	}{
+		{
+			name: "default is http",
+			tls:  TLSConfig{},
+			want: TLSModeDisabled,
+		},
+		{
+			name: "cert and key provided serves tls",
+			tls:  TLSConfig{CertFile: "server.crt", KeyFile: "server.key"},
+			want: TLSModeProvided,
+		},
+		{
+			name: "cert only is ignored, falls through to disabled",
+			tls:  TLSConfig{CertFile: "server.crt"},
+			want: TLSModeDisabled,
+		},
+		{
+			name: "key only is ignored, falls through to disabled",
+			tls:  TLSConfig{KeyFile: "server.key"},
+			want: TLSModeDisabled,
+		},
+		{
+			name: "auto self-signed when no pair provided",
+			tls:  TLSConfig{AutoSelfSigned: true},
+			want: TLSModeSelfSigned,
+		},
+		{
+			name: "partial pair falls back to self-signed when enabled",
+			tls:  TLSConfig{CertFile: "server.crt", AutoSelfSigned: true},
+			want: TLSModeSelfSigned,
+		},
+		{
+			name: "provided pair wins over auto self-signed",
+			tls:  TLSConfig{CertFile: "server.crt", KeyFile: "server.key", AutoSelfSigned: true},
+			want: TLSModeProvided,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.tls.Mode(); got != tc.want {
+				t.Fatalf("Mode() = %v, want %v", got, tc.want)
+			}
+			wantEnabled := tc.want != TLSModeDisabled
+			if got := tc.tls.Enabled(); got != wantEnabled {
+				t.Fatalf("Enabled() = %v, want %v", got, wantEnabled)
+			}
+		})
+	}
+}
+
+func TestApplyTLSEnv(t *testing.T) {
+	t.Run("empty env fills default self-signed dir", func(t *testing.T) {
+		t.Setenv("TLS_CERT_FILE", "")
+		t.Setenv("TLS_KEY_FILE", "")
+		t.Setenv("TLS_AUTO_SELF_SIGNED", "")
+		t.Setenv("TLS_SELF_SIGNED_DIR", "")
+
+		var tls TLSConfig
+		applyTLSEnv(&tls)
+
+		if tls.SelfSignedDir != DefaultSelfSignedDir {
+			t.Fatalf("SelfSignedDir = %q, want default %q", tls.SelfSignedDir, DefaultSelfSignedDir)
+		}
+		if tls.Mode() != TLSModeDisabled {
+			t.Fatalf("Mode() = %v, want disabled", tls.Mode())
+		}
+	})
+
+	t.Run("provided cert and key via env", func(t *testing.T) {
+		t.Setenv("TLS_CERT_FILE", "/etc/hydra/tls.crt")
+		t.Setenv("TLS_KEY_FILE", "/etc/hydra/tls.key")
+		t.Setenv("TLS_AUTO_SELF_SIGNED", "")
+		t.Setenv("TLS_SELF_SIGNED_DIR", "")
+
+		var tls TLSConfig
+		applyTLSEnv(&tls)
+
+		if tls.CertFile != "/etc/hydra/tls.crt" || tls.KeyFile != "/etc/hydra/tls.key" {
+			t.Fatalf("cert/key not applied from env: %+v", tls)
+		}
+		if tls.Mode() != TLSModeProvided {
+			t.Fatalf("Mode() = %v, want provided", tls.Mode())
+		}
+	})
+
+	t.Run("auto self-signed with custom dir via env", func(t *testing.T) {
+		t.Setenv("TLS_CERT_FILE", "")
+		t.Setenv("TLS_KEY_FILE", "")
+		t.Setenv("TLS_AUTO_SELF_SIGNED", "true")
+		t.Setenv("TLS_SELF_SIGNED_DIR", "/var/lib/hydra/tls")
+
+		var tls TLSConfig
+		applyTLSEnv(&tls)
+
+		if !tls.AutoSelfSigned {
+			t.Fatal("AutoSelfSigned should be true")
+		}
+		if tls.SelfSignedDir != "/var/lib/hydra/tls" {
+			t.Fatalf("SelfSignedDir = %q, want /var/lib/hydra/tls", tls.SelfSignedDir)
+		}
+		if tls.Mode() != TLSModeSelfSigned {
+			t.Fatalf("Mode() = %v, want self-signed", tls.Mode())
+		}
+	})
+
+	t.Run("invalid bool is ignored", func(t *testing.T) {
+		t.Setenv("TLS_CERT_FILE", "")
+		t.Setenv("TLS_KEY_FILE", "")
+		t.Setenv("TLS_AUTO_SELF_SIGNED", "not-a-bool")
+		t.Setenv("TLS_SELF_SIGNED_DIR", "")
+
+		tls := TLSConfig{AutoSelfSigned: false}
+		applyTLSEnv(&tls)
+
+		if tls.AutoSelfSigned {
+			t.Fatal("invalid TLS_AUTO_SELF_SIGNED should leave value unchanged")
+		}
+	})
+}

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package tlsutil provides helpers for serving the control-plane API over TLS.
+//
+// Public ACME certificate authorities cannot issue certificates for private-LAN
+// names (the appliance's typical deployment), so this package supports serving
+// TLS from an operator-provided cert/key pair or from a self-signed certificate
+// that is generated once and persisted on first boot.
+package tlsutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// DefaultValidity is how long a generated self-signed certificate is valid.
+	// Appliances are long-lived and self-managed, so a long window avoids forcing
+	// re-provisioning of trust on the LAN.
+	DefaultValidity = 10 * 365 * 24 * time.Hour
+
+	certFileName = "self-signed.crt"
+	keyFileName  = "self-signed.key"
+)
+
+// GenerateSelfSigned creates a self-signed certificate and private key valid for
+// the supplied hosts (DNS names and/or IP addresses). It returns PEM-encoded
+// certificate and key bytes that load via tls.X509KeyPair. When hosts is empty,
+// loopback names are used. A non-positive validFor falls back to DefaultValidity.
+func GenerateSelfSigned(hosts []string, validFor time.Duration) (certPEM, keyPEM []byte, err error) {
+	if validFor <= 0 {
+		validFor = DefaultValidity
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate private key: %w", err)
+	}
+
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate serial number: %w", err)
+	}
+
+	now := time.Now()
+	tmpl := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			Organization: []string{"HydraDNS"},
+			CommonName:   "HydraDNS Control Plane",
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(validFor),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		// Self-signed leaf that operators may also import as a trust anchor.
+		IsCA: true,
+	}
+
+	if len(hosts) == 0 {
+		hosts = []string{"localhost", "127.0.0.1", "::1"}
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		} else {
+			tmpl.DNSNames = append(tmpl.DNSNames, h)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create certificate: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM, nil
+}
+
+// EnsureSelfSigned returns the certificate and key file paths within dir,
+// generating and persisting a new self-signed pair on first boot if either file
+// is missing. Subsequent calls reuse the persisted pair so the certificate is
+// stable across restarts.
+func EnsureSelfSigned(dir string, hosts []string) (certFile, keyFile string, err error) {
+	if dir == "" {
+		return "", "", fmt.Errorf("self-signed cert directory is empty")
+	}
+	certFile = filepath.Join(dir, certFileName)
+	keyFile = filepath.Join(dir, keyFileName)
+
+	if fileExists(certFile) && fileExists(keyFile) {
+		return certFile, keyFile, nil
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", "", fmt.Errorf("create cert directory: %w", err)
+	}
+
+	certPEM, keyPEM, err := GenerateSelfSigned(hosts, DefaultValidity)
+	if err != nil {
+		return "", "", err
+	}
+
+	if err := os.WriteFile(certFile, certPEM, 0o644); err != nil {
+		return "", "", fmt.Errorf("write certificate: %w", err)
+	}
+	// The private key is written with restrictive permissions.
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		return "", "", fmt.Errorf("write private key: %w", err)
+	}
+
+	return certFile, keyFile, nil
+}
+
+// HostsForListenAddr derives the SAN host list for a self-signed certificate
+// from a listen address such as "0.0.0.0:8080" or "192.168.1.10:8080". Loopback
+// names are always included; a specific bind host is appended, while bind-all
+// hosts (0.0.0.0, ::) contribute nothing beyond loopback.
+func HostsForListenAddr(listenAddr string) []string {
+	hosts := []string{"localhost", "127.0.0.1", "::1"}
+	host, _, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		host = listenAddr
+	}
+	switch host {
+	case "", "0.0.0.0", "::", "[::]":
+		// bind-all: loopback SANs are sufficient for local trust.
+	default:
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package tlsutil
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGenerateSelfSignedLoadable(t *testing.T) {
+	certPEM, keyPEM, err := GenerateSelfSigned([]string{"localhost", "127.0.0.1"}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateSelfSigned returned error: %v", err)
+	}
+
+	// The core contract: the generated pair loads via tls.X509KeyPair.
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		t.Fatalf("tls.X509KeyPair could not load generated pair: %v", err)
+	}
+}
+
+func TestGenerateSelfSignedDefaultsAndSANs(t *testing.T) {
+	// Empty hosts -> loopback SANs; non-positive validity -> DefaultValidity.
+	certPEM, keyPEM, err := GenerateSelfSigned(nil, 0)
+	if err != nil {
+		t.Fatalf("GenerateSelfSigned returned error: %v", err)
+	}
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		t.Fatalf("tls.X509KeyPair error: %v", err)
+	}
+
+	cert, err := parseLeaf(certPEM)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	if len(cert.IPAddresses) == 0 {
+		t.Fatal("expected loopback IP SANs when hosts is empty")
+	}
+	if got := cert.NotAfter.Sub(cert.NotBefore); got < DefaultValidity {
+		t.Fatalf("validity window %v shorter than DefaultValidity %v", got, DefaultValidity)
+	}
+}
+
+func TestEnsureSelfSignedPersistsAndReuses(t *testing.T) {
+	dir := t.TempDir()
+
+	certFile, keyFile, err := EnsureSelfSigned(dir, []string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("EnsureSelfSigned (first boot) error: %v", err)
+	}
+
+	// Loadable from disk.
+	if _, err := tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+		t.Fatalf("tls.LoadX509KeyPair error: %v", err)
+	}
+
+	firstCert, err := os.ReadFile(certFile)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+
+	// Second call must reuse the persisted pair, not regenerate it.
+	certFile2, keyFile2, err := EnsureSelfSigned(dir, []string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("EnsureSelfSigned (reuse) error: %v", err)
+	}
+	if certFile2 != certFile || keyFile2 != keyFile {
+		t.Fatalf("paths changed between calls: (%s,%s) vs (%s,%s)", certFile, keyFile, certFile2, keyFile2)
+	}
+	secondCert, err := os.ReadFile(certFile)
+	if err != nil {
+		t.Fatalf("read cert (second): %v", err)
+	}
+	if !bytes.Equal(firstCert, secondCert) {
+		t.Fatal("certificate was regenerated on second boot; expected reuse")
+	}
+
+	// Key file must be persisted with restrictive permissions.
+	info, err := os.Stat(keyFile)
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("key file perm = %o, want 600", perm)
+	}
+}
+
+func TestEnsureSelfSignedEmptyDir(t *testing.T) {
+	if _, _, err := EnsureSelfSigned("", nil); err == nil {
+		t.Fatal("expected error for empty dir, got nil")
+	}
+}
+
+func TestHostsForListenAddr(t *testing.T) {
+	tests := []struct {
+		name  string
+		addr  string
+		extra string // host expected in addition to loopback, "" means none
+	}{
+		{name: "bind all v4", addr: "0.0.0.0:8080", extra: ""},
+		{name: "bind all v6", addr: "[::]:8080", extra: ""},
+		{name: "specific ip", addr: "192.168.1.10:8080", extra: "192.168.1.10"},
+		{name: "hostname", addr: "hydra.local:8080", extra: "hydra.local"},
+		{name: "no port", addr: "10.0.0.5", extra: "10.0.0.5"},
+	}
+	loopback := []string{"localhost", "127.0.0.1", "::1"}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := HostsForListenAddr(tc.addr)
+			want := append([]string{}, loopback...)
+			if tc.extra != "" {
+				want = append(want, tc.extra)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("HostsForListenAddr(%q) = %v, want %v", tc.addr, got, want)
+			}
+		})
+	}
+}
+
+// parseLeaf extracts and parses the first certificate from a PEM bundle.
+func parseLeaf(certPEM []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in certificate")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}


### PR DESCRIPTION
## What

Adds optional HTTPS/TLS for the control-plane HTTP API. **HTTP stays the default** — no behavior change for existing deployments unless TLS is explicitly configured.

## Why

The appliance is typically deployed on private-LAN names/IPs, where public ACME certificate authorities cannot issue certificates. So instead of automatic ACME, TLS is served from one of:

1. **Operator-provided** cert/key pair (`TLS_CERT_FILE` + `TLS_KEY_FILE`), or
2. **Auto self-signed** cert (`TLS_AUTO_SELF_SIGNED`), generated with `crypto/x509`+`crypto/tls` and **persisted on first boot** so it is stable across restarts, or
3. Plain **HTTP** (default).

## How

- `internal/config/config.go`: new `TLSConfig` on `ControlPlaneConfig` (yaml `tls:` + `TLS_CERT_FILE`/`TLS_KEY_FILE`/`TLS_AUTO_SELF_SIGNED`/`TLS_SELF_SIGNED_DIR` env). A `TLSConfig.Mode()` resolves the serving mode with clear precedence: a full provided pair wins; a partial pair is ignored and falls through to self-signed or disabled so a misconfiguration never silently changes behavior.
- New `internal/tlsutil` package: `GenerateSelfSigned` (ECDSA P-256, SAN-aware) returns PEM cert/key loadable by `tls.X509KeyPair`; `EnsureSelfSigned` persists/reuses the pair (key written `0600`); `HostsForListenAddr` derives SANs from the listen address.
- `cmd/controlplane/main.go`: `serve()` selects `gin` `Run` vs `RunTLS` based on the resolved mode.
- `configs/config.yaml`: documented, commented-out `tls:` block (default off).
- mTLS on the loopback gRPC channel is intentionally **out of scope**.

## Tests

- `internal/tlsutil`: self-signed generator output loads via `tls.X509KeyPair` and `tls.LoadX509KeyPair`; SAN/validity defaults; persistence + reuse across "reboots" (no regeneration); key-file permission `0600`; SAN derivation from listen addr. No real port is bound.
- `internal/config`: `Mode()` selection matrix (http vs provided-tls vs self-signed, including partial-pair fallback and provided-wins-over-auto) plus `TLS_*` env overlay.
- `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)