### PR TITLE
feat(dataplane): DoT + DoH upstream resolver support (I-018)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -8,8 +8,12 @@ local_only: false
 dataplane:
   listen_addr: "0.0.0.0:1053"
   upstream_resolvers:
+    # Plain UDP/TCP (default). Optionally prefix with "udp://".
     - "8.8.8.8:53"
     - "1.1.1.1:53"
+    # Encrypted upstreams are opt-in per resolver:
+    #   - "tls://1.1.1.1:853"                     # DNS-over-TLS (DoT)
+    #   - "https://cloudflare-dns.com/dns-query"  # DNS-over-HTTPS (DoH)
   anonymization:
     secret: "${PHANTOM_ANON_SECRET:-change-me-in-production}"
   blocklist_update_interval: "6h"

--- a/internal/dnsengine/connections.go
+++ b/internal/dnsengine/connections.go
@@ -116,6 +116,10 @@ func NewUpstreamPool(upstreamAddr string, maxConns int) (*UpstreamPool, error) {
 	}, nil
 }
 
+// Addr returns the upstream address this pool serves. It satisfies the
+// Upstream interface used by UpstreamManager for logging.
+func (p *UpstreamPool) Addr() string { return p.upstreamAddr }
+
 // Close shuts down the pool and closes all sockets. It is safe to call multiple times.
 func (p *UpstreamPool) Close() error {
 	p.mu.Lock()

--- a/internal/dnsengine/encrypted_upstream.go
+++ b/internal/dnsengine/encrypted_upstream.go
@@ -1,0 +1,146 @@
+// DoT (DNS-over-TLS) and DoH (DNS-over-HTTPS) upstream transports.
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Compile-time assertions that every transport satisfies Upstream.
+var (
+	_ Upstream = (*UpstreamPool)(nil)
+	_ Upstream = (*dotClient)(nil)
+	_ Upstream = (*dohClient)(nil)
+)
+
+// dohContentType is the media type mandated by RFC 8484 for wire-format DNS.
+const dohContentType = "application/dns-message"
+
+// dotClient implements Upstream using DNS-over-TLS (RFC 7858) via the
+// miekg/dns TLS client ("tcp-tls").
+type dotClient struct {
+	addr   string
+	client *dns.Client
+}
+
+// newDoTClient builds a DoT client for a host:port address (e.g. 1.1.1.1:853).
+func newDoTClient(addr string) (*dotClient, error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid DoT address %q: %w", addr, err)
+	}
+	return &dotClient{
+		addr: addr,
+		client: &dns.Client{
+			Net:     "tcp-tls",
+			Timeout: defaultQueryTimeout,
+			TLSConfig: &tls.Config{
+				ServerName: host,
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}, nil
+}
+
+// Exchange sends q over the DoT client. The timeout argument is accepted for
+// interface parity with the plain path (which likewise applies a fixed query
+// timeout); DoT uses the client's configured timeout.
+func (d *dotClient) Exchange(q *dns.Msg, _ time.Duration) (*dns.Msg, error) {
+	resp, _, err := d.client.Exchange(q, d.addr)
+	if err != nil {
+		return nil, fmt.Errorf("dot exchange to %s: %w", d.addr, err)
+	}
+	return resp, nil
+}
+
+func (d *dotClient) Close() error { return nil }
+
+func (d *dotClient) Addr() string { return "tls://" + d.addr }
+
+// dohClient implements Upstream using DNS-over-HTTPS (RFC 8484). Queries are
+// POSTed as application/dns-message and the response body is the wire-format
+// reply.
+type dohClient struct {
+	endpoint string
+	client   *http.Client
+}
+
+// newDoHClient builds a DoH client for a full https endpoint URL
+// (e.g. https://cloudflare-dns.com/dns-query).
+func newDoHClient(endpoint string) (*dohClient, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid DoH endpoint %q: %w", endpoint, err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("DoH endpoint must use https: %q", endpoint)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("DoH endpoint missing host: %q", endpoint)
+	}
+	return &dohClient{
+		endpoint: endpoint,
+		client: &http.Client{
+			Timeout: defaultQueryTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig:   &tls.Config{MinVersion: tls.VersionTLS12},
+				ForceAttemptHTTP2: true,
+			},
+		},
+	}, nil
+}
+
+// Exchange packs q, POSTs it to the DoH endpoint per RFC 8484, and unpacks the
+// wire-format response. The timeout argument is accepted for interface parity;
+// the request is bounded by the HTTP client's configured timeout.
+func (d *dohClient) Exchange(q *dns.Msg, _ time.Duration) (*dns.Msg, error) {
+	packed, err := q.Pack()
+	if err != nil {
+		return nil, fmt.Errorf("doh pack query: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, d.endpoint, bytes.NewReader(packed))
+	if err != nil {
+		return nil, fmt.Errorf("doh build request: %w", err)
+	}
+	req.Header.Set("Content-Type", dohContentType)
+	req.Header.Set("Accept", dohContentType)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("doh exchange to %s: %w", d.endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("doh unexpected status %d from %s", resp.StatusCode, d.endpoint)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, dns.MaxMsgSize))
+	if err != nil {
+		return nil, fmt.Errorf("doh read response: %w", err)
+	}
+
+	out := new(dns.Msg)
+	if err := out.Unpack(body); err != nil {
+		return nil, fmt.Errorf("doh unpack response: %w", err)
+	}
+	return out, nil
+}
+
+func (d *dohClient) Close() error {
+	d.client.CloseIdleConnections()
+	return nil
+}
+
+func (d *dohClient) Addr() string { return d.endpoint }

--- a/internal/dnsengine/encrypted_upstream_test.go
+++ b/internal/dnsengine/encrypted_upstream_test.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func TestParseResolverScheme(t *testing.T) {
+	tests := []struct {
+		entry      string
+		wantScheme string
+		wantTarget string
+		wantErr    bool
+	}{
+		{"1.1.1.1:53", schemePlain, "1.1.1.1:53", false},
+		{"8.8.8.8:53", schemePlain, "8.8.8.8:53", false},
+		{"udp://8.8.8.8:53", schemePlain, "8.8.8.8:53", false},
+		{"tls://1.1.1.1:853", schemeDoT, "1.1.1.1:853", false},
+		{"tls://dns.google", schemeDoT, "dns.google:853", false},
+		{"TLS://1.1.1.1:853", schemeDoT, "1.1.1.1:853", false},
+		{"https://cloudflare-dns.com/dns-query", schemeDoH, "https://cloudflare-dns.com/dns-query", false},
+		{"  1.1.1.1:53  ", schemePlain, "1.1.1.1:53", false},
+		{"", "", "", true},
+		{"ftp://foo", "", "", true},
+		{"tls://", "", "", true},
+		{"udp://", "", "", true},
+	}
+	for _, tt := range tests {
+		scheme, target, err := parseResolverScheme(tt.entry)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseResolverScheme(%q): expected error, got (%q, %q)", tt.entry, scheme, target)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseResolverScheme(%q): unexpected error %v", tt.entry, err)
+			continue
+		}
+		if scheme != tt.wantScheme || target != tt.wantTarget {
+			t.Errorf("parseResolverScheme(%q) = (%q, %q), want (%q, %q)",
+				tt.entry, scheme, target, tt.wantScheme, tt.wantTarget)
+		}
+	}
+}
+
+func TestEnsurePort(t *testing.T) {
+	tests := []struct {
+		host string
+		want string
+	}{
+		{"1.1.1.1", "1.1.1.1:853"},
+		{"1.1.1.1:853", "1.1.1.1:853"},
+		{"dns.google", "dns.google:853"},
+	}
+	for _, tt := range tests {
+		if got := ensurePort(tt.host, defaultDoTPort); got != tt.want {
+			t.Errorf("ensurePort(%q) = %q, want %q", tt.host, got, tt.want)
+		}
+	}
+}
+
+func TestNewUpstream_Encrypted(t *testing.T) {
+	// DoT and DoH constructors must not touch the network, so this stays hermetic.
+	up, err := newUpstream("tls://1.1.1.1:853", 4)
+	if err != nil {
+		t.Fatalf("newUpstream(tls): %v", err)
+	}
+	if _, ok := up.(*dotClient); !ok {
+		t.Errorf("expected *dotClient, got %T", up)
+	}
+
+	up2, err := newUpstream("https://cloudflare-dns.com/dns-query", 4)
+	if err != nil {
+		t.Fatalf("newUpstream(https): %v", err)
+	}
+	if _, ok := up2.(*dohClient); !ok {
+		t.Errorf("expected *dohClient, got %T", up2)
+	}
+
+	if _, err := newUpstream("ftp://nope", 4); err == nil {
+		t.Error("expected error for unsupported scheme")
+	}
+}
+
+func TestNewDoTClient(t *testing.T) {
+	d, err := newDoTClient("1.1.1.1:853")
+	if err != nil {
+		t.Fatalf("newDoTClient: %v", err)
+	}
+	if d.client.Net != "tcp-tls" {
+		t.Errorf("expected Net tcp-tls, got %q", d.client.Net)
+	}
+	if d.addr != "1.1.1.1:853" {
+		t.Errorf("expected addr 1.1.1.1:853, got %q", d.addr)
+	}
+	if d.client.TLSConfig == nil || d.client.TLSConfig.ServerName != "1.1.1.1" {
+		t.Errorf("expected TLS ServerName 1.1.1.1, got %+v", d.client.TLSConfig)
+	}
+	if got := d.Addr(); got != "tls://1.1.1.1:853" {
+		t.Errorf("Addr() = %q, want tls://1.1.1.1:853", got)
+	}
+}
+
+func TestNewDoTClient_MissingPort(t *testing.T) {
+	if _, err := newDoTClient("1.1.1.1"); err == nil {
+		t.Error("expected error for DoT address without a port")
+	}
+}
+
+func TestNewDoHClient_Invalid(t *testing.T) {
+	if _, err := newDoHClient("http://example.com/dns-query"); err == nil {
+		t.Error("expected error for non-https DoH endpoint")
+	}
+	if _, err := newDoHClient("https://"); err == nil {
+		t.Error("expected error for DoH endpoint without a host")
+	}
+}
+
+func TestDoHExchange(t *testing.T) {
+	const answerIP = "93.184.216.34"
+
+	// A hermetic DoH server: unpack the wire-format request, verify the framing,
+	// and respond with a valid dns-message reply.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != dohContentType {
+			t.Errorf("expected Content-Type %q, got %q", dohContentType, ct)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		reqMsg := new(dns.Msg)
+		if err := reqMsg.Unpack(body); err != nil {
+			t.Fatalf("unpack request: %v", err)
+		}
+		if len(reqMsg.Question) != 1 || reqMsg.Question[0].Name != "example.com." {
+			t.Fatalf("unexpected question in request: %+v", reqMsg.Question)
+		}
+
+		reply := new(dns.Msg)
+		reply.SetReply(reqMsg)
+		rr, err := dns.NewRR("example.com. 60 IN A " + answerIP)
+		if err != nil {
+			t.Fatalf("build RR: %v", err)
+		}
+		reply.Answer = append(reply.Answer, rr)
+
+		packed, err := reply.Pack()
+		if err != nil {
+			t.Fatalf("pack reply: %v", err)
+		}
+		w.Header().Set("Content-Type", dohContentType)
+		_, _ = w.Write(packed)
+	}))
+	defer srv.Close()
+
+	d, err := newDoHClient(srv.URL)
+	if err != nil {
+		t.Fatalf("newDoHClient: %v", err)
+	}
+	// Trust the httptest server's self-signed certificate.
+	d.client = srv.Client()
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	resp, err := d.Exchange(q, time.Second)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %+v", resp)
+	}
+	a, ok := resp.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("expected A record, got %T", resp.Answer[0])
+	}
+	if a.A.String() != answerIP {
+		t.Errorf("expected %s, got %s", answerIP, a.A.String())
+	}
+	if resp.Id != q.Id {
+		t.Errorf("response id %d != query id %d", resp.Id, q.Id)
+	}
+}
+
+func TestDoHExchange_BadStatus(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d, err := newDoHClient(srv.URL)
+	if err != nil {
+		t.Fatalf("newDoHClient: %v", err)
+	}
+	d.client = srv.Client()
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+
+	if _, err := d.Exchange(q, time.Second); err == nil {
+		t.Error("expected error on non-200 status")
+	}
+}

--- a/internal/dnsengine/upstream_manager.go
+++ b/internal/dnsengine/upstream_manager.go
@@ -3,15 +3,47 @@
 package dnsengine
 
 import (
+	"errors"
+	"fmt"
 	"math/rand"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"github.com/miekg/dns"
 )
 
+// Resolver schemes supported in the upstream configuration. A resolver entry
+// may be written as:
+//
+//	1.1.1.1:53                            plain UDP/TCP (default, unchanged)
+//	udp://1.1.1.1:53                      explicit plain UDP/TCP
+//	tls://1.1.1.1:853                     DNS-over-TLS (DoT, RFC 7858)
+//	https://cloudflare-dns.com/dns-query  DNS-over-HTTPS (DoH, RFC 8484)
+const (
+	schemePlain = "plain"
+	schemeUDP   = "udp"
+	schemeDoT   = "tls"
+	schemeDoH   = "https"
+
+	defaultDoTPort = "853"
+)
+
+// Upstream is a single outbound resolver. The plain UDP/TCP pool, the DoT
+// client and the DoH client all satisfy this interface, so UpstreamManager can
+// treat them uniformly for pooling/failover.
+type Upstream interface {
+	// Exchange sends a query and returns the response.
+	Exchange(q *dns.Msg, timeout time.Duration) (*dns.Msg, error)
+	// Close releases any resources held by the upstream.
+	Close() error
+	// Addr returns a human-readable identifier used for logging.
+	Addr() string
+}
+
 type UpstreamManager struct {
-	pools []*UpstreamPool
+	upstreams []Upstream
 	// dns0x20 enables DNS 0x20 case-randomization on outbound queries.
 	// When false the send path behaves exactly as before.
 	dns0x20 bool
@@ -25,25 +57,91 @@ func WithDNS0x20(enabled bool) UpstreamOption {
 	return func(m *UpstreamManager) { m.dns0x20 = enabled }
 }
 
-// NewUpstreamManager builds a pool for each configured resolver
+// NewUpstreamManager builds an upstream for each configured resolver. The
+// resolver scheme selects the transport; entries with no scheme (or "udp://")
+// use the existing plain UDP/TCP path unchanged.
 func NewUpstreamManager(resolvers []string, poolSize int, opts ...UpstreamOption) (*UpstreamManager, error) {
 	manager := &UpstreamManager{}
 	for _, opt := range opts {
 		opt(manager)
 	}
-	for _, addr := range resolvers {
-		pool, err := NewUpstreamPool(addr, poolSize)
+	for _, entry := range resolvers {
+		up, err := newUpstream(entry, poolSize)
 		if err != nil {
 			return nil, err
 		}
-		manager.pools = append(manager.pools, pool)
+		manager.upstreams = append(manager.upstreams, up)
 	}
 	return manager, nil
 }
 
+// newUpstream parses the resolver scheme and constructs the matching transport.
+func newUpstream(entry string, poolSize int) (Upstream, error) {
+	scheme, target, err := parseResolverScheme(entry)
+	if err != nil {
+		return nil, err
+	}
+	switch scheme {
+	case schemePlain:
+		return NewUpstreamPool(target, poolSize)
+	case schemeDoT:
+		return newDoTClient(target)
+	case schemeDoH:
+		return newDoHClient(target)
+	default:
+		return nil, fmt.Errorf("unsupported resolver scheme %q in %q", scheme, entry)
+	}
+}
+
+// parseResolverScheme splits a resolver entry into a normalized scheme and the
+// transport-specific target. Entries without a "scheme://" prefix, and "udp://"
+// entries, are treated as plain UDP/TCP. For DoT the returned target is a
+// host:port (defaulting to :853); for DoH it is the full https URL.
+func parseResolverScheme(entry string) (scheme, target string, err error) {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return "", "", errors.New("empty resolver entry")
+	}
+
+	idx := strings.Index(entry, "://")
+	if idx < 0 {
+		// No scheme: plain UDP/TCP, unchanged behavior.
+		return schemePlain, entry, nil
+	}
+
+	scheme = strings.ToLower(entry[:idx])
+	rest := entry[idx+len("://"):]
+
+	switch scheme {
+	case schemeUDP, schemePlain:
+		if rest == "" {
+			return "", "", fmt.Errorf("resolver %q missing host", entry)
+		}
+		return schemePlain, rest, nil
+	case schemeDoT:
+		if rest == "" {
+			return "", "", fmt.Errorf("resolver %q missing host", entry)
+		}
+		return schemeDoT, ensurePort(rest, defaultDoTPort), nil
+	case schemeDoH:
+		// The full URL (including scheme) is needed by the HTTP client.
+		return schemeDoH, entry, nil
+	default:
+		return "", "", fmt.Errorf("unsupported resolver scheme %q in %q", scheme, entry)
+	}
+}
+
+// ensurePort appends defPort to host when host has no port component.
+func ensurePort(host, defPort string) string {
+	if _, _, err := net.SplitHostPort(host); err == nil {
+		return host
+	}
+	return net.JoinHostPort(host, defPort)
+}
+
 func (m *UpstreamManager) Close() {
-	for _, pool := range m.pools {
-		pool.Close()
+	for _, up := range m.upstreams {
+		_ = up.Close()
 	}
 }
 
@@ -67,9 +165,9 @@ func (m *UpstreamManager) Exchange(q *dns.Msg, timeout time.Duration, maxRetries
 	outbound, originals := m.prepareOutbound(q, r)
 
 	var lastErr error
-	for _, pool := range m.pools {
+	for _, up := range m.upstreams {
 		for attempt := 0; attempt < maxRetries; attempt++ {
-			resp, err := pool.Exchange(outbound, timeout)
+			resp, err := up.Exchange(outbound, timeout)
 			if err == nil {
 				if originals != nil {
 					restoreCase0x20(resp, originals)
@@ -77,7 +175,7 @@ func (m *UpstreamManager) Exchange(q *dns.Msg, timeout time.Duration, maxRetries
 				return resp, nil
 			}
 			lastErr = err
-			logger.Log.Warnf("upstream %s failed (attempt %d): %v", pool.upstreamAddr, attempt+1, err)
+			logger.Log.Warnf("upstream %s failed (attempt %d): %v", up.Addr(), attempt+1, err)
 		}
 	}
 	return nil, lastErr


### PR DESCRIPTION
## 📝 Description

Adds opt-in **encrypted upstream resolvers** — DNS-over-TLS (DoT, RFC 7858) and DNS-over-HTTPS (DoH, RFC 8484) — alongside the existing plain UDP/TCP path. Transport is chosen per resolver via a URL scheme, so plain resolvers are completely unchanged (no regression).

## 🔗 Related Issues

- Related to I-018 (encrypted upstream, outbound half)

## 🧪 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🔍 What / Why / How

**What:** Upstream resolvers can now be encrypted. Resolver entries accept a scheme:

| Entry | Transport |
| --- | --- |
| `1.1.1.1:53` / `udp://1.1.1.1:53` | plain UDP/TCP (unchanged) |
| `tls://1.1.1.1:853` | DNS-over-TLS (DoT) |
| `https://cloudflare-dns.com/dns-query` | DNS-over-HTTPS (DoH) |

**Why:** Plain DNS to the upstream leaks queries to the network path between the gateway and the resolver. DoT/DoH close that gap. Making it opt-in per resolver keeps existing deployments byte-for-byte identical.

**How:**
- Scheme parsing lives in the upstream layer (`internal/dnsengine/upstream_manager.go`). No `://` (or `udp://`) → plain path; `tls://` → DoT (default port `853`); `https://` → DoH (full URL preserved).
- A small `Upstream` interface (`Exchange` / `Close` / `Addr`) unifies the plain pool, DoT and DoH clients, so all three flow through the **existing** `UpstreamManager` pool/failover loop with no changes to failover semantics.
- **DoT** (`internal/dnsengine/encrypted_upstream.go`): `miekg/dns` client with `Net: "tcp-tls"`, TLS 1.2+ and SNI derived from the host.
- **DoH**: pack the `dns.Msg`, `POST application/dns-message` via `net/http`, unpack the wire-format reply (TLS 1.2+, size-limited read).
- Existing `*UpstreamPool` gains an `Addr()` method; the plain UDP-fastpath/TCP-fallback code path is untouched.
- Commented DoT/DoH examples added to `configs/config.yaml`.

## 🧪 Testing

### Tests Performed
- [x] Unit tests pass (`go test ./...`)
- [x] `gofmt` clean (touched files), `go build ./...`, `go vet ./...` all green

### Test Cases (hermetic — no live network)
1. **Scheme parsing** — `tls` / `https` / plain / `udp` / trimmed / invalid-scheme / missing-host cases, plus default-port (`:853`) behavior.
2. **DoH request building + response unpacking** — against an `httptest` **TLS** server that unpacks the posted wire-format query, verifies method + `Content-Type`, and returns a valid `application/dns-message` reply; asserts answer + matching message ID. Includes a non-200 error path.
3. **DoT client construction** — verifies `Net: "tcp-tls"`, SNI/TLS config, address handling, and missing-port rejection.
4. **Dispatch** — `newUpstream` returns the correct concrete transport per scheme without touching the network.

No real resolvers are contacted in any test.

## 📋 Checklist
- [x] Follows project style; self-reviewed
- [x] New warnings: none (`go vet` clean)
- [x] Added tests covering the feature
- [x] Backwards compatible — plain path unchanged, feature is opt-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)