### PR TITLE
feat(controlplane): versioned config export/import (I-062)

### DIFF
--- a/cmd/controlplane/handlers/config.go
+++ b/cmd/controlplane/handlers/config.go
@@ -1,0 +1,341 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ConfigVersion is the schema version stamped on every export and required on
+// import. Bump this only for backward-incompatible changes to the shape.
+const ConfigVersion = "1"
+
+// validPolicyActions mirrors the actions the policy engine understands.
+var validPolicyActions = map[string]bool{
+	"BLOCK":    true,
+	"ALLOW":    true,
+	"REDIRECT": true,
+}
+
+// ConfigPolicy is a policy as it appears in an exported config. It intentionally
+// omits server-managed timestamps so exports are stable and diffable.
+type ConfigPolicy struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Category    string   `json:"category"`
+	Action      string   `json:"action"`
+	RedirectIP  string   `json:"redirect_ip,omitempty"`
+	Domains     []string `json:"domains"`
+	Priority    int      `json:"priority"`
+	Enabled     bool     `json:"enabled"`
+}
+
+// ConfigBlocklist is a blocklist source as it appears in an exported config.
+// Downloaded entries and timestamps are runtime state, not config, so they are
+// excluded — only the source definition round-trips.
+type ConfigBlocklist struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	URL      string `json:"url"`
+	Format   string `json:"format"`
+	Category string `json:"category"`
+	Priority int    `json:"priority"`
+	Enabled  bool   `json:"enabled"`
+}
+
+// ConfigSettings holds the key persisted system settings.
+type ConfigSettings struct {
+	DNSEnabled    bool `json:"dns_enabled"`
+	PolicyEnabled bool `json:"policy_enabled"`
+}
+
+// Config is the full versioned, portable representation of a HydraDNS
+// configuration: policies, blocklist sources and key settings.
+type Config struct {
+	Version    string            `json:"version"`
+	Policies   []ConfigPolicy    `json:"policies"`
+	Blocklists []ConfigBlocklist `json:"blocklists"`
+	Settings   ConfigSettings    `json:"settings"`
+}
+
+// ImportSummary is returned from POST /config/import describing what an import
+// did (or, for a dry run, what it would do).
+type ImportSummary struct {
+	DryRun             bool     `json:"dry_run"`
+	PoliciesImported   int      `json:"policies_imported"`
+	BlocklistsImported int      `json:"blocklists_imported"`
+	SettingsApplied    bool     `json:"settings_applied"`
+	Warnings           []string `json:"warnings,omitempty"`
+}
+
+// ExportConfig handles GET /api/v1/config/export.
+// It dumps the current policies, blocklist sources and key settings as a single
+// versioned JSON document for backup, cloning or diffing.
+func (h *APIHandler) ExportConfig(c *gin.Context) {
+	cfg, err := h.buildExport()
+	if err != nil {
+		errMsg := "failed to export config"
+		c.JSON(http.StatusInternalServerError, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+	c.JSON(http.StatusOK, ResponseGeneric{Status: "success", Data: cfg})
+}
+
+// buildExport reads the live config out of the repositories and normalises it
+// into a deterministic (id-sorted, timestamp-free) document so that
+// export → import → export round-trips byte-for-byte.
+func (h *APIHandler) buildExport() (*Config, error) {
+	policyModels, err := h.Store.Policies.List()
+	if err != nil {
+		return nil, err
+	}
+	policies := make([]ConfigPolicy, 0, len(policyModels))
+	for _, m := range policyModels {
+		var domains []string
+		if m.Domains != "" {
+			_ = json.Unmarshal([]byte(m.Domains), &domains)
+		}
+		policies = append(policies, ConfigPolicy{
+			ID:          m.ID,
+			Name:        m.Name,
+			Description: m.Description,
+			Category:    m.Category,
+			Action:      m.Action,
+			RedirectIP:  m.RedirectIP,
+			Domains:     domains,
+			Priority:    m.Priority,
+			Enabled:     m.Enabled,
+		})
+	}
+	sort.Slice(policies, func(i, j int) bool { return policies[i].ID < policies[j].ID })
+
+	sources, err := h.Store.Blocklist.ListSources()
+	if err != nil {
+		return nil, err
+	}
+	blocklists := make([]ConfigBlocklist, 0, len(sources))
+	for _, src := range sources {
+		blocklists = append(blocklists, ConfigBlocklist{
+			ID:       src.ID,
+			Name:     src.Name,
+			URL:      src.URL,
+			Format:   src.Format,
+			Category: src.Category,
+			Priority: src.Priority,
+			Enabled:  src.Enabled,
+		})
+	}
+	sort.Slice(blocklists, func(i, j int) bool { return blocklists[i].ID < blocklists[j].ID })
+
+	state, err := h.Store.SystemState.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{
+		Version:    ConfigVersion,
+		Policies:   policies,
+		Blocklists: blocklists,
+		Settings: ConfigSettings{
+			DNSEnabled:    state.DNSEnabled,
+			PolicyEnabled: state.PolicyEnabled,
+		},
+	}, nil
+}
+
+// ImportConfig handles POST /api/v1/config/import.
+// It validates the supplied config and, unless ?dry_run=true, applies it
+// atomically (all-or-nothing) via the real repositories and reloads the engine.
+func (h *APIHandler) ImportConfig(c *gin.Context) {
+	var cfg Config
+	if err := c.ShouldBindJSON(&cfg); err != nil {
+		errMsg := "invalid config payload: " + err.Error()
+		c.JSON(http.StatusBadRequest, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+
+	if err := validateConfig(&cfg); err != nil {
+		errMsg := err.Error()
+		c.JSON(http.StatusBadRequest, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+
+	dryRun := strings.EqualFold(c.Query("dry_run"), "true")
+
+	summary := ImportSummary{
+		DryRun:             dryRun,
+		PoliciesImported:   len(cfg.Policies),
+		BlocklistsImported: len(cfg.Blocklists),
+		SettingsApplied:    true,
+	}
+
+	if dryRun {
+		// Validation succeeded; persist nothing.
+		c.JSON(http.StatusOK, ResponseGeneric{Status: "success", Data: summary})
+		return
+	}
+
+	if err := h.applyConfig(&cfg); err != nil {
+		errMsg := "failed to apply config"
+		c.JSON(http.StatusInternalServerError, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+
+	// Reload the engine so the dataplane reflects the imported settings.
+	// Best-effort: persistence is the source of truth, so a dataplane hiccup
+	// does not fail the import — it is surfaced as a warning instead.
+	if h.DataPlaneClient != nil {
+		if err := h.DataPlaneClient.SetAcceptQueries(cfg.Settings.DNSEnabled); err != nil {
+			summary.Warnings = append(summary.Warnings, "config persisted but engine reload failed: "+err.Error())
+		}
+	}
+
+	c.JSON(http.StatusOK, ResponseGeneric{Status: "success", Data: summary})
+}
+
+// validateConfig checks a config is well-formed before anything is persisted.
+func validateConfig(cfg *Config) error {
+	if cfg.Version == "" {
+		return &configError{"config version is required"}
+	}
+	if cfg.Version != ConfigVersion {
+		return &configError{"unsupported config version: " + cfg.Version}
+	}
+
+	seenPolicies := make(map[string]bool, len(cfg.Policies))
+	for _, p := range cfg.Policies {
+		if p.ID == "" {
+			return &configError{"policy id is required"}
+		}
+		if seenPolicies[p.ID] {
+			return &configError{"duplicate policy id: " + p.ID}
+		}
+		seenPolicies[p.ID] = true
+		if p.Name == "" {
+			return &configError{"policy name is required for id: " + p.ID}
+		}
+		if !validPolicyActions[p.Action] {
+			return &configError{"invalid action for policy " + p.ID + ": " + p.Action}
+		}
+	}
+
+	seenBlocklists := make(map[string]bool, len(cfg.Blocklists))
+	for _, b := range cfg.Blocklists {
+		if b.ID == "" {
+			return &configError{"blocklist id is required"}
+		}
+		if seenBlocklists[b.ID] {
+			return &configError{"duplicate blocklist id: " + b.ID}
+		}
+		seenBlocklists[b.ID] = true
+		if b.Name == "" {
+			return &configError{"blocklist name is required for id: " + b.ID}
+		}
+		if b.URL == "" {
+			return &configError{"blocklist url is required for id: " + b.ID}
+		}
+		// Guard against SSRF via non-http(s) schemes, consistent with setup.
+		if !strings.HasPrefix(b.URL, "http://") && !strings.HasPrefix(b.URL, "https://") {
+			return &configError{"blocklist url must use http:// or https:// for id: " + b.ID}
+		}
+		if b.Format == "" {
+			return &configError{"blocklist format is required for id: " + b.ID}
+		}
+	}
+
+	return nil
+}
+
+// applyConfig persists an already-validated config atomically. Policies and
+// blocklist sources are upserted by id (merge semantics: nothing is deleted),
+// and settings are updated in place. Server-managed CreatedAt timestamps of
+// existing rows are preserved so re-imports stay idempotent.
+func (h *APIHandler) applyConfig(cfg *Config) error {
+	now := time.Now()
+
+	return h.Store.DB.Transaction(func(tx *gorm.DB) error {
+		for _, p := range cfg.Policies {
+			domainsJSON, err := json.Marshal(p.Domains)
+			if err != nil {
+				return err
+			}
+			m := models.Policy{
+				ID:          p.ID,
+				Name:        p.Name,
+				Description: p.Description,
+				Category:    p.Category,
+				Action:      p.Action,
+				RedirectIP:  p.RedirectIP,
+				Domains:     string(domainsJSON),
+				Priority:    p.Priority,
+				Enabled:     p.Enabled,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}
+			if err := tx.Clauses(clause.OnConflict{
+				Columns: []clause.Column{{Name: "id"}},
+				DoUpdates: clause.AssignmentColumns([]string{
+					"name", "description", "category", "action",
+					"redirect_ip", "domains", "priority", "enabled", "updated_at",
+				}),
+			}).Create(&m).Error; err != nil {
+				return err
+			}
+		}
+
+		for _, b := range cfg.Blocklists {
+			src := models.BlocklistSource{
+				ID:        b.ID,
+				Name:      b.Name,
+				URL:       b.URL,
+				Format:    b.Format,
+				Category:  b.Category,
+				Priority:  b.Priority,
+				Enabled:   b.Enabled,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}
+			if err := tx.Clauses(clause.OnConflict{
+				Columns: []clause.Column{{Name: "id"}},
+				DoUpdates: clause.AssignmentColumns([]string{
+					"name", "url", "format", "category", "priority", "enabled", "updated_at",
+				}),
+			}).Create(&src).Error; err != nil {
+				return err
+			}
+		}
+
+		state := models.SystemState{
+			ID:            1,
+			DNSEnabled:    cfg.Settings.DNSEnabled,
+			PolicyEnabled: cfg.Settings.PolicyEnabled,
+			UpdatedAt:     now,
+		}
+		if err := tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "id"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"dns_enabled", "policy_enabled", "updated_at",
+			}),
+		}).Create(&state).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// configError is a small typed error so validation failures carry a message
+// straight into the standard error envelope.
+type configError struct {
+	msg string
+}
+
+func (e *configError) Error() string { return e.msg }

--- a/cmd/controlplane/handlers/config_test.go
+++ b/cmd/controlplane/handlers/config_test.go
@@ -1,0 +1,300 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// configEnvelope is the standard response envelope with a typed Config payload.
+type configEnvelope struct {
+	Status string  `json:"status"`
+	Data   Config  `json:"data"`
+	Error  *string `json:"error"`
+}
+
+// summaryEnvelope is the standard response envelope with an import summary.
+type summaryEnvelope struct {
+	Status string        `json:"status"`
+	Data   ImportSummary `json:"data"`
+	Error  *string       `json:"error"`
+}
+
+func newConfigTestServer(t *testing.T) (*gin.Engine, *repositories.Store) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Policy{},
+		&models.SystemState{},
+		&models.BlocklistSource{},
+		&models.BlocklistSnapshot{},
+		&models.BlocklistEntry{},
+	); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	store := repositories.NewStore(db)
+	// DataPlaneClient and Inventory are nil: import persists and skips the
+	// best-effort reload; handlers must treat a nil Inventory as empty.
+	h := NewAPIHandler(*store, nil, nil)
+
+	r := gin.New()
+	api := r.Group("/api/v1")
+	api.GET("/config/export", h.ExportConfig)
+	api.POST("/config/import", h.ImportConfig)
+	return r, store
+}
+
+// seedConfig loads a representative config directly into the repositories.
+func seedConfig(t *testing.T, store *repositories.Store) {
+	t.Helper()
+	now := time.Now()
+
+	if err := store.DB.Create(&models.SystemState{
+		ID: 1, DNSEnabled: false, PolicyEnabled: true, UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("seed system state: %v", err)
+	}
+
+	if err := store.Policies.Create(&models.Policy{
+		ID: "block-ads", Name: "Block Ads", Description: "no ads",
+		Category: "ads", Action: "BLOCK",
+		Domains: `["ads.example.com","tracker.com"]`, Priority: 100, Enabled: true,
+	}); err != nil {
+		t.Fatalf("seed policy: %v", err)
+	}
+	if err := store.Policies.Create(&models.Policy{
+		ID: "redirect-safe", Name: "Safe Search", Action: "REDIRECT",
+		RedirectIP: "10.0.0.1", Domains: `["google.com"]`, Priority: 50, Enabled: true,
+	}); err != nil {
+		t.Fatalf("seed policy 2: %v", err)
+	}
+
+	if err := store.Blocklist.CreateSource(&models.BlocklistSource{
+		ID: "steven-black", Name: "StevenBlack", URL: "https://example.com/hosts",
+		Format: "hosts", Category: "ads", Priority: 10, Enabled: true, CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed blocklist: %v", err)
+	}
+}
+
+func doExport(t *testing.T, r *gin.Engine) configEnvelope {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/export", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("export: expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var env configEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("export: failed to decode body: %v", err)
+	}
+	return env
+}
+
+func doImport(t *testing.T, r *gin.Engine, cfg Config, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal import body: %v", err)
+	}
+	url := "/api/v1/config/import"
+	if query != "" {
+		url += "?" + query
+	}
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestExportConfig_Shape(t *testing.T) {
+	r, store := newConfigTestServer(t)
+	seedConfig(t, store)
+
+	env := doExport(t, r)
+
+	if env.Status != "success" {
+		t.Fatalf("expected status success, got %q", env.Status)
+	}
+	if env.Data.Version != ConfigVersion {
+		t.Errorf("expected version %q, got %q", ConfigVersion, env.Data.Version)
+	}
+	if len(env.Data.Policies) != 2 {
+		t.Fatalf("expected 2 policies, got %d", len(env.Data.Policies))
+	}
+	// Deterministic id ordering.
+	if env.Data.Policies[0].ID != "block-ads" || env.Data.Policies[1].ID != "redirect-safe" {
+		t.Errorf("policies not id-sorted: %+v", env.Data.Policies)
+	}
+	p0 := env.Data.Policies[0]
+	if p0.Action != "BLOCK" || p0.Priority != 100 || !p0.Enabled {
+		t.Errorf("unexpected policy fields: %+v", p0)
+	}
+	if len(p0.Domains) != 2 || p0.Domains[0] != "ads.example.com" {
+		t.Errorf("unexpected domains: %+v", p0.Domains)
+	}
+	if len(env.Data.Blocklists) != 1 {
+		t.Fatalf("expected 1 blocklist, got %d", len(env.Data.Blocklists))
+	}
+	b0 := env.Data.Blocklists[0]
+	if b0.ID != "steven-black" || b0.URL != "https://example.com/hosts" || b0.Format != "hosts" {
+		t.Errorf("unexpected blocklist fields: %+v", b0)
+	}
+	if env.Data.Settings.DNSEnabled != false || env.Data.Settings.PolicyEnabled != true {
+		t.Errorf("unexpected settings: %+v", env.Data.Settings)
+	}
+}
+
+func TestImportExportRoundTrip(t *testing.T) {
+	r, store := newConfigTestServer(t)
+	seedConfig(t, store)
+
+	first := doExport(t, r)
+
+	// Re-import the exported config, then export again.
+	w := doImport(t, r, first.Data, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("import: expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var sum summaryEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &sum); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if sum.Data.DryRun {
+		t.Error("expected dry_run=false on real import")
+	}
+	if sum.Data.PoliciesImported != 2 || sum.Data.BlocklistsImported != 1 {
+		t.Errorf("unexpected summary counts: %+v", sum.Data)
+	}
+
+	second := doExport(t, r)
+
+	firstJSON, _ := json.Marshal(first.Data)
+	secondJSON, _ := json.Marshal(second.Data)
+	if !bytes.Equal(firstJSON, secondJSON) {
+		t.Errorf("round-trip not stable:\n first: %s\nsecond: %s", firstJSON, secondJSON)
+	}
+}
+
+func TestImportInvalidRejected(t *testing.T) {
+	r, store := newConfigTestServer(t)
+	seedConfig(t, store)
+
+	before, err := store.Policies.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "unsupported version",
+			cfg:  Config{Version: "99"},
+		},
+		{
+			name: "invalid policy action",
+			cfg: Config{Version: ConfigVersion, Policies: []ConfigPolicy{
+				{ID: "new-pol", Name: "New", Action: "NUKE", Domains: []string{"x.com"}},
+			}},
+		},
+		{
+			name: "blocklist with non-http url",
+			cfg: Config{Version: ConfigVersion, Blocklists: []ConfigBlocklist{
+				{ID: "bad", Name: "Bad", URL: "file:///etc/passwd", Format: "hosts"},
+			}},
+		},
+		{
+			name: "policy missing id",
+			cfg: Config{Version: ConfigVersion, Policies: []ConfigPolicy{
+				{Name: "No ID", Action: "BLOCK"},
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := doImport(t, r, tc.cfg, "")
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	// Nothing should have been persisted by any rejected import.
+	after, err := store.Policies.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Errorf("invalid import mutated state: before=%d after=%d", len(before), len(after))
+	}
+}
+
+func TestImportDryRunDoesNotPersist(t *testing.T) {
+	r, store := newConfigTestServer(t)
+	// Start empty (only default settings created on first Get).
+
+	cfg := Config{
+		Version: ConfigVersion,
+		Policies: []ConfigPolicy{
+			{ID: "dry-pol", Name: "Dry", Action: "BLOCK", Domains: []string{"a.com"}, Enabled: true},
+		},
+		Blocklists: []ConfigBlocklist{
+			{ID: "dry-bl", Name: "Dry BL", URL: "https://example.com/list", Format: "hosts", Enabled: true},
+		},
+		Settings: ConfigSettings{DNSEnabled: true, PolicyEnabled: true},
+	}
+
+	w := doImport(t, r, cfg, "dry_run=true")
+	if w.Code != http.StatusOK {
+		t.Fatalf("dry-run: expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var sum summaryEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &sum); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if !sum.Data.DryRun {
+		t.Error("expected dry_run=true in summary")
+	}
+	if sum.Data.PoliciesImported != 1 || sum.Data.BlocklistsImported != 1 {
+		t.Errorf("dry-run summary should report would-import counts: %+v", sum.Data)
+	}
+
+	// Persistence must not have happened.
+	pols, err := store.Policies.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pols) != 0 {
+		t.Errorf("dry-run persisted %d policies, expected 0", len(pols))
+	}
+	srcs, err := store.Blocklist.ListSources()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(srcs) != 0 {
+		t.Errorf("dry-run persisted %d blocklist sources, expected 0", len(srcs))
+	}
+}

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -63,5 +63,12 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 		{
 			devices.GET("", apiHandler.GetDevices)
 		}
+
+		// Config export/import endpoints
+		cfg := api.Group("/config")
+		{
+			cfg.GET("/export", apiHandler.ExportConfig)
+			cfg.POST("/import", apiHandler.ImportConfig)
+		}
 	}
 }

--- a/internal/storage/repositories/store.go
+++ b/internal/storage/repositories/store.go
@@ -12,6 +12,11 @@ type Store struct {
 	SystemState SystemStateRepository
 	Policies    PolicyRepository
 	Auth        AuthRepository
+
+	// DB is the shared gorm handle backing every repository above. It is
+	// exposed so multi-entity operations (e.g. atomic config import) can run
+	// their writes inside a single transaction.
+	DB *gorm.DB
 }
 
 func NewStore(db *gorm.DB) *Store {
@@ -23,5 +28,6 @@ func NewStore(db *gorm.DB) *Store {
 		SystemState: NewSystemStateRepo(db),
 		Policies:    NewPolicyRepo(db),
 		Auth:        NewAuthRepo(db),
+		DB:          db,
 	}
 }


### PR DESCRIPTION
## 📝 Description

Adds config-as-code to the control plane: export the running configuration as a single versioned JSON document and import it back. Enables backups, cloning a golden config onto a fresh appliance, and diffing config between boxes.

## 🧪 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🔍 Changes Made

**What**
- `GET /api/v1/config/export` — dumps `{version, policies[], blocklists[], settings{}}`.
- `POST /api/v1/config/import` — validates and applies a config; `?dry_run=true` validates only and persists nothing.

**Why**
- Operators need a portable, diffable representation of a HydraDNS box to back up, replicate onto new hardware, and review changes. Everything is read/written through the real repositories — no mock data.

**How**
- Export reads policies, blocklist sources and key settings via the existing repos and normalizes to a deterministic (id-sorted, timestamp-free) document so `export → import → export` round-trips byte-for-byte.
- Import validates first (version, required fields, allowed policy actions, duplicate ids, http(s)-only blocklist URLs to guard against SSRF), then applies **atomically** in a single transaction. Policies and blocklist sources are upserted by id (merge semantics — nothing is deleted; existing `created_at` preserved for idempotent re-imports); settings are updated in place. After commit the engine is reloaded best-effort via the dataplane client (persistence stays the source of truth; a reload hiccup is surfaced as a warning, not a failure).
- Import returns a summary `{dry_run, policies_imported, blocklists_imported, settings_applied, warnings?}`. Responses use the standard `{status, data, error}` envelope.
- Exposes the shared `*gorm.DB` on `repositories.Store` so the multi-entity import can run inside one transaction.

**Scope note**
- Deliberately scoped to what exists on `main`: **policies**, **blocklist sources**, and key **settings** (`dns_enabled`, `policy_enabled`). **Resolvers are intentionally excluded** — that model is not on `main` yet. `version` is stamped so the schema can grow (e.g. resolvers) without breaking older exports.

## 🧪 Testing

### Tests Performed
- [x] Unit tests pass (`make test`)

### Test Cases (httptest + Gin + in-memory sqlite)

1. **Export shape** — version, id-sorted policies/blocklists, decoded domains, and settings all present and correct.
2. **Round-trip stability** — `export → import → export` produces byte-identical JSON.
3. **Invalid import rejected** — unsupported version, invalid policy action, non-http blocklist URL, and missing policy id all return 400 and persist nothing.
4. **Dry-run** — `?dry_run=true` returns a summary and writes zero policies/blocklist sources.

## 📋 Checklist

- [x] `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green
- [x] New tests added covering the feature
- [x] No new warnings; backwards compatible (additive endpoints + one additive struct field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)