### PR TITLE
feat: blocklist source health monitoring (I-135)

### DIFF
--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/lopster568/phantomDNS/internal/blocklist"
@@ -65,6 +66,11 @@ func main() {
 			cancel()
 		}
 	}()
+
+	// 3b. Blocklist source health monitoring — flags dead, collapsed, or stale
+	// sources on an interval. Non-fatal; results are retained for status/heartbeat.
+	healthChecker := blocklist.NewHealthChecker(repos.Blocklist, blocklist.DefaultHealthThresholds(), time.Now)
+	go healthChecker.Run(context.Background(), healthInterval(config.DefaultConfig.DataPlane.BlocklistHealthInterval))
 
 	// 4. Initialize Policy Engine — load from file + DB
 	policyEngine := policy.NewPolicyEngine()
@@ -135,6 +141,24 @@ func main() {
 
 	logger.Log.Infof("DNS server listening on %s", config.DefaultConfig.DataPlane.ListenAddr)
 	srv.Run()
+}
+
+// healthInterval parses the configured blocklist health interval. "off", "0",
+// "disabled", or an empty value turn the periodic monitor off (a single check
+// still runs); an unparseable value falls back to 1h.
+func healthInterval(v string) time.Duration {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "":
+		return time.Hour
+	case "off", "0", "disabled":
+		return 0
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		logger.Log.Warnf("invalid BLOCKLIST_HEALTH_INTERVAL %q, using 1h", v)
+		return time.Hour
+	}
+	return d
 }
 
 func refreshBlocklists(ctx context.Context, engine *blocklist.Engine, repo repositories.BlocklistRepository) {

--- a/internal/blocklist/health.go
+++ b/internal/blocklist/health.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package blocklist
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+// Clock returns the current time. It is injectable so the health checker and its
+// pure evaluation are fully deterministic under test.
+type Clock func() time.Time
+
+// HealthReason enumerates why a blocklist source is considered unhealthy.
+// An empty reason means the source is healthy.
+type HealthReason string
+
+const (
+	ReasonOK        HealthReason = ""
+	ReasonNoData    HealthReason = "no_data"   // dead / unreachable: the source never produced usable entries
+	ReasonCollapsed HealthReason = "collapsed" // domain count dropped sharply versus the previous snapshot
+	ReasonStale     HealthReason = "stale"     // not refreshed within the staleness threshold
+)
+
+// HealthStatus is the outcome of evaluating a single blocklist source.
+type HealthStatus struct {
+	SourceID   string       `json:"source_id"`
+	SourceName string       `json:"source_name"`
+	OK         bool         `json:"ok"`
+	Reason     HealthReason `json:"reason,omitempty"`
+	Detail     string       `json:"detail,omitempty"`
+	CheckedAt  time.Time    `json:"checked_at"`
+}
+
+// HealthThresholds tunes evaluate. A zero value for a field disables the
+// corresponding check.
+type HealthThresholds struct {
+	// StaleAfter flags a source whose newest snapshot is older than this.
+	StaleAfter time.Duration
+	// CollapseRatio flags a source whose newest snapshot size fell below
+	// previousSize * CollapseRatio. For example 0.5 means "flag if the domain
+	// count more than halved versus the previous snapshot".
+	CollapseRatio float64
+}
+
+// DefaultHealthThresholds returns conservative defaults: stale after a week,
+// collapse when the count more than halves.
+func DefaultHealthThresholds() HealthThresholds {
+	return HealthThresholds{
+		StaleAfter:    7 * 24 * time.Hour,
+		CollapseRatio: 0.5,
+	}
+}
+
+// evaluate is the pure health decision for a single source. It is deterministic:
+// given the same inputs it always returns the same status.
+//
+//   - latest is the most recent snapshot for the source, or nil when the source
+//     has never produced one.
+//   - prev is the snapshot immediately before latest, used only as the baseline
+//     for collapse detection; nil disables that check.
+//   - now is the injected wall clock.
+func evaluate(src models.BlocklistSource, latest, prev *models.BlocklistSnapshot, now time.Time, t HealthThresholds) HealthStatus {
+	st := HealthStatus{
+		SourceID:   src.ID,
+		SourceName: src.Name,
+		CheckedAt:  now,
+		OK:         true,
+	}
+
+	// 1. Dead / unreachable: no snapshot has ever landed, or the newest one is
+	//    empty. A dead or unreachable URL never populates usable entries, so this
+	//    surfaces both.
+	if latest == nil || latest.Size <= 0 {
+		st.OK = false
+		st.Reason = ReasonNoData
+		if latest == nil {
+			st.Detail = "no snapshot has ever been produced for this source"
+		} else {
+			st.Detail = "most recent snapshot contains zero domains"
+		}
+		return st
+	}
+
+	// 2. Collapsed: the newest domain count fell sharply versus the previous
+	//    snapshot, which usually means the upstream returned a truncated or
+	//    partial list.
+	if t.CollapseRatio > 0 && prev != nil && prev.Size > 0 {
+		floor := float64(prev.Size) * t.CollapseRatio
+		if float64(latest.Size) < floor {
+			drop := (1 - float64(latest.Size)/float64(prev.Size)) * 100
+			st.OK = false
+			st.Reason = ReasonCollapsed
+			st.Detail = fmt.Sprintf("domain count fell %.0f%% (%d -> %d)", drop, prev.Size, latest.Size)
+			return st
+		}
+	}
+
+	// 3. Stale: the newest snapshot is older than the staleness threshold, so the
+	//    source is no longer being refreshed.
+	if t.StaleAfter > 0 {
+		if age := now.Sub(latest.CreatedAt); age > t.StaleAfter {
+			st.OK = false
+			st.Reason = ReasonStale
+			st.Detail = fmt.Sprintf("last updated %s ago (threshold %s)", age.Truncate(time.Second), t.StaleAfter)
+			return st
+		}
+	}
+
+	return st
+}
+
+// HealthDataSource is the read-only view of blocklist storage the checker needs.
+// *repositories.BlocklistRepo satisfies it.
+type HealthDataSource interface {
+	ListSources() ([]models.BlocklistSource, error)
+	GetRecentSnapshots(sourceID string, limit int) ([]models.BlocklistSnapshot, error)
+}
+
+// HealthChecker periodically evaluates every configured blocklist source and
+// retains the latest per-source result so a status endpoint or heartbeat can
+// report which sources are unhealthy.
+type HealthChecker struct {
+	data       HealthDataSource
+	clock      Clock
+	thresholds HealthThresholds
+
+	mu       sync.RWMutex
+	statuses map[string]HealthStatus
+}
+
+// NewHealthChecker builds a checker. A nil clock defaults to time.Now.
+func NewHealthChecker(data HealthDataSource, thresholds HealthThresholds, clock Clock) *HealthChecker {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &HealthChecker{
+		data:       data,
+		clock:      clock,
+		thresholds: thresholds,
+		statuses:   make(map[string]HealthStatus),
+	}
+}
+
+// CheckOnce evaluates every enabled source once, refreshes the retained status
+// map, logs a warning per unhealthy source, and returns the results. It is
+// non-fatal: a storage error for one source is logged and that source is still
+// evaluated (with no snapshot data, so it surfaces as unhealthy) rather than
+// aborting the whole sweep.
+func (h *HealthChecker) CheckOnce() []HealthStatus {
+	sources, err := h.data.ListSources()
+	if err != nil {
+		logger.Log.Errorf("blocklist health: failed to list sources: %v", err)
+		return nil
+	}
+
+	now := h.clock()
+	results := make([]HealthStatus, 0, len(sources))
+	fresh := make(map[string]HealthStatus, len(sources))
+
+	for _, src := range sources {
+		if !src.Enabled {
+			continue
+		}
+
+		var latest, prev *models.BlocklistSnapshot
+		snaps, err := h.data.GetRecentSnapshots(src.ID, 2)
+		if err != nil {
+			logger.Log.Errorf("blocklist health: failed to load snapshots for %s: %v", src.ID, err)
+		} else {
+			if len(snaps) > 0 {
+				latest = &snaps[0]
+			}
+			if len(snaps) > 1 {
+				prev = &snaps[1]
+			}
+		}
+
+		st := evaluate(src, latest, prev, now, h.thresholds)
+		if !st.OK {
+			logger.Log.Warnf("blocklist source %q (%s) unhealthy: %s (%s)", st.SourceName, st.SourceID, st.Reason, st.Detail)
+		}
+		fresh[src.ID] = st
+		results = append(results, st)
+	}
+
+	h.mu.Lock()
+	h.statuses = fresh
+	h.mu.Unlock()
+	return results
+}
+
+// Run performs an immediate check and then re-checks on every tick of interval
+// until ctx is cancelled. A non-positive interval disables periodic checking:
+// Run performs a single check and returns, so BLOCKLIST_HEALTH_INTERVAL can turn
+// the background monitor off.
+func (h *HealthChecker) Run(ctx context.Context, interval time.Duration) {
+	h.CheckOnce()
+	if interval <= 0 {
+		logger.Log.Info("blocklist health: periodic monitoring disabled (ran a single check)")
+		return
+	}
+
+	logger.Log.Infof("blocklist health: monitoring every %s", interval)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.CheckOnce()
+		}
+	}
+}
+
+// Statuses returns the most recent health status for every evaluated source.
+func (h *HealthChecker) Statuses() []HealthStatus {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make([]HealthStatus, 0, len(h.statuses))
+	for _, st := range h.statuses {
+		out = append(out, st)
+	}
+	return out
+}
+
+// Unhealthy returns the sources currently flagged as unhealthy. It always
+// returns a non-nil slice so it serialises cleanly from a status endpoint.
+func (h *HealthChecker) Unhealthy() []HealthStatus {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make([]HealthStatus, 0)
+	for _, st := range h.statuses {
+		if !st.OK {
+			out = append(out, st)
+		}
+	}
+	return out
+}
+
+// Healthy reports whether every evaluated source is currently OK. A checker that
+// has not run yet (no sources evaluated) is reported healthy.
+func (h *HealthChecker) Healthy() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, st := range h.statuses {
+		if !st.OK {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/blocklist/health_test.go
+++ b/internal/blocklist/health_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package blocklist
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+// fixedClock returns a deterministic wall clock for tests.
+func fixedClock(t time.Time) Clock { return func() time.Time { return t } }
+
+func snap(size int, created time.Time) *models.BlocklistSnapshot {
+	return &models.BlocklistSnapshot{Size: size, CreatedAt: created}
+}
+
+func TestEvaluate(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	th := HealthThresholds{StaleAfter: 7 * 24 * time.Hour, CollapseRatio: 0.5}
+	src := models.BlocklistSource{ID: "s1", Name: "StevenBlack", Enabled: true}
+
+	tests := []struct {
+		name       string
+		latest     *models.BlocklistSnapshot
+		prev       *models.BlocklistSnapshot
+		wantOK     bool
+		wantReason HealthReason
+	}{
+		{
+			name:       "dead: no snapshot ever produced",
+			latest:     nil,
+			prev:       nil,
+			wantOK:     false,
+			wantReason: ReasonNoData,
+		},
+		{
+			name:       "dead: newest snapshot is empty",
+			latest:     snap(0, now.Add(-time.Hour)),
+			prev:       snap(1000, now.Add(-25*time.Hour)),
+			wantOK:     false,
+			wantReason: ReasonNoData,
+		},
+		{
+			name:       "collapsed: count more than halved",
+			latest:     snap(100, now.Add(-time.Hour)),
+			prev:       snap(1000, now.Add(-25*time.Hour)),
+			wantOK:     false,
+			wantReason: ReasonCollapsed,
+		},
+		{
+			name:       "stale: newest snapshot older than threshold",
+			latest:     snap(1000, now.Add(-10*24*time.Hour)),
+			prev:       nil,
+			wantOK:     false,
+			wantReason: ReasonStale,
+		},
+		{
+			name:       "healthy: fresh, full, stable",
+			latest:     snap(1000, now.Add(-time.Hour)),
+			prev:       snap(1000, now.Add(-25*time.Hour)),
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "healthy: minor dip within tolerance",
+			latest:     snap(800, now.Add(-time.Hour)),
+			prev:       snap(1000, now.Add(-25*time.Hour)),
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "healthy: growth is never a collapse",
+			latest:     snap(5000, now.Add(-time.Hour)),
+			prev:       snap(1000, now.Add(-25*time.Hour)),
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "healthy: exactly at collapse floor is not flagged",
+			latest:     snap(500, now.Add(-time.Hour)),
+			prev:       snap(1000, now.Add(-25*time.Hour)),
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "collapse ignored without a baseline",
+			latest:     snap(1, now.Add(-time.Hour)),
+			prev:       nil,
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evaluate(src, tc.latest, tc.prev, now, th)
+			if got.OK != tc.wantOK {
+				t.Fatalf("OK = %v, want %v (detail: %q)", got.OK, tc.wantOK, got.Detail)
+			}
+			if got.Reason != tc.wantReason {
+				t.Fatalf("Reason = %q, want %q (detail: %q)", got.Reason, tc.wantReason, got.Detail)
+			}
+			if got.SourceID != src.ID || got.SourceName != src.Name {
+				t.Fatalf("identity = %q/%q, want %q/%q", got.SourceID, got.SourceName, src.ID, src.Name)
+			}
+			if !got.CheckedAt.Equal(now) {
+				t.Fatalf("CheckedAt = %v, want %v", got.CheckedAt, now)
+			}
+			if !got.OK && got.Detail == "" {
+				t.Fatalf("expected a non-empty detail for unhealthy status")
+			}
+		})
+	}
+}
+
+func TestEvaluate_DisabledThresholds(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	src := models.BlocklistSource{ID: "s1", Name: "src", Enabled: true}
+
+	// Zero thresholds disable stale and collapse checks; only the dead check remains.
+	th := HealthThresholds{}
+
+	if st := evaluate(src, snap(1, now.Add(-100*24*time.Hour)), snap(1000, now), now, th); !st.OK {
+		t.Fatalf("with checks disabled a populated source should be OK, got %q/%q", st.Reason, st.Detail)
+	}
+	if st := evaluate(src, nil, nil, now, th); st.OK {
+		t.Fatalf("dead check must fire even with other thresholds disabled")
+	}
+}
+
+// fakeData is an in-memory HealthDataSource for checker tests.
+type fakeData struct {
+	sources   []models.BlocklistSource
+	snapshots map[string][]models.BlocklistSnapshot
+	listErr   error
+	snapErr   error
+}
+
+func (f *fakeData) ListSources() ([]models.BlocklistSource, error) {
+	return f.sources, f.listErr
+}
+
+func (f *fakeData) GetRecentSnapshots(sourceID string, limit int) ([]models.BlocklistSnapshot, error) {
+	if f.snapErr != nil {
+		return nil, f.snapErr
+	}
+	all := f.snapshots[sourceID]
+	if limit > 0 && limit < len(all) {
+		all = all[:limit]
+	}
+	return all, nil
+}
+
+func TestHealthChecker_CheckOnce(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	th := HealthThresholds{StaleAfter: 7 * 24 * time.Hour, CollapseRatio: 0.5}
+
+	data := &fakeData{
+		sources: []models.BlocklistSource{
+			{ID: "healthy", Name: "good", Enabled: true},
+			{ID: "dead", Name: "bad", Enabled: true},
+			{ID: "disabled", Name: "off", Enabled: false},
+		},
+		snapshots: map[string][]models.BlocklistSnapshot{
+			// most-recent-first, as GetRecentSnapshots promises
+			"healthy": {
+				{Size: 1000, CreatedAt: now.Add(-time.Hour)},
+				{Size: 1000, CreatedAt: now.Add(-25 * time.Hour)},
+			},
+			"dead": {},
+		},
+	}
+
+	hc := NewHealthChecker(data, th, fixedClock(now))
+	results := hc.CheckOnce()
+
+	// disabled source is skipped: only 2 evaluated
+	if len(results) != 2 {
+		t.Fatalf("expected 2 evaluated sources, got %d", len(results))
+	}
+
+	unhealthy := hc.Unhealthy()
+	if len(unhealthy) != 1 {
+		t.Fatalf("expected 1 unhealthy source, got %d", len(unhealthy))
+	}
+	if unhealthy[0].SourceID != "dead" || unhealthy[0].Reason != ReasonNoData {
+		t.Fatalf("unexpected unhealthy source: %+v", unhealthy[0])
+	}
+	if hc.Healthy() {
+		t.Fatalf("Healthy() should be false while a source is unhealthy")
+	}
+	if len(hc.Statuses()) != 2 {
+		t.Fatalf("expected 2 retained statuses, got %d", len(hc.Statuses()))
+	}
+}
+
+func TestHealthChecker_CheckOnce_ListError(t *testing.T) {
+	data := &fakeData{listErr: context.DeadlineExceeded}
+	hc := NewHealthChecker(data, DefaultHealthThresholds(), fixedClock(time.Now()))
+	if got := hc.CheckOnce(); got != nil {
+		t.Fatalf("expected nil results on list error, got %+v", got)
+	}
+	if !hc.Healthy() {
+		t.Fatalf("no evaluated sources should report healthy")
+	}
+}
+
+func TestHealthChecker_SnapshotErrorSurfacesUnhealthy(t *testing.T) {
+	now := time.Now()
+	data := &fakeData{
+		sources: []models.BlocklistSource{{ID: "s1", Name: "src", Enabled: true}},
+		snapErr: context.DeadlineExceeded,
+	}
+	hc := NewHealthChecker(data, DefaultHealthThresholds(), fixedClock(now))
+	results := hc.CheckOnce()
+	if len(results) != 1 || results[0].OK {
+		t.Fatalf("a source whose snapshots fail to load must surface as unhealthy, got %+v", results)
+	}
+	if results[0].Reason != ReasonNoData {
+		t.Fatalf("expected %q, got %q", ReasonNoData, results[0].Reason)
+	}
+}
+
+func TestHealthChecker_RunDisabledIntervalRunsOnce(t *testing.T) {
+	now := time.Now()
+	data := &fakeData{
+		sources:   []models.BlocklistSource{{ID: "s1", Name: "src", Enabled: true}},
+		snapshots: map[string][]models.BlocklistSnapshot{"s1": {{Size: 1000, CreatedAt: now}}},
+	}
+	hc := NewHealthChecker(data, DefaultHealthThresholds(), fixedClock(now))
+
+	// A non-positive interval must perform a single check and return promptly.
+	done := make(chan struct{})
+	go func() {
+		hc.Run(context.Background(), 0)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run with a disabled interval did not return")
+	}
+	if len(hc.Statuses()) != 1 {
+		t.Fatalf("expected the single check to populate 1 status, got %d", len(hc.Statuses()))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,10 @@ type DataPlaneConfig struct {
 	BlocklistUpdateInterval string           `yaml:"blocklist_update_interval"`
 	MetricsAddr             string           `yaml:"metrics_addr"`
 
+	// BlocklistHealthInterval controls how often blocklist source health is
+	// checked. Empty (zero value) uses the package default (1h).
+	BlocklistHealthInterval string `yaml:"blocklist_health_interval"`
+
 	// ThreatBlockThreshold enables enforcement of the heuristic threat detector.
 	// When > 0, a query scored suspicious with ThreatScore >= threshold is blocked
 	// (or logged as a would-be block when ThreatBlockDryRun is set). 0 disables
@@ -136,6 +140,7 @@ func defaultConfig() *Config {
 			UpstreamResolvers:       []string{"8.8.8.8:53", "1.1.1.1:53"},
 			BlocklistUpdateInterval: "6h",
 			MetricsAddr:             "0.0.0.0:9153",
+			BlocklistHealthInterval: "1h",
 			GRPCServer: GRPCServerConfig{
 				Port:       50051,
 				ListenAddr: "localhost:50051",
@@ -173,6 +178,9 @@ var DefaultConfig = func() *Config {
 	}
 	if interval := os.Getenv("BLOCKLIST_UPDATE_INTERVAL"); interval != "" {
 		cfg.DataPlane.BlocklistUpdateInterval = interval
+	}
+	if interval := os.Getenv("BLOCKLIST_HEALTH_INTERVAL"); interval != "" {
+		cfg.DataPlane.BlocklistHealthInterval = interval
 	}
 	if v := os.Getenv("THREAT_BLOCK_THRESHOLD"); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {

--- a/internal/storage/repositories/blocklist.go
+++ b/internal/storage/repositories/blocklist.go
@@ -20,6 +20,7 @@ type BlocklistRepository interface {
 	DeleteSource(id string) error
 	CountEntriesBySource(sourceID string) (int64, error)
 	CountEntriesGroupedBySource() (map[string]int64, error)
+	GetRecentSnapshots(sourceID string, limit int) ([]models.BlocklistSnapshot, error)
 }
 
 // Implementation
@@ -131,6 +132,20 @@ func (r *BlocklistRepo) CountEntriesBySource(sourceID string) (int64, error) {
 	var count int64
 	err := r.db.Model(&models.BlocklistEntry{}).Where("source_id = ?", sourceID).Count(&count).Error
 	return count, err
+}
+
+// GetRecentSnapshots returns up to limit snapshots for a source, most recent
+// first. A non-positive limit returns all snapshots. Ordering is by creation
+// time then ID so ties (snapshots written in the same instant) stay
+// deterministic, which the health checker relies on for its collapse baseline.
+func (r *BlocklistRepo) GetRecentSnapshots(sourceID string, limit int) ([]models.BlocklistSnapshot, error) {
+	var snaps []models.BlocklistSnapshot
+	q := r.db.Where("source_id = ?", sourceID).Order("created_at desc, id desc")
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	err := q.Find(&snaps).Error
+	return snaps, err
 }
 
 // CountEntriesGroupedBySource returns domain counts keyed by source ID in a single query.

--- a/internal/storage/repositories/repositories_test.go
+++ b/internal/storage/repositories/repositories_test.go
@@ -133,6 +133,48 @@ func TestBlocklistRepo_SaveSnapshotWithEntries(t *testing.T) {
 	}
 }
 
+func TestBlocklistRepo_GetRecentSnapshots(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewBlocklistRepo(db)
+
+	base := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	// Insert three snapshots for src-a (oldest -> newest) plus one for src-b.
+	db.Create(&models.BlocklistSnapshot{SourceID: "src-a", Size: 100, CreatedAt: base})
+	db.Create(&models.BlocklistSnapshot{SourceID: "src-a", Size: 200, CreatedAt: base.Add(time.Hour)})
+	db.Create(&models.BlocklistSnapshot{SourceID: "src-a", Size: 300, CreatedAt: base.Add(2 * time.Hour)})
+	db.Create(&models.BlocklistSnapshot{SourceID: "src-b", Size: 999, CreatedAt: base})
+
+	// limit=2 returns the two newest for src-a, most recent first.
+	snaps, err := repo.GetRecentSnapshots("src-a", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snaps))
+	}
+	if snaps[0].Size != 300 || snaps[1].Size != 200 {
+		t.Fatalf("expected newest-first [300,200], got [%d,%d]", snaps[0].Size, snaps[1].Size)
+	}
+
+	// limit<=0 returns all snapshots for the source, and only that source.
+	all, err := repo.GetRecentSnapshots("src-a", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 snapshots for src-a, got %d", len(all))
+	}
+
+	// A source with no snapshots returns an empty slice, not an error.
+	none, err := repo.GetRecentSnapshots("missing", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("expected 0 snapshots for missing source, got %d", len(none))
+	}
+}
+
 func TestBlocklistRepo_GetAll_Empty(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewBlocklistRepo(db)


### PR DESCRIPTION
## What
Adds background health monitoring for configured blocklist sources. A `HealthChecker` periodically evaluates each enabled source and flags it as:

- **dead / unreachable** — the source has never produced a snapshot, or its newest snapshot is empty (a dead or unreachable URL never populates usable entries)
- **collapsed** — the newest domain count fell below `previousSize * CollapseRatio` (default 0.5, i.e. more than halved) versus the previous snapshot
- **stale** — the newest snapshot is older than the staleness threshold (default 7 days)

Unhealthy sources are logged as warnings and retained in memory so a status endpoint or heartbeat can report them.

## Why
Blocklist sources rot silently: an upstream URL goes dead, returns a truncated list, or stops updating, and DNS filtering quietly degrades with no signal. This surfaces those failures without touching the fetch/refresh hot path.

## How
- New `internal/blocklist/health.go`:
  - Pure, deterministic `evaluate(source, latest, prev, now, thresholds) -> HealthStatus{ok, reason, detail}` — no I/O, injectable clock, the single decision point for all three signals.
  - `HealthChecker` with an injected `Clock` and a narrow `HealthDataSource` interface (satisfied by the existing blocklist repo). `Run(ctx, interval)` does an immediate check then ticks; a non-positive interval runs one check and returns. Non-fatal throughout: per-source storage errors are logged and the source still surfaces as unhealthy.
  - Status accessors `Unhealthy()`, `Statuses()`, `Healthy()` for a status endpoint / heartbeat.
- `repositories.BlocklistRepo.GetRecentSnapshots(sourceID, limit)` — most-recent-first snapshot lookup used for the current + baseline comparison (deterministic ordering by `created_at, id`).
- Config: `BLOCKLIST_HEALTH_INTERVAL` env var + `blocklist_health_interval` YAML (default `1h`; `off`/`0`/`disabled` turns the periodic monitor off). Wired into the dataplane as a background goroutine alongside the existing blocklist refresh.

## Tests
- Pure `evaluate` covered heavily via table tests: dead (nil + empty snapshot), collapsed, stale, and healthy cases (fresh/full, minor dip, growth, exact collapse floor, no-baseline), plus disabled-threshold behavior — all with mock source/snapshot data and an injected fixed clock.
- `HealthChecker`: disabled sources skipped, unhealthy accounting, list-error and snapshot-error paths, and `Run` returning after a single check when the interval is disabled.
- Repo: `GetRecentSnapshots` ordering, limit, and empty-source behavior.
- `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)