### PR TITLE
feat: self-heal watchdog + systemd unit (I-078)

### DIFF
--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/storage/db"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"github.com/lopster568/phantomDNS/internal/watchdog"
 )
 
 func main() {
@@ -139,6 +140,14 @@ func main() {
 		logger.Log.Fatal("Failed to create server: " + err.Error())
 	}
 
+	// 8. Self-heal watchdog — supervise dataplane liveness on unattended boxes.
+	// Probe: the engine must be accepting queries. Recovery: an in-process
+	// listener restart is not safely in scope from here (the DNS server owns its
+	// own bind/shutdown lifecycle), so we emit a critical log line instead; the
+	// systemd unit (deploy/hydradns.service, Restart=always) handles bare-metal
+	// process-level recovery when the box is truly wedged.
+	startWatchdog(engine)
+
 	logger.Log.Infof("DNS server listening on %s", config.DefaultConfig.DataPlane.ListenAddr)
 	srv.Run()
 }
@@ -159,6 +168,42 @@ func healthInterval(v string) time.Duration {
 		return time.Hour
 	}
 	return d
+}
+
+// startWatchdog constructs and launches the self-heal watchdog for the DNS
+// engine. It is a no-op when WATCHDOG_INTERVAL disables it. The watchdog is
+// started in a background goroutine that first waits for the DNS server to come
+// up, so the normal startup window is not flagged as unhealthy.
+func startWatchdog(engine *dnsengine.Engine) {
+	wd := watchdog.New(
+		watchdog.Config{
+			Interval:         config.DefaultConfig.DataPlane.WatchdogIntervalDuration(),
+			FailureThreshold: config.DefaultConfig.DataPlane.WatchdogFailureThreshold,
+		},
+		// Liveness probe: engine is healthy while it is accepting queries.
+		func() bool { return engine.Status().AcceptingQueries },
+		// Recovery: log critically for external supervision. Restarting the DNS
+		// listener in-process is not safely in scope here; deploy/hydradns.service
+		// (Restart=always) provides bare-metal auto-restart for hard failures.
+		func() {
+			logger.Log.Error("watchdog: dataplane stalled (engine not accepting queries); " +
+				"relying on systemd Restart=always for bare-metal recovery")
+		},
+		logger.Log,
+	)
+
+	if !wd.Enabled() {
+		logger.Log.Info("Self-heal watchdog disabled (WATCHDOG_INTERVAL off)")
+		return
+	}
+
+	go func() {
+		// Wait for the server to start accepting queries before supervising.
+		for !engine.Status().AcceptingQueries {
+			time.Sleep(500 * time.Millisecond)
+		}
+		wd.Start(context.Background())
+	}()
 }
 
 func refreshBlocklists(ctx context.Context, engine *blocklist.Engine, repo repositories.BlocklistRepository) {

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -27,6 +27,11 @@ dataplane:
   dns_0x20: false
   # Address for the Prometheus /metrics endpoint (defaults to 0.0.0.0:9153).
   metrics_addr: "0.0.0.0:9153"
+  # Self-heal watchdog: probe cadence and consecutive-failure threshold before
+  # recovery. Set watchdog_interval to "off" or "0" to disable. Overridable via
+  # WATCHDOG_INTERVAL / WATCHDOG_FAILURE_THRESHOLD env vars.
+  watchdog_interval: "30s"
+  watchdog_failure_threshold: 3
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/deploy/hydradns.service
+++ b/deploy/hydradns.service
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# systemd unit for the HydraDNS dataplane on bare-metal / appliance boxes.
+#
+# Install:
+#   sudo cp deploy/hydradns.service /etc/systemd/system/hydradns.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now hydradns.service
+#
+# This unit provides process-level auto-restart (Restart=always) that complements
+# the in-process self-heal watchdog: the watchdog handles soft stalls in-process,
+# while systemd recovers the box when the process itself dies or is wedged.
+
+[Unit]
+Description=HydraDNS DNS security gateway (dataplane)
+Documentation=https://docs.hydradns.app
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/dataplane
+Restart=always
+RestartSec=2s
+
+# Self-heal watchdog cadence (Go duration; "off" or "0" disables it).
+Environment=WATCHDOG_INTERVAL=30s
+Environment=WATCHDOG_FAILURE_THRESHOLD=3
+
+# Config / data locations (override as needed for your deployment).
+Environment=PHANTOM_CONFIG=/etc/hydradns/config.yaml
+Environment=PHANTOM_DB=/var/lib/hydradns/phantomdns.db
+
+# Hardening — DNS needs to bind privileged ports; grant only that capability.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/hydradns
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"gopkg.in/yaml.v3"
@@ -59,6 +60,28 @@ type DataPlaneConfig struct {
 	// DNS0x20 enables DNS 0x20 case-randomization on outbound upstream queries
 	// (anti-spoofing hardening). Default false = behaviour unchanged.
 	DNS0x20 bool `yaml:"dns_0x20"`
+
+	// WatchdogInterval is the self-heal watchdog probe cadence as a Go duration
+	// (e.g. "30s"). Empty, "0" or "off" disables the watchdog.
+	WatchdogInterval string `yaml:"watchdog_interval"`
+	// WatchdogFailureThreshold is the number of consecutive unhealthy probes
+	// before the watchdog attempts recovery. <= 0 uses the watchdog default.
+	WatchdogFailureThreshold int `yaml:"watchdog_failure_threshold"`
+}
+
+// WatchdogIntervalDuration parses WatchdogInterval into a duration. It returns 0
+// (watchdog disabled) when the value is empty, "0", "off", or unparseable.
+func (c DataPlaneConfig) WatchdogIntervalDuration() time.Duration {
+	s := strings.TrimSpace(c.WatchdogInterval)
+	if s == "" || s == "0" || strings.EqualFold(s, "off") {
+		return 0
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		logger.Log.Warnf("Invalid WATCHDOG_INTERVAL %q, disabling watchdog", c.WatchdogInterval)
+		return 0
+	}
+	return d
 }
 
 type ControlPlaneConfig struct {
@@ -136,11 +159,13 @@ const DefaultSelfSignedDir = "/app/data/tls"
 func defaultConfig() *Config {
 	return &Config{
 		DataPlane: DataPlaneConfig{
-			ListenAddr:              "0.0.0.0:1053",
-			UpstreamResolvers:       []string{"8.8.8.8:53", "1.1.1.1:53"},
-			BlocklistUpdateInterval: "6h",
-			MetricsAddr:             "0.0.0.0:9153",
-			BlocklistHealthInterval: "1h",
+			ListenAddr:               "0.0.0.0:1053",
+			UpstreamResolvers:        []string{"8.8.8.8:53", "1.1.1.1:53"},
+			BlocklistUpdateInterval:  "6h",
+			MetricsAddr:              "0.0.0.0:9153",
+			BlocklistHealthInterval:  "1h",
+			WatchdogInterval:         "30s",
+			WatchdogFailureThreshold: 3,
 			GRPCServer: GRPCServerConfig{
 				Port:       50051,
 				ListenAddr: "localhost:50051",
@@ -233,6 +258,16 @@ var DefaultConfig = func() *Config {
 		cfg.DataPlane.MetricsAddr = "0.0.0.0:9153"
 	}
 	applyTLSEnv(&cfg.ControlPlane.TLS)
+	if v := os.Getenv("WATCHDOG_INTERVAL"); v != "" {
+		cfg.DataPlane.WatchdogInterval = v
+	}
+	if v := os.Getenv("WATCHDOG_FAILURE_THRESHOLD"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.DataPlane.WatchdogFailureThreshold = n
+		} else {
+			logger.Log.Warnf("Invalid WATCHDOG_FAILURE_THRESHOLD %q, using default", v)
+		}
+	}
 	return cfg
 }()
 

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package watchdog provides a lightweight self-heal supervisor for the
+// PhantomDNS dataplane, intended for unattended boxes (appliances) where no
+// operator is present to notice a stalled resolver.
+//
+// The watchdog periodically calls an injected liveness Probe. When the probe
+// reports unhealthy for a sustained number of consecutive ticks
+// (FailureThreshold), it invokes an injected Recovery callback and flips an
+// internal health flag. It is deliberately bounded and non-fatal: it never
+// terminates the process, contains panics from the probe or recovery callback,
+// and backs off after each recovery attempt so it cannot spin in a tight loop.
+//
+// For hard failures where the whole process is wedged (and this in-process
+// goroutine can no longer run), recovery is delegated to the process manager —
+// see deploy/hydradns.service, which sets Restart=always for bare-metal
+// auto-restart.
+package watchdog
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Probe reports whether the supervised dataplane is currently healthy. It must
+// be fast and non-blocking; a false return counts as one unhealthy tick. A
+// panic inside the probe is treated as unhealthy.
+type Probe func() bool
+
+// Recovery attempts to bring the dataplane back to a healthy state (for example
+// by re-initialising the DNS listener, or, when an in-process restart is not
+// safely in scope, by emitting a critical log line for external supervision).
+// It is invoked at most once per sustained unhealthy episode.
+type Recovery func()
+
+// Logger is the minimal logging surface the watchdog needs. It is satisfied by
+// *logrus.Logger. A nil Logger disables logging.
+type Logger interface {
+	Infof(format string, args ...any)
+	Warnf(format string, args ...any)
+	Errorf(format string, args ...any)
+}
+
+const (
+	// DefaultInterval is a sane probe cadence for an unattended appliance.
+	DefaultInterval = 30 * time.Second
+	// DefaultFailureThreshold is the number of consecutive unhealthy probes
+	// required before recovery is attempted.
+	DefaultFailureThreshold = 3
+)
+
+// Config controls watchdog behaviour.
+type Config struct {
+	// Interval between liveness probes. A value <= 0 disables the watchdog:
+	// New returns a watchdog whose Start is a no-op and Enabled reports false.
+	Interval time.Duration
+	// FailureThreshold is the number of consecutive unhealthy probes that must
+	// occur before Recovery is invoked. Values < 1 fall back to
+	// DefaultFailureThreshold.
+	FailureThreshold int
+}
+
+// Watchdog supervises dataplane liveness. Construct one with New and launch it
+// with Start. The zero value is not usable.
+type Watchdog struct {
+	interval  time.Duration
+	threshold int
+	probe     Probe
+	recover   Recovery
+	log       Logger
+
+	// newTicker is injectable so tests can drive the loop deterministically
+	// without real time. It returns a tick channel and a stop function.
+	newTicker func(time.Duration) (<-chan time.Time, func())
+
+	enabled bool
+	started atomic.Bool
+
+	mu       sync.Mutex // guards failures
+	failures int
+
+	healthy atomic.Bool
+}
+
+// New builds a Watchdog. probe and recover may be nil (a nil probe is treated as
+// always healthy; a nil recover makes recovery a no-op), which is useful in
+// tests. log may be nil to disable logging.
+func New(cfg Config, probe Probe, recover Recovery, log Logger) *Watchdog {
+	threshold := cfg.FailureThreshold
+	if threshold < 1 {
+		threshold = DefaultFailureThreshold
+	}
+	w := &Watchdog{
+		interval:  cfg.Interval,
+		threshold: threshold,
+		probe:     probe,
+		recover:   recover,
+		log:       log,
+		newTicker: realTicker,
+		enabled:   cfg.Interval > 0,
+	}
+	w.healthy.Store(true)
+	return w
+}
+
+func realTicker(d time.Duration) (<-chan time.Time, func()) {
+	t := time.NewTicker(d)
+	return t.C, t.Stop
+}
+
+// Enabled reports whether the watchdog will actually run (interval > 0).
+func (w *Watchdog) Enabled() bool { return w.enabled }
+
+// Healthy reports the last observed health state. It starts true and is flipped
+// by each probe cycle. Safe for concurrent use.
+func (w *Watchdog) Healthy() bool { return w.healthy.Load() }
+
+// Start launches the watchdog loop in a background goroutine and returns
+// immediately. It is a no-op if the watchdog is disabled or already started.
+// The loop runs until ctx is cancelled.
+func (w *Watchdog) Start(ctx context.Context) {
+	if !w.enabled {
+		w.logf(w.infof, "watchdog disabled (interval <= 0)")
+		return
+	}
+	if !w.started.CompareAndSwap(false, true) {
+		return
+	}
+	go w.run(ctx)
+}
+
+func (w *Watchdog) run(ctx context.Context) {
+	tickC, stop := w.newTicker(w.interval)
+	defer stop()
+
+	w.logf(w.infof, "watchdog started (interval=%s failure_threshold=%d)", w.interval, w.threshold)
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logf(w.infof, "watchdog stopping: %v", ctx.Err())
+			return
+		case <-tickC:
+			w.check()
+		}
+	}
+}
+
+// check runs a single probe cycle. It is fully synchronous and is the unit under
+// test. It returns true if a recovery was triggered on this cycle.
+func (w *Watchdog) check() bool {
+	healthy := w.safeProbe()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if healthy {
+		if !w.healthy.Load() {
+			w.logf(w.infof, "watchdog: dataplane recovered")
+		}
+		w.failures = 0
+		w.healthy.Store(true)
+		return false
+	}
+
+	w.failures++
+	w.healthy.Store(false)
+	w.logf(w.warnf, "watchdog: dataplane unhealthy (%d/%d consecutive)", w.failures, w.threshold)
+
+	if w.failures >= w.threshold {
+		w.logf(w.errorf, "watchdog: failure threshold reached (%d), invoking recovery", w.threshold)
+		w.safeRecover()
+		// Back off: require another full threshold of failures before the next
+		// recovery attempt so we never spin in a tight loop.
+		w.failures = 0
+		return true
+	}
+	return false
+}
+
+func (w *Watchdog) safeProbe() (healthy bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.logf(w.errorf, "watchdog: probe panicked: %v", r)
+			healthy = false
+		}
+	}()
+	if w.probe == nil {
+		return true
+	}
+	return w.probe()
+}
+
+func (w *Watchdog) safeRecover() {
+	defer func() {
+		if r := recover(); r != nil {
+			w.logf(w.errorf, "watchdog: recovery panicked: %v", r)
+		}
+	}()
+	if w.recover != nil {
+		w.recover()
+	}
+}
+
+// logf funnels all logging through a nil-safe helper.
+func (w *Watchdog) logf(fn func(string, ...any), format string, args ...any) {
+	if w.log == nil || fn == nil {
+		return
+	}
+	fn(format, args...)
+}
+
+func (w *Watchdog) infof(format string, args ...any)  { w.log.Infof(format, args...) }
+func (w *Watchdog) warnf(format string, args ...any)  { w.log.Warnf(format, args...) }
+func (w *Watchdog) errorf(format string, args ...any) { w.log.Errorf(format, args...) }

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package watchdog
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCheck_RecoversAfterThreshold verifies that recovery fires only after the
+// probe reports unhealthy for FailureThreshold consecutive ticks.
+func TestCheck_RecoversAfterThreshold(t *testing.T) {
+	var recoveries int
+	w := New(
+		Config{Interval: time.Second, FailureThreshold: 3},
+		func() bool { return false }, // always unhealthy
+		func() { recoveries++ },
+		nil,
+	)
+
+	// First two unhealthy ticks: no recovery yet.
+	if w.check() {
+		t.Fatal("tick 1 should not trigger recovery")
+	}
+	if w.check() {
+		t.Fatal("tick 2 should not trigger recovery")
+	}
+	if recoveries != 0 {
+		t.Fatalf("expected 0 recoveries before threshold, got %d", recoveries)
+	}
+
+	// Third consecutive unhealthy tick: recovery fires.
+	if !w.check() {
+		t.Fatal("tick 3 should trigger recovery")
+	}
+	if recoveries != 1 {
+		t.Fatalf("expected exactly 1 recovery at threshold, got %d", recoveries)
+	}
+	if w.Healthy() {
+		t.Fatal("watchdog should report unhealthy after failing probes")
+	}
+}
+
+// TestCheck_HealthyNoAction verifies that a healthy probe never triggers
+// recovery and keeps the health flag set.
+func TestCheck_HealthyNoAction(t *testing.T) {
+	var recoveries int
+	w := New(
+		Config{Interval: time.Second, FailureThreshold: 3},
+		func() bool { return true }, // always healthy
+		func() { recoveries++ },
+		nil,
+	)
+
+	for i := 0; i < 10; i++ {
+		if w.check() {
+			t.Fatalf("healthy probe must not trigger recovery (tick %d)", i)
+		}
+	}
+	if recoveries != 0 {
+		t.Fatalf("expected 0 recoveries when healthy, got %d", recoveries)
+	}
+	if !w.Healthy() {
+		t.Fatal("watchdog should report healthy when probe is healthy")
+	}
+}
+
+// TestCheck_IntermittentResetsCounter verifies that a single healthy tick resets
+// the consecutive-failure counter, so recovery requires N *consecutive* failures.
+func TestCheck_IntermittentResetsCounter(t *testing.T) {
+	var recoveries int
+	healthy := false
+	w := New(
+		Config{Interval: time.Second, FailureThreshold: 3},
+		func() bool { return healthy },
+		func() { recoveries++ },
+		nil,
+	)
+
+	// Two failures, then a healthy tick resets the counter.
+	w.check()
+	w.check()
+	healthy = true
+	w.check()
+	if !w.Healthy() {
+		t.Fatal("should be healthy after a healthy tick")
+	}
+
+	// Two more failures: still below threshold because the counter was reset.
+	healthy = false
+	w.check()
+	if w.check() {
+		t.Fatal("recovery should not fire: only 2 consecutive failures after reset")
+	}
+	if recoveries != 0 {
+		t.Fatalf("expected 0 recoveries, got %d", recoveries)
+	}
+}
+
+// TestCheck_BackoffAfterRecovery verifies the watchdog requires a fresh full
+// threshold of failures before recovering again (no tight recovery loop).
+func TestCheck_BackoffAfterRecovery(t *testing.T) {
+	var recoveries int
+	w := New(
+		Config{Interval: time.Second, FailureThreshold: 2},
+		func() bool { return false },
+		func() { recoveries++ },
+		nil,
+	)
+
+	w.check() // 1
+	w.check() // 2 -> recover
+	if recoveries != 1 {
+		t.Fatalf("expected 1 recovery, got %d", recoveries)
+	}
+	w.check() // 1 (counter was reset)
+	if recoveries != 1 {
+		t.Fatalf("expected still 1 recovery on next tick, got %d", recoveries)
+	}
+	w.check() // 2 -> recover again
+	if recoveries != 2 {
+		t.Fatalf("expected 2 recoveries, got %d", recoveries)
+	}
+}
+
+// TestDisabled_IsNoOp verifies that a non-positive interval disables the
+// watchdog: Enabled is false and Start never invokes the probe or recovery.
+func TestDisabled_IsNoOp(t *testing.T) {
+	var probeCalls, recoveries int32
+	w := New(
+		Config{Interval: 0},
+		func() bool { atomic.AddInt32(&probeCalls, 1); return false },
+		func() { atomic.AddInt32(&recoveries, 1) },
+		nil,
+	)
+
+	if w.Enabled() {
+		t.Fatal("watchdog with interval 0 must be disabled")
+	}
+
+	// Start must be a no-op: fail the injected ticker if it is ever used.
+	w.newTicker = func(time.Duration) (<-chan time.Time, func()) {
+		t.Fatal("disabled watchdog must not create a ticker")
+		return nil, func() {}
+	}
+	w.Start(context.Background())
+
+	time.Sleep(20 * time.Millisecond)
+	if atomic.LoadInt32(&probeCalls) != 0 {
+		t.Fatalf("disabled watchdog must not probe, got %d calls", probeCalls)
+	}
+	if atomic.LoadInt32(&recoveries) != 0 {
+		t.Fatalf("disabled watchdog must not recover, got %d", recoveries)
+	}
+}
+
+// TestProbePanic_TreatedAsUnhealthy verifies a panicking probe is contained and
+// counted as an unhealthy tick rather than crashing the process.
+func TestProbePanic_TreatedAsUnhealthy(t *testing.T) {
+	var recoveries int
+	w := New(
+		Config{Interval: time.Second, FailureThreshold: 1},
+		func() bool { panic("probe boom") },
+		func() { recoveries++ },
+		nil,
+	)
+
+	if !w.check() {
+		t.Fatal("panicking probe should count as unhealthy and hit threshold=1")
+	}
+	if recoveries != 1 {
+		t.Fatalf("expected recovery after panicking probe, got %d", recoveries)
+	}
+}
+
+// TestRun_DriveWithInjectedTicker exercises the full Start/run loop
+// deterministically by injecting a manual tick channel (an injected clock),
+// with no reliance on real time cadence.
+func TestRun_DriveWithInjectedTicker(t *testing.T) {
+	ticks := make(chan time.Time)
+	recovered := make(chan struct{}, 1)
+
+	w := New(
+		Config{Interval: time.Hour, FailureThreshold: 3},
+		func() bool { return false },
+		func() { recovered <- struct{}{} },
+		nil,
+	)
+	w.newTicker = func(time.Duration) (<-chan time.Time, func()) {
+		return ticks, func() {}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+
+	// Drive three unhealthy ticks; the third must invoke recovery.
+	for i := 0; i < 3; i++ {
+		ticks <- time.Now()
+	}
+
+	select {
+	case <-recovered:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("recovery was not invoked within timeout")
+	}
+
+	cancel()
+}


### PR DESCRIPTION
## What
A lightweight self-heal watchdog for unattended/appliance HydraDNS boxes, plus a systemd unit for bare-metal auto-restart.

- **`internal/watchdog`** — a bounded, non-fatal supervisor. A background goroutine periodically calls an injected liveness `Probe`; after `FailureThreshold` consecutive unhealthy probes it invokes a `Recovery` callback and flips an internal health flag. Probe/recovery panics are contained; it never terminates the process and backs off after each recovery attempt so it cannot spin.
- **`cmd/dataplane/main.go`** — minimal hookup. Probe = engine accepting queries; recovery emits a critical log line (an in-process listener restart is not safely in scope — the DNS server owns its own bind/shutdown lifecycle). The watchdog starts only after the server is up, so the startup window isn't flagged unhealthy.
- **`deploy/hydradns.service`** — systemd unit with `Restart=always` (+ `RestartSec`, `CAP_NET_BIND_SERVICE`, basic hardening) for process-level recovery when the box is truly wedged.

## Why
Appliances run unattended with no operator to notice a stalled resolver. The in-process watchdog handles soft stalls (engine stops accepting queries) with detection + alerting + a health flag; systemd `Restart=always` handles hard process death that an in-process goroutine can't recover from. The two layers are complementary.

## How
- Config: `WATCHDOG_INTERVAL` (default `30s`; `off`/`0` disables) and `WATCHDOG_FAILURE_THRESHOLD` (default `3`), settable via `config.yaml` or env vars. Env overrides live alongside the existing dataplane env overrides in `internal/config`.
- Recovery backs off (failure counter resets) after each attempt to avoid tight loops.

## Tests
`internal/watchdog/watchdog_test.go`, deterministic (injected fake probe + injected ticker, no reliance on real-time cadence):
- recovery fires only after N consecutive unhealthy probes; healthy = no action
- a single healthy tick resets the consecutive-failure counter
- back-off requires a fresh full threshold before recovering again
- disabled (interval ≤ 0) = no-op: never probes, never creates a ticker
- panicking probe is contained and counted as unhealthy
- full `Start`/run loop driven via an injected tick channel

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green (also `-race -count=5` on the watchdog package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)