### PR TITLE
feat: soft license validation for managed tiers (I-075)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/config"
 	client "github.com/lopster568/phantomDNS/internal/grpc/controlplane"
 	"github.com/lopster568/phantomDNS/internal/inventory"
+	"github.com/lopster568/phantomDNS/internal/license"
 	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/db"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
@@ -29,6 +30,13 @@ func main() {
 	}
 	db.InitDB(dbPath)
 	repos := repositories.NewStore(db.DB)
+
+	// Soft license validation for managed-service tiers. This is a SOFT
+	// gate: it only governs premium/managed features and support. Core DNS
+	// resolution/filtering (in the data plane) is never affected — a
+	// missing or expired license simply runs the install in community mode.
+	ls := license.InitFromEnv().Status()
+	log.Printf("license: mode=%s tier=%s valid=%t", ls.Mode, ls.Tier, ls.Valid)
 
 	// Initialize grpc client. This dials the dataplane's gRPC server, which is
 	// a different address than the dataplane's own bind address

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -82,3 +82,11 @@ controlplane:
   #   # Or auto-generate a self-signed cert on first boot:
   #   auto_self_signed: false                 # env: TLS_AUTO_SELF_SIGNED
   #   self_signed_dir: "/app/data/tls"        # env: TLS_SELF_SIGNED_DIR
+
+# Managed-service licensing (SOFT gate — premium/managed features + support only).
+# Core DNS resolution/filtering ALWAYS works regardless of license state; a
+# missing or expired license simply runs the install in "community" mode.
+# Provide a signed license token via one of these environment variables:
+#   LICENSE_KEY  - the raw signed license token (takes precedence)
+#   LICENSE_FILE - path to a file containing the token
+# See internal/license for the token format and validation details.

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package license implements soft validation of managed-service license
+// tokens for HydraDNS.
+//
+// IMPORTANT (GPL-friendly design): this is a SOFT gate. It only unlocks
+// premium/managed features and support. Core DNS resolution and filtering
+// MUST always work regardless of license state. A missing, malformed, or
+// expired-beyond-grace license simply downgrades the installation to
+// "community" mode — the resolver is never affected.
+//
+// A license token is a signed payload of the form:
+//
+//	base64url(payloadJSON) "." base64url(ed25519Signature)
+//
+// where payloadJSON marshals the Claims struct (customer, tier, issued,
+// expiry). The signature is produced with an Ed25519 private key held by
+// HydraDNS and verified with the corresponding public key (embedded below,
+// overridable via Options.PublicKey for testing/tooling).
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+// Mode describes the operational licensing mode of the installation.
+type Mode string
+
+const (
+	// ModeCommunity means no valid license: premium/managed features are
+	// locked. Core DNS resolution/filtering is unaffected.
+	ModeCommunity Mode = "community"
+	// ModeLicensed means a valid, unexpired license is present.
+	ModeLicensed Mode = "licensed"
+	// ModeGrace means the license expired but is still within the grace
+	// window; premium features remain enabled while renewal is pending.
+	ModeGrace Mode = "grace"
+)
+
+// CommunityTier is the tier reported when no valid license is present.
+const CommunityTier = "community"
+
+// DefaultGracePeriod is how long premium features keep working after a
+// license expires, giving customers time to renew without disruption.
+const DefaultGracePeriod = 14 * 24 * time.Hour
+
+// embeddedPublicKeyB64 is the base64 (std encoding) Ed25519 public key used
+// to verify license tokens.
+//
+// PLACEHOLDER: this key is a documented placeholder generated for the
+// open-source build. Managed/enterprise builds replace it (or override it
+// at load time via Options.PublicKey) with HydraDNS's real signing key.
+// Because validation is a soft gate, shipping the placeholder is safe: it
+// only means no production license verifies against it, so the build runs
+// in community mode.
+const embeddedPublicKeyB64 = "BwTPBVExuwQ9o/HrHbhg+ee/ldvORAf5hb6nctCR8F8="
+
+// Errors returned by Verify.
+var (
+	// ErrMalformedToken indicates the token is not in the expected
+	// "payload.signature" base64url form or the payload is not valid JSON.
+	ErrMalformedToken = errors.New("license: malformed token")
+	// ErrBadSignature indicates the signature did not verify against the
+	// public key (tampered or forged token).
+	ErrBadSignature = errors.New("license: signature verification failed")
+	// ErrInvalidPublicKey indicates the verifier public key is missing or
+	// the wrong size.
+	ErrInvalidPublicKey = errors.New("license: invalid public key")
+	// ErrIncompleteClaims indicates required claim fields are missing.
+	ErrIncompleteClaims = errors.New("license: incomplete claims")
+)
+
+// Claims is the license payload carried by a token.
+type Claims struct {
+	Customer string    `json:"customer"`
+	Tier     string    `json:"tier"`
+	Issued   time.Time `json:"issued"`
+	Expiry   time.Time `json:"expiry"`
+}
+
+// Status is a snapshot of the current licensing state. It is what callers
+// (e.g. the control plane / UI) inspect to decide whether to expose premium
+// features. It intentionally carries no capability to affect resolution.
+type Status struct {
+	// Valid is true when premium/managed features should be enabled
+	// (licensed or within the grace window).
+	Valid bool `json:"valid"`
+	// Tier is the licensed tier, or CommunityTier when not licensed.
+	Tier string `json:"tier"`
+	// Customer is the licensed customer id, empty in community mode.
+	Customer string `json:"customer,omitempty"`
+	// Expiry is the license expiry, zero in community mode.
+	Expiry time.Time `json:"expiry,omitempty"`
+	// Mode is the operational mode: community, licensed, or grace.
+	Mode Mode `json:"mode"`
+}
+
+// communityStatus returns the default, unlicensed status.
+func communityStatus() Status {
+	return Status{Valid: false, Tier: CommunityTier, Mode: ModeCommunity}
+}
+
+// Sign produces a license token for the given claims using an Ed25519
+// private key. It is primarily used by license-issuing tooling and tests.
+func Sign(c Claims, priv ed25519.PrivateKey) (string, error) {
+	if len(priv) != ed25519.PrivateKeySize {
+		return "", fmt.Errorf("license: invalid private key size %d", len(priv))
+	}
+	payload, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	sig := ed25519.Sign(priv, payload)
+	return base64.RawURLEncoding.EncodeToString(payload) + "." +
+		base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// Verify checks a token's Ed25519 signature against pub and parses its
+// claims. It validates the signature and structural integrity only; expiry
+// and grace evaluation is done by Evaluate. A tampered payload or signature
+// yields ErrBadSignature.
+func Verify(token string, pub ed25519.PublicKey) (Claims, error) {
+	var c Claims
+	if len(pub) != ed25519.PublicKeySize {
+		return c, ErrInvalidPublicKey
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return c, ErrMalformedToken
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return c, fmt.Errorf("%w: bad payload encoding: %v", ErrMalformedToken, err)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return c, fmt.Errorf("%w: bad signature encoding: %v", ErrMalformedToken, err)
+	}
+	if !ed25519.Verify(pub, payload, sig) {
+		return c, ErrBadSignature
+	}
+	if err := json.Unmarshal(payload, &c); err != nil {
+		return c, fmt.Errorf("%w: %v", ErrMalformedToken, err)
+	}
+	if c.Customer == "" || c.Tier == "" {
+		return c, ErrIncompleteClaims
+	}
+	return c, nil
+}
+
+// Evaluate turns verified claims into a Status given the current time and a
+// grace window. If grace <= 0, DefaultGracePeriod is used.
+//
+//   - now <= expiry              -> licensed (valid)
+//   - expiry < now <= expiry+grace -> grace   (valid)
+//   - now > expiry+grace         -> community (invalid)
+func Evaluate(c Claims, now time.Time, grace time.Duration) Status {
+	if grace <= 0 {
+		grace = DefaultGracePeriod
+	}
+	switch {
+	case !now.After(c.Expiry):
+		return Status{
+			Valid:    true,
+			Tier:     c.Tier,
+			Customer: c.Customer,
+			Expiry:   c.Expiry,
+			Mode:     ModeLicensed,
+		}
+	case now.Before(c.Expiry.Add(grace)):
+		return Status{
+			Valid:    true,
+			Tier:     c.Tier,
+			Customer: c.Customer,
+			Expiry:   c.Expiry,
+			Mode:     ModeGrace,
+		}
+	default:
+		return communityStatus()
+	}
+}
+
+// embeddedPublicKey decodes the embedded placeholder public key. It returns
+// nil if the constant is somehow invalid, in which case verification fails
+// closed to community mode.
+func embeddedPublicKey() ed25519.PublicKey {
+	b, err := base64.StdEncoding.DecodeString(embeddedPublicKeyB64)
+	if err != nil || len(b) != ed25519.PublicKeySize {
+		return nil
+	}
+	return ed25519.PublicKey(b)
+}
+
+// Options configures how a license is loaded and evaluated.
+type Options struct {
+	// Token is a raw license token (from the LICENSE_KEY env var / config).
+	// Takes precedence over File.
+	Token string
+	// File is a path to a file containing a license token (LICENSE_FILE).
+	File string
+	// PublicKey overrides the embedded verifier key. Defaults to the
+	// embedded placeholder key when nil.
+	PublicKey ed25519.PublicKey
+	// Grace overrides the grace window. Defaults to DefaultGracePeriod.
+	Grace time.Duration
+	// Now overrides the clock, for deterministic evaluation in tests.
+	Now func() time.Time
+}
+
+// License holds the evaluated licensing state of the installation.
+type License struct {
+	status Status
+	claims Claims
+}
+
+// Status returns the current licensing status snapshot.
+func (l *License) Status() Status { return l.status }
+
+// Claims returns the verified claims. In community mode the zero value is
+// returned.
+func (l *License) Claims() Claims { return l.claims }
+
+// Load reads and evaluates a license from opts. It NEVER fails hard: any
+// problem (missing token, unreadable file, bad signature, expiry beyond
+// grace) results in a community-mode License. This is the core of the soft
+// gate — license trouble must never break the running service.
+func Load(opts Options) *License {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	pub := opts.PublicKey
+	if pub == nil {
+		pub = embeddedPublicKey()
+	}
+
+	token := strings.TrimSpace(opts.Token)
+	if token == "" && opts.File != "" {
+		data, err := os.ReadFile(opts.File)
+		if err != nil {
+			logger.Log.Warnf("license: cannot read LICENSE_FILE %q: %v; running in community mode", opts.File, err)
+			return &License{status: communityStatus()}
+		}
+		token = strings.TrimSpace(string(data))
+	}
+	if token == "" {
+		// No license configured: this is the normal open-source path.
+		return &License{status: communityStatus()}
+	}
+
+	claims, err := Verify(token, pub)
+	if err != nil {
+		logger.Log.Warnf("license: verification failed: %v; running in community mode", err)
+		return &License{status: communityStatus()}
+	}
+
+	status := Evaluate(claims, now(), opts.Grace)
+	switch status.Mode {
+	case ModeGrace:
+		logger.Log.Warnf("license: token for %q expired on %s; running in grace period, please renew",
+			claims.Customer, claims.Expiry.Format(time.RFC3339))
+	case ModeCommunity:
+		logger.Log.Warnf("license: token for %q expired beyond grace on %s; running in community mode",
+			claims.Customer, claims.Expiry.Format(time.RFC3339))
+	}
+	return &License{status: status, claims: claims}
+}
+
+// Package-level default license, so callers can query Status() without
+// threading a *License everywhere. Defaults to community mode until Init.
+var (
+	mu  sync.RWMutex
+	std = &License{status: communityStatus()}
+)
+
+// Init loads a license from opts and installs it as the package default.
+func Init(opts Options) *License {
+	l := Load(opts)
+	mu.Lock()
+	std = l
+	mu.Unlock()
+	return l
+}
+
+// InitFromEnv loads the package default license from the LICENSE_KEY and
+// LICENSE_FILE environment variables. LICENSE_KEY takes precedence.
+func InitFromEnv() *License {
+	return Init(Options{
+		Token: os.Getenv("LICENSE_KEY"),
+		File:  os.Getenv("LICENSE_FILE"),
+	})
+}
+
+// Current returns the current status of the package default license. It is
+// the package-level counterpart to (*License).Status().
+func Current() Status {
+	mu.RLock()
+	defer mu.RUnlock()
+	return std.status
+}

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedNow returns a deterministic clock for tests.
+func fixedNow(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+// newTestClaims builds a claims value with the given expiry offset from base.
+func newTestClaims(base time.Time, expiryOffset time.Duration) Claims {
+	return Claims{
+		Customer: "acme-schools",
+		Tier:     "managed-pro",
+		Issued:   base,
+		Expiry:   base.Add(expiryOffset),
+	}
+}
+
+func TestVerify_ValidToken(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	claims := newTestClaims(base, 30*24*time.Hour)
+
+	token, err := Sign(claims, priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	got, err := Verify(token, pub)
+	if err != nil {
+		t.Fatalf("Verify returned error for valid token: %v", err)
+	}
+	if got.Customer != claims.Customer || got.Tier != claims.Tier {
+		t.Errorf("claims mismatch: got %+v want %+v", got, claims)
+	}
+	if !got.Expiry.Equal(claims.Expiry) {
+		t.Errorf("expiry mismatch: got %v want %v", got.Expiry, claims.Expiry)
+	}
+}
+
+func TestVerify_TamperedPayloadRejected(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	token, err := Sign(newTestClaims(base, 30*24*time.Hour), priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	// Tamper with the payload: decode, mutate tier to a higher one, re-encode.
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		t.Fatalf("unexpected token shape: %q", token)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	tampered := strings.Replace(string(payload), "managed-pro", "managed-xxl", 1)
+	if tampered == string(payload) {
+		t.Fatalf("tamper had no effect")
+	}
+	tamperedToken := base64.RawURLEncoding.EncodeToString([]byte(tampered)) + "." + parts[1]
+
+	if _, err := Verify(tamperedToken, pub); err == nil {
+		t.Fatal("Verify accepted a tampered token")
+	}
+}
+
+func TestVerify_WrongKeyRejected(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	token, err := Sign(newTestClaims(base, time.Hour), priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err := Verify(token, otherPub); err == nil {
+		t.Fatal("Verify accepted a token signed by a different key")
+	}
+}
+
+func TestVerify_MalformedRejected(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	for _, tok := range []string{"", "no-dot", "a.b.c", ".", "notbase64!.sig"} {
+		if _, err := Verify(tok, pub); err == nil {
+			t.Errorf("Verify accepted malformed token %q", tok)
+		}
+	}
+}
+
+func TestVerify_InvalidPublicKey(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	token, _ := Sign(newTestClaims(time.Now(), time.Hour), priv)
+	if _, err := Verify(token, ed25519.PublicKey([]byte("short"))); err != ErrInvalidPublicKey {
+		t.Errorf("expected ErrInvalidPublicKey, got %v", err)
+	}
+}
+
+func TestEvaluate_ModesAndGrace(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expiry := base.Add(24 * time.Hour)
+	claims := Claims{Customer: "acme", Tier: "managed-pro", Issued: base, Expiry: expiry}
+	grace := 48 * time.Hour
+
+	tests := []struct {
+		name      string
+		now       time.Time
+		wantValid bool
+		wantMode  Mode
+		wantTier  string
+	}{
+		{"before expiry", expiry.Add(-time.Hour), true, ModeLicensed, "managed-pro"},
+		{"at expiry", expiry, true, ModeLicensed, "managed-pro"},
+		{"within grace", expiry.Add(24 * time.Hour), true, ModeGrace, "managed-pro"},
+		{"just past grace", expiry.Add(grace + time.Second), false, ModeCommunity, CommunityTier},
+		{"long past grace", expiry.Add(365 * 24 * time.Hour), false, ModeCommunity, CommunityTier},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Evaluate(claims, tt.now, grace)
+			if s.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", s.Valid, tt.wantValid)
+			}
+			if s.Mode != tt.wantMode {
+				t.Errorf("Mode = %q, want %q", s.Mode, tt.wantMode)
+			}
+			if s.Tier != tt.wantTier {
+				t.Errorf("Tier = %q, want %q", s.Tier, tt.wantTier)
+			}
+		})
+	}
+}
+
+func TestLoad_ValidTokenLicensed(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	token, _ := Sign(newTestClaims(base, 30*24*time.Hour), priv)
+
+	l := Load(Options{
+		Token:     token,
+		PublicKey: pub,
+		Now:       fixedNow(base.Add(time.Hour)),
+	})
+	s := l.Status()
+	if !s.Valid || s.Mode != ModeLicensed {
+		t.Fatalf("expected licensed+valid, got %+v", s)
+	}
+	if s.Tier != "managed-pro" || s.Customer != "acme-schools" {
+		t.Errorf("unexpected claims in status: %+v", s)
+	}
+}
+
+func TestLoad_ExpiredPastGraceIsCommunity(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Expired 1 year ago, well past the default grace window.
+	token, _ := Sign(newTestClaims(base, -365*24*time.Hour), priv)
+
+	l := Load(Options{
+		Token:     token,
+		PublicKey: pub,
+		Now:       fixedNow(base),
+	})
+	s := l.Status()
+	if s.Valid || s.Mode != ModeCommunity {
+		t.Fatalf("expected community+invalid for expired-past-grace, got %+v", s)
+	}
+	if s.Tier != CommunityTier {
+		t.Errorf("expected community tier, got %q", s.Tier)
+	}
+}
+
+func TestLoad_MissingTokenIsCommunity(t *testing.T) {
+	l := Load(Options{}) // no token, no file
+	s := l.Status()
+	if s.Valid || s.Mode != ModeCommunity {
+		t.Fatalf("expected community mode with no license, got %+v", s)
+	}
+	if s.Tier != CommunityTier {
+		t.Errorf("expected community tier, got %q", s.Tier)
+	}
+}
+
+func TestLoad_TamperedTokenFallsBackToCommunity(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	token, _ := Sign(newTestClaims(base, 30*24*time.Hour), priv)
+	// Corrupt the signature segment.
+	tampered := token[:len(token)-2] + "AA"
+
+	l := Load(Options{Token: tampered, PublicKey: pub, Now: fixedNow(base)})
+	s := l.Status()
+	if s.Valid || s.Mode != ModeCommunity {
+		t.Fatalf("expected community fallback for tampered token, got %+v", s)
+	}
+}
+
+func TestLoad_FromFile(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	token, _ := Sign(newTestClaims(base, 30*24*time.Hour), priv)
+
+	dir := t.TempDir()
+	path := dir + "/license.key"
+	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+		t.Fatalf("write license file: %v", err)
+	}
+	l := Load(Options{File: path, PublicKey: pub, Now: fixedNow(base.Add(time.Hour))})
+	if s := l.Status(); !s.Valid || s.Mode != ModeLicensed {
+		t.Fatalf("expected licensed from file, got %+v", s)
+	}
+}
+
+func TestLoad_MissingFileIsCommunity(t *testing.T) {
+	l := Load(Options{File: "/nonexistent/does-not-exist.key"})
+	if s := l.Status(); s.Valid || s.Mode != ModeCommunity {
+		t.Fatalf("expected community mode for missing file, got %+v", s)
+	}
+}
+
+func TestEmbeddedPublicKeyValid(t *testing.T) {
+	pk := embeddedPublicKey()
+	if len(pk) != ed25519.PublicKeySize {
+		t.Fatalf("embedded public key has wrong size: %d", len(pk))
+	}
+}
+
+func TestPackageDefaultStatus(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	token, _ := Sign(newTestClaims(base, 30*24*time.Hour), priv)
+
+	Init(Options{Token: token, PublicKey: pub, Now: fixedNow(base.Add(time.Hour))})
+	t.Cleanup(func() { Init(Options{}) }) // reset package default to community
+
+	if s := Current(); !s.Valid || s.Mode != ModeLicensed {
+		t.Fatalf("package Current() = %+v, want licensed", s)
+	}
+}


### PR DESCRIPTION
## What

Adds a new `internal/license` package that validates signed managed-service license tokens and exposes the installation's licensing status, with a grace period after expiry.

A license token is `base64url(payloadJSON).base64url(ed25519Signature)`, where the payload carries `customer`, `tier`, `issued`, and `expiry` claims.

- `Verify(token, pubkey) (Claims, error)` — verifies the Ed25519 signature and parses claims (rejects tampered/forged/malformed tokens).
- `Evaluate(claims, now, grace) Status` — applies expiry + grace window.
- `Status` / `(*License).Status()` / package-level `Current()` — reports `{valid, tier, expiry, mode}` where mode is `community` | `licensed` | `grace`.
- `Load(Options)` / `InitFromEnv()` — reads the token from `LICENSE_KEY` or `LICENSE_FILE`.
- A placeholder Ed25519 public key is embedded and documented (overridable via `Options.PublicKey`).

## Why

The managed-service tiers need a way to unlock premium/managed features and support for paying customers, while staying friendly to the GPL-3.0 open-source build.

## How — core resolution is NEVER gated

This is a **soft gate** over premium/managed features and support only. Core DNS resolution and filtering (the data plane) are never touched. Any license problem — missing token, unreadable file, tampered signature, or expiry beyond the grace window — simply downgrades the install to **community mode** with the resolver fully functional. `Load` never fails hard; it logs a warning and returns a community-mode status.

Wiring is limited to the control plane startup (where managed features live), which logs the resolved mode. The grace period (default 14 days) keeps premium features working while a customer renews.

## Tests

`internal/license/license_test.go` generates a fresh Ed25519 keypair inside the tests (deterministic, self-contained) and covers:
- valid signed license → verifies and reports `licensed`
- tampered payload / wrong key / malformed token / short key → rejected
- expiry modes: before expiry → `licensed`, within grace → `grace`, past grace → `community`
- missing token and missing file → community mode
- tampered token via `Load` → falls back to community
- embedded public key is well-formed

`gofmt -w`, `go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)