### PR TITLE
feat: disk/SD-card health monitoring (I-071)

### DIFF
--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lopster568/phantomDNS/internal/blocklist"
 	"github.com/lopster568/phantomDNS/internal/config"
+	"github.com/lopster568/phantomDNS/internal/diskhealth"
 	"github.com/lopster568/phantomDNS/internal/dnsengine"
 	dataplanegrpc "github.com/lopster568/phantomDNS/internal/grpc/dataplane"
 	"github.com/lopster568/phantomDNS/internal/logger"
@@ -27,6 +28,13 @@ func main() {
 		dbPath = p
 	}
 	db.InitDB(dbPath)
+
+	// 1b. Disk / SD-card health monitor (best-effort, non-fatal). Watches free
+	// space and growth on the data path; expose diskMon.Status() from a
+	// health / heartbeat surface. Configured via DISK_HEALTH_INTERVAL and
+	// DISK_MIN_FREE_PERCENT.
+	diskMon := diskhealth.NewMonitorFromEnv(dbPath)
+	go diskMon.Run(context.Background())
 
 	// 2. Initialize Repositories
 	repos := repositories.NewStore(db.DB)

--- a/internal/diskhealth/diskhealth.go
+++ b/internal/diskhealth/diskhealth.go
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package diskhealth provides best-effort disk / SD-card health monitoring for
+// unattended appliances. It tracks free space (and its growth trend) on the
+// data/DB path, flags low free space or rapidly shrinking headroom, and — where
+// trivially available — surfaces flash wear information.
+//
+// The core evaluation (evaluate) is a pure function over a sampled diskStat and
+// a set of thresholds, which keeps the decision logic deterministic and easy to
+// test without requiring a real low-disk condition. A Monitor wires that pure
+// core to a periodic sampler and exposes the latest Status via a concurrency-safe
+// accessor suitable for a health / heartbeat surface.
+package diskhealth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+// ErrUnsupported is returned by the platform stat reader when free-space
+// inspection is not available (e.g. non-unix builds). It is non-fatal: the
+// Monitor logs and degrades gracefully.
+var ErrUnsupported = errors.New("diskhealth: statfs unsupported on this platform")
+
+// Reason codes for a non-OK status. They are stable strings so a health surface
+// (or tests) can switch on them.
+const (
+	ReasonOK          = ""
+	ReasonLowSpace    = "low-space"
+	ReasonRapidGrowth = "rapid-growth"
+)
+
+// Sane defaults for unattended boxes. Overridable via environment.
+const (
+	DefaultInterval             = 5 * time.Minute
+	DefaultMinFreePercent       = 10.0 // flag when free space dips below this
+	DefaultGrowthPercentPerHour = 20.0 // flag when usage grows this fast (%-of-capacity/hour)
+)
+
+// Environment variable names.
+const (
+	EnvInterval       = "DISK_HEALTH_INTERVAL"
+	EnvMinFreePercent = "DISK_MIN_FREE_PERCENT"
+)
+
+// diskStat is a single point-in-time sample of a filesystem.
+type diskStat struct {
+	Path       string
+	TotalBytes uint64 // total capacity in bytes
+	FreeBytes  uint64 // bytes available to unprivileged callers
+	SampledAt  time.Time
+}
+
+// valid reports whether the sample carries usable capacity data.
+func (d diskStat) valid() bool {
+	return d.TotalBytes > 0 && !d.SampledAt.IsZero()
+}
+
+// freePercent returns free space as a percentage of total capacity (0 when the
+// sample is empty).
+func (d diskStat) freePercent() float64 {
+	if d.TotalBytes == 0 {
+		return 0
+	}
+	return float64(d.FreeBytes) / float64(d.TotalBytes) * 100
+}
+
+// usedBytes returns bytes consumed (never underflows).
+func (d diskStat) usedBytes() uint64 {
+	if d.FreeBytes >= d.TotalBytes {
+		return 0
+	}
+	return d.TotalBytes - d.FreeBytes
+}
+
+// Thresholds configures when a sample is considered unhealthy.
+type Thresholds struct {
+	// MinFreePercent flags a status when free space falls below this percent.
+	MinFreePercent float64
+	// GrowthPercentPerHour flags a status when usage is growing faster than
+	// this many percent-of-total-capacity per hour. Zero disables the check.
+	GrowthPercentPerHour float64
+}
+
+// DefaultThresholds returns the built-in sane thresholds.
+func DefaultThresholds() Thresholds {
+	return Thresholds{
+		MinFreePercent:       DefaultMinFreePercent,
+		GrowthPercentPerHour: DefaultGrowthPercentPerHour,
+	}
+}
+
+// WearInfo is best-effort flash-wear data. It is nil when unavailable.
+type WearInfo struct {
+	Device      string // e.g. "mmcblk0"
+	LifeUsedPct int    // estimated percent of rated write life consumed
+	Source      string // where the estimate came from, e.g. "emmc-life_time"
+}
+
+// Status is the evaluated health of the monitored path. It is safe to copy and
+// is the value returned by the health / heartbeat accessor.
+type Status struct {
+	OK          bool
+	Reason      string // one of the Reason* codes; "" when OK
+	Detail      string // human-readable elaboration
+	Path        string
+	TotalBytes  uint64
+	FreeBytes   uint64
+	FreePercent float64
+	// GrowthPercentPerHour is the observed usage growth rate between the two
+	// most recent samples, or 0 when not yet computable.
+	GrowthPercentPerHour float64
+	Wear                 *WearInfo // best-effort; nil when unavailable
+	CheckedAt            time.Time
+}
+
+// growthRatePercentPerHour computes usage growth between prev and cur as a
+// percentage of total capacity per hour. It returns 0 (not computable) when
+// either sample is invalid, when no time elapsed, or when usage did not grow.
+func growthRatePercentPerHour(prev, cur diskStat) float64 {
+	if !prev.valid() || !cur.valid() || cur.TotalBytes == 0 {
+		return 0
+	}
+	elapsed := cur.SampledAt.Sub(prev.SampledAt)
+	if elapsed <= 0 {
+		return 0
+	}
+	prevUsed := prev.usedBytes()
+	curUsed := cur.usedBytes()
+	if curUsed <= prevUsed {
+		return 0
+	}
+	deltaPct := float64(curUsed-prevUsed) / float64(cur.TotalBytes) * 100
+	return deltaPct / elapsed.Hours()
+}
+
+// evaluate is the pure core: given the current sample, an optional previous
+// sample (for trend), and thresholds, it returns a Status. It performs no I/O
+// and reads no clock, so it is fully deterministic.
+//
+// Precedence: low free space is reported ahead of rapid growth, since it is the
+// more immediate failure condition.
+func evaluate(prev, cur diskStat, th Thresholds) Status {
+	freePct := cur.freePercent()
+	growth := growthRatePercentPerHour(prev, cur)
+
+	st := Status{
+		OK:                   true,
+		Reason:               ReasonOK,
+		Path:                 cur.Path,
+		TotalBytes:           cur.TotalBytes,
+		FreeBytes:            cur.FreeBytes,
+		FreePercent:          freePct,
+		GrowthPercentPerHour: growth,
+		CheckedAt:            cur.SampledAt,
+	}
+
+	switch {
+	case th.MinFreePercent > 0 && freePct < th.MinFreePercent:
+		st.OK = false
+		st.Reason = ReasonLowSpace
+		st.Detail = fmt.Sprintf("free space %.1f%% below minimum %.1f%%", freePct, th.MinFreePercent)
+	case th.GrowthPercentPerHour > 0 && growth > th.GrowthPercentPerHour:
+		st.OK = false
+		st.Reason = ReasonRapidGrowth
+		st.Detail = fmt.Sprintf("usage growing %.1f%%/hour above threshold %.1f%%/hour", growth, th.GrowthPercentPerHour)
+	default:
+		st.Detail = fmt.Sprintf("free space %.1f%% healthy", freePct)
+	}
+
+	return st
+}
+
+// LoadConfig resolves the monitor interval and thresholds from the environment,
+// falling back to sane defaults. Invalid values are ignored (with a warning)
+// rather than being treated as fatal.
+func LoadConfig() (time.Duration, Thresholds) {
+	interval := DefaultInterval
+	if v := os.Getenv(EnvInterval); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			interval = d
+		} else {
+			logger.Log.Warnf("diskhealth: invalid %s=%q, using default %s", EnvInterval, v, DefaultInterval)
+		}
+	}
+
+	th := DefaultThresholds()
+	if v := os.Getenv(EnvMinFreePercent); v != "" {
+		if p, err := strconv.ParseFloat(v, 64); err == nil && p > 0 && p < 100 {
+			th.MinFreePercent = p
+		} else {
+			logger.Log.Warnf("diskhealth: invalid %s=%q, using default %.0f", EnvMinFreePercent, v, DefaultMinFreePercent)
+		}
+	}
+
+	return interval, th
+}
+
+// Monitor periodically samples a path's free space and exposes the latest
+// evaluated Status. It is safe for concurrent use.
+type Monitor struct {
+	dir        string
+	interval   time.Duration
+	thresholds Thresholds
+
+	// injectable for testing; default to the platform implementations.
+	readStat func(string) (diskStat, error)
+	readWear func(string) *WearInfo
+
+	mu      sync.RWMutex
+	last    Status
+	prev    diskStat
+	hasPrev bool
+}
+
+// NewMonitor builds a Monitor for the directory containing dbPath. The directory
+// (not the DB file itself) is what Statfs inspects, so the monitor keeps working
+// even before the DB file exists.
+func NewMonitor(dbPath string, interval time.Duration, th Thresholds) *Monitor {
+	dir := filepath.Dir(dbPath)
+	if dir == "" {
+		dir = "."
+	}
+	return &Monitor{
+		dir:        dir,
+		interval:   interval,
+		thresholds: th,
+		readStat:   readDiskStat,
+		readWear:   readWear,
+		last: Status{
+			OK:        true,
+			Reason:    ReasonOK,
+			Detail:    "not yet sampled",
+			Path:      dir,
+			CheckedAt: time.Time{},
+		},
+	}
+}
+
+// NewMonitorFromEnv is a convenience constructor that pulls interval and
+// thresholds from the environment.
+func NewMonitorFromEnv(dbPath string) *Monitor {
+	interval, th := LoadConfig()
+	return NewMonitor(dbPath, interval, th)
+}
+
+// Status returns the most recently evaluated health status. It is the accessor a
+// health / heartbeat surface should call. Safe for concurrent use.
+func (m *Monitor) Status() Status {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.last
+}
+
+// sample takes one reading, evaluates it against the previous reading, attaches
+// best-effort wear info, and stores the result. It returns the new Status.
+func (m *Monitor) sample() Status {
+	cur, err := m.readStat(m.dir)
+	if err != nil {
+		// Degrade gracefully: keep prior status, note the sampling failure.
+		logger.Log.Warnf("diskhealth: failed to stat %s: %v", m.dir, err)
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return m.last
+	}
+
+	m.mu.Lock()
+	prev := m.prev
+	hadPrev := m.hasPrev
+	m.mu.Unlock()
+
+	var trendPrev diskStat
+	if hadPrev {
+		trendPrev = prev
+	}
+
+	st := evaluate(trendPrev, cur, m.thresholds)
+	if w := m.readWear(m.dir); w != nil {
+		st.Wear = w
+	}
+
+	m.mu.Lock()
+	m.last = st
+	m.prev = cur
+	m.hasPrev = true
+	m.mu.Unlock()
+
+	if !st.OK {
+		logger.Log.Warnf("diskhealth: %s unhealthy (%s): %s", m.dir, st.Reason, st.Detail)
+	}
+	return st
+}
+
+// Run samples immediately, then on every interval tick until ctx is cancelled.
+// It is non-fatal and intended to be launched in its own goroutine.
+func (m *Monitor) Run(ctx context.Context) {
+	if m.interval <= 0 {
+		m.interval = DefaultInterval
+	}
+
+	m.sample() // prime immediately so Status() is meaningful right away.
+
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.sample()
+		}
+	}
+}

--- a/internal/diskhealth/diskhealth_test.go
+++ b/internal/diskhealth/diskhealth_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diskhealth
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+const gib = uint64(1) << 30
+
+// base is a fixed reference time so growth math is fully deterministic.
+var base = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func mkStat(totalGiB, freeGiB uint64, at time.Time) diskStat {
+	return diskStat{
+		Path:       "/data",
+		TotalBytes: totalGiB * gib,
+		FreeBytes:  freeGiB * gib,
+		SampledAt:  at,
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	th := Thresholds{MinFreePercent: 10, GrowthPercentPerHour: 20}
+
+	tests := []struct {
+		name       string
+		prev       diskStat
+		cur        diskStat
+		th         Thresholds
+		wantOK     bool
+		wantReason string
+	}{
+		{
+			name:       "healthy: plenty free, no prev",
+			cur:        mkStat(100, 80, base),
+			th:         th,
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "healthy: exactly at min free is OK",
+			cur:        mkStat(100, 10, base), // 10% free, min is 10% -> not below
+			th:         th,
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "low space: below min, no prev",
+			cur:        mkStat(100, 5, base), // 5% free
+			th:         th,
+			wantOK:     false,
+			wantReason: ReasonLowSpace,
+		},
+		{
+			name:       "low space: just under min",
+			cur:        mkStat(1000, 99, base), // 9.9% free
+			th:         th,
+			wantOK:     false,
+			wantReason: ReasonLowSpace,
+		},
+		{
+			name:       "low space: totally full",
+			cur:        mkStat(64, 0, base),
+			th:         th,
+			wantOK:     false,
+			wantReason: ReasonLowSpace,
+		},
+		{
+			name:       "rapid growth: usage up 30%/hour, still above min free",
+			prev:       mkStat(100, 70, base),
+			cur:        mkStat(100, 40, base.Add(time.Hour)), // used 30->60, +30% in 1h
+			th:         th,
+			wantOK:     false,
+			wantReason: ReasonRapidGrowth,
+		},
+		{
+			name:       "slow growth: 10%/hour under 20 threshold is OK",
+			prev:       mkStat(100, 60, base),
+			cur:        mkStat(100, 50, base.Add(time.Hour)), // +10% in 1h
+			th:         th,
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "growth over shorter window: +5% in 15min -> 20%/hour, at threshold not over",
+			prev:       mkStat(100, 55, base),
+			cur:        mkStat(100, 50, base.Add(15*time.Minute)), // +5% in .25h = 20%/h, not > 20
+			th:         th,
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "growth over shorter window: +6% in 15min -> 24%/hour flagged",
+			prev:       mkStat(1000, 550, base),
+			cur:        mkStat(1000, 490, base.Add(15*time.Minute)), // +6% in .25h = 24%/h
+			th:         th,
+			wantOK:     false,
+			wantReason: ReasonRapidGrowth,
+		},
+		{
+			name:       "low space wins over rapid growth (precedence)",
+			prev:       mkStat(100, 40, base),
+			cur:        mkStat(100, 5, base.Add(time.Hour)), // 5% free AND +35%/h growth
+			th:         th,
+			wantOK:     false,
+			wantReason: ReasonLowSpace,
+		},
+		{
+			name:       "usage shrinking is never rapid-growth",
+			prev:       mkStat(100, 20, base),
+			cur:        mkStat(100, 80, base.Add(time.Hour)), // freed up space
+			th:         th,
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "growth check disabled when threshold is zero",
+			prev:       mkStat(100, 90, base),
+			cur:        mkStat(100, 30, base.Add(time.Hour)), // +60%/h but check off
+			th:         Thresholds{MinFreePercent: 10, GrowthPercentPerHour: 0},
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "zero elapsed time yields no growth flag",
+			prev:       mkStat(100, 80, base),
+			cur:        mkStat(100, 20, base), // same instant
+			th:         th,
+			wantOK:     true,
+			wantReason: ReasonOK,
+		},
+		{
+			name:       "min-free check disabled when threshold is zero, growth still evaluated",
+			prev:       mkStat(100, 40, base),
+			cur:        mkStat(100, 2, base.Add(time.Hour)), // 2% free but min disabled; +38%/h
+			th:         Thresholds{MinFreePercent: 0, GrowthPercentPerHour: 20},
+			wantOK:     false,
+			wantReason: ReasonRapidGrowth,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluate(tt.prev, tt.cur, tt.th)
+			if got.OK != tt.wantOK {
+				t.Errorf("OK = %v, want %v (detail: %s)", got.OK, tt.wantOK, got.Detail)
+			}
+			if got.Reason != tt.wantReason {
+				t.Errorf("Reason = %q, want %q (detail: %s)", got.Reason, tt.wantReason, got.Detail)
+			}
+			// Status must always echo the current sample's capacity data.
+			if got.TotalBytes != tt.cur.TotalBytes || got.FreeBytes != tt.cur.FreeBytes {
+				t.Errorf("capacity not echoed: got total=%d free=%d, want total=%d free=%d",
+					got.TotalBytes, got.FreeBytes, tt.cur.TotalBytes, tt.cur.FreeBytes)
+			}
+		})
+	}
+}
+
+func TestFreePercent(t *testing.T) {
+	if got := mkStat(100, 25, base).freePercent(); got != 25 {
+		t.Errorf("freePercent = %v, want 25", got)
+	}
+	// Empty sample must not divide by zero.
+	if got := (diskStat{}).freePercent(); got != 0 {
+		t.Errorf("empty freePercent = %v, want 0", got)
+	}
+}
+
+func TestUsedBytesNoUnderflow(t *testing.T) {
+	// Free exceeding total (shouldn't happen, but must not underflow).
+	s := diskStat{TotalBytes: 10, FreeBytes: 20}
+	if got := s.usedBytes(); got != 0 {
+		t.Errorf("usedBytes underflow guard failed: got %d, want 0", got)
+	}
+}
+
+func TestGrowthRateHelper(t *testing.T) {
+	// Invalid prev -> not computable.
+	if r := growthRatePercentPerHour(diskStat{}, mkStat(100, 50, base)); r != 0 {
+		t.Errorf("growth with invalid prev = %v, want 0", r)
+	}
+	// Clean 20%/hour.
+	r := growthRatePercentPerHour(mkStat(100, 70, base), mkStat(100, 50, base.Add(time.Hour)))
+	if r != 20 {
+		t.Errorf("growth = %v, want 20", r)
+	}
+}
+
+func TestLoadConfigDefaults(t *testing.T) {
+	t.Setenv(EnvInterval, "")
+	t.Setenv(EnvMinFreePercent, "")
+	interval, th := LoadConfig()
+	if interval != DefaultInterval {
+		t.Errorf("interval = %v, want %v", interval, DefaultInterval)
+	}
+	if th.MinFreePercent != DefaultMinFreePercent {
+		t.Errorf("min free = %v, want %v", th.MinFreePercent, DefaultMinFreePercent)
+	}
+}
+
+func TestLoadConfigOverrides(t *testing.T) {
+	t.Setenv(EnvInterval, "30s")
+	t.Setenv(EnvMinFreePercent, "15")
+	interval, th := LoadConfig()
+	if interval != 30*time.Second {
+		t.Errorf("interval = %v, want 30s", interval)
+	}
+	if th.MinFreePercent != 15 {
+		t.Errorf("min free = %v, want 15", th.MinFreePercent)
+	}
+}
+
+func TestLoadConfigInvalidFallsBack(t *testing.T) {
+	t.Setenv(EnvInterval, "not-a-duration")
+	t.Setenv(EnvMinFreePercent, "500") // out of (0,100)
+	interval, th := LoadConfig()
+	if interval != DefaultInterval {
+		t.Errorf("invalid interval should fall back, got %v", interval)
+	}
+	if th.MinFreePercent != DefaultMinFreePercent {
+		t.Errorf("invalid min free should fall back, got %v", th.MinFreePercent)
+	}
+}
+
+func TestMonitorSample(t *testing.T) {
+	m := NewMonitor("/data/phantomdns.db", time.Minute, Thresholds{MinFreePercent: 10, GrowthPercentPerHour: 20})
+
+	// Before sampling, Status is the neutral placeholder.
+	if !m.Status().OK {
+		t.Fatalf("initial status should be OK placeholder")
+	}
+
+	// Inject a deterministic low-space reading.
+	m.readStat = func(string) (diskStat, error) {
+		return mkStat(100, 3, base), nil
+	}
+	m.readWear = func(string) *WearInfo {
+		return &WearInfo{Device: "mmcblk0", LifeUsedPct: 40, Source: "test"}
+	}
+
+	st := m.sample()
+	if st.OK || st.Reason != ReasonLowSpace {
+		t.Fatalf("expected low-space, got OK=%v reason=%q", st.OK, st.Reason)
+	}
+	if st.Wear == nil || st.Wear.LifeUsedPct != 40 {
+		t.Fatalf("wear info not attached: %+v", st.Wear)
+	}
+	// Accessor must reflect the latest sample.
+	if got := m.Status(); got.Reason != ReasonLowSpace {
+		t.Fatalf("Status() accessor stale: %q", got.Reason)
+	}
+}
+
+func TestMonitorSampleErrorKeepsPriorStatus(t *testing.T) {
+	m := NewMonitor("/data/phantomdns.db", time.Minute, DefaultThresholds())
+
+	// First: a healthy reading.
+	m.readWear = func(string) *WearInfo { return nil }
+	m.readStat = func(string) (diskStat, error) { return mkStat(100, 90, base), nil }
+	healthy := m.sample()
+	if !healthy.OK {
+		t.Fatalf("expected healthy, got %q", healthy.Reason)
+	}
+
+	// Then: sampler errors -> prior status is retained, not overwritten.
+	m.readStat = func(string) (diskStat, error) { return diskStat{}, errors.New("boom") }
+	after := m.sample()
+	if !after.OK {
+		t.Fatalf("errored sample should retain healthy status, got %q", after.Reason)
+	}
+}
+
+func TestMonitorGrowthAcrossSamples(t *testing.T) {
+	m := NewMonitor("/data/phantomdns.db", time.Minute, Thresholds{MinFreePercent: 5, GrowthPercentPerHour: 20})
+	m.readWear = func(string) *WearInfo { return nil }
+
+	// First sample establishes a baseline (no prev -> can't flag growth).
+	m.readStat = func(string) (diskStat, error) { return mkStat(100, 70, base), nil }
+	if first := m.sample(); !first.OK {
+		t.Fatalf("first sample should be OK, got %q", first.Reason)
+	}
+
+	// Second sample an hour later with usage up 30% -> rapid growth.
+	m.readStat = func(string) (diskStat, error) { return mkStat(100, 40, base.Add(time.Hour)), nil }
+	second := m.sample()
+	if second.OK || second.Reason != ReasonRapidGrowth {
+		t.Fatalf("expected rapid-growth on second sample, got OK=%v reason=%q", second.OK, second.Reason)
+	}
+	if second.GrowthPercentPerHour != 30 {
+		t.Errorf("growth rate = %v, want 30", second.GrowthPercentPerHour)
+	}
+}

--- a/internal/diskhealth/stat_other.go
+++ b/internal/diskhealth/stat_other.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !unix
+
+package diskhealth
+
+// readDiskStat is unsupported on non-unix platforms. The Monitor treats the
+// error as non-fatal and simply keeps its prior status.
+func readDiskStat(dir string) (diskStat, error) {
+	return diskStat{}, ErrUnsupported
+}

--- a/internal/diskhealth/stat_unix.go
+++ b/internal/diskhealth/stat_unix.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build unix
+
+package diskhealth
+
+import (
+	"syscall"
+	"time"
+)
+
+// readDiskStat inspects the filesystem backing dir via syscall.Statfs and
+// returns a point-in-time capacity sample. Byte counts are derived from the
+// filesystem block size. Bavail (blocks available to unprivileged users) is used
+// for free space so the reading matches what the application can actually write.
+func readDiskStat(dir string) (diskStat, error) {
+	var fs syscall.Statfs_t
+	if err := syscall.Statfs(dir, &fs); err != nil {
+		return diskStat{}, err
+	}
+
+	// Bsize is signed on some platforms; normalise to uint64.
+	bsize := uint64(fs.Bsize)
+	total := uint64(fs.Blocks) * bsize
+	free := uint64(fs.Bavail) * bsize
+
+	return diskStat{
+		Path:       dir,
+		TotalBytes: total,
+		FreeBytes:  free,
+		SampledAt:  time.Now(),
+	}, nil
+}

--- a/internal/diskhealth/wear_linux.go
+++ b/internal/diskhealth/wear_linux.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build linux
+
+package diskhealth
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// wearGlob points at eMMC/SD life-time estimation exposed by the MMC subsystem.
+// Overridable in tests. The kernel exposes one or two hex "life time" values
+// (JEDEC eMMC 5.0 DEVICE_LIFE_TIME_EST_TYP_A/B): 0x01 => 0-10% of rated write
+// life consumed, 0x0A => 90-100%, 0x0B => exceeded.
+var wearGlob = "/sys/block/mmcblk*/device/life_time"
+
+// readWear makes a best-effort attempt to read flash wear for an eMMC/SD device.
+// It returns nil (not an error) whenever the information is unavailable, so
+// callers degrade gracefully on plain disks or where sysfs lacks the attribute.
+func readWear(_ string) *WearInfo {
+	matches, err := filepath.Glob(wearGlob)
+	if err != nil || len(matches) == 0 {
+		return nil
+	}
+
+	for _, path := range matches {
+		// #nosec G304 -- path comes from globbing a fixed sysfs prefix, not user input.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		pct, ok := parseLifeTime(string(data))
+		if !ok {
+			continue
+		}
+		// path is .../mmcblkX/device/life_time; device name is 3 dirs up.
+		dev := filepath.Base(filepath.Dir(filepath.Dir(path)))
+		return &WearInfo{
+			Device:      dev,
+			LifeUsedPct: pct,
+			Source:      "emmc-life_time",
+		}
+	}
+	return nil
+}
+
+// parseLifeTime turns a "0x01 0x02" life-time line into an estimated percent of
+// rated write life consumed, using the higher (worse) of the reported values.
+func parseLifeTime(s string) (int, bool) {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return 0, false
+	}
+	worst := -1
+	for _, f := range fields {
+		v, err := strconv.ParseInt(strings.TrimPrefix(strings.TrimPrefix(f, "0x"), "0X"), 16, 32)
+		if err != nil {
+			continue
+		}
+		if v <= 0 {
+			continue // 0x00 means "not defined"
+		}
+		var pct int
+		if v >= 0x0B {
+			pct = 100 // exceeded estimated life
+		} else {
+			pct = int(v-1) * 10 // 0x01 => 0%, 0x0A => 90%
+		}
+		if pct > worst {
+			worst = pct
+		}
+	}
+	if worst < 0 {
+		return 0, false
+	}
+	return worst, true
+}

--- a/internal/diskhealth/wear_linux_test.go
+++ b/internal/diskhealth/wear_linux_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build linux
+
+package diskhealth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseLifeTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantPct int
+		wantOK  bool
+	}{
+		{"fresh card", "0x01 0x01\n", 0, true},
+		{"half worn", "0x06 0x06\n", 50, true},
+		{"worst of two wins", "0x02 0x07\n", 60, true},
+		{"exceeded life", "0x0B 0x0B\n", 100, true},
+		{"undefined values", "0x00 0x00\n", 0, false},
+		{"single value", "0x0A\n", 90, true},
+		{"garbage", "not-hex\n", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pct, ok := parseLifeTime(tt.in)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && pct != tt.wantPct {
+				t.Errorf("pct = %d, want %d", pct, tt.wantPct)
+			}
+		})
+	}
+}
+
+func TestReadWearFromSysfsFixture(t *testing.T) {
+	// Build a fake sysfs tree: <root>/mmcblk0/device/life_time
+	root := t.TempDir()
+	devDir := filepath.Join(root, "mmcblk0", "device")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "life_time"), []byte("0x03 0x03\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := wearGlob
+	wearGlob = filepath.Join(root, "mmcblk*", "device", "life_time")
+	defer func() { wearGlob = orig }()
+
+	w := readWear("/data")
+	if w == nil {
+		t.Fatal("expected wear info, got nil")
+	}
+	if w.Device != "mmcblk0" {
+		t.Errorf("device = %q, want mmcblk0", w.Device)
+	}
+	if w.LifeUsedPct != 20 {
+		t.Errorf("life used = %d, want 20", w.LifeUsedPct)
+	}
+}
+
+func TestReadWearNoDevice(t *testing.T) {
+	orig := wearGlob
+	wearGlob = filepath.Join(t.TempDir(), "nope*", "life_time")
+	defer func() { wearGlob = orig }()
+
+	if w := readWear("/data"); w != nil {
+		t.Errorf("expected nil wear when no device, got %+v", w)
+	}
+}

--- a/internal/diskhealth/wear_other.go
+++ b/internal/diskhealth/wear_other.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !linux
+
+package diskhealth
+
+// readWear reports no wear information on non-Linux platforms. Wear/SMART is
+// best-effort only, so nil is the expected graceful-degradation result.
+func readWear(_ string) *WearInfo {
+	return nil
+}


### PR DESCRIPTION
## What

Adds `internal/diskhealth`: best-effort SD-card/disk health and free-space monitoring for unattended appliances. It tracks free space and its growth trend on the DB/data path, flags low free space or rapidly shrinking headroom, and surfaces flash wear where trivially available. A concurrency-safe `Status()` accessor makes the result consumable from a health/heartbeat surface.

## Why

Unattended boxes (SD-card/eMMC backed) silently fill up or wear out. A DB that can no longer write is a hard outage with no warning. This gives an early, non-fatal signal (low-space / rapid-growth / wear) that a heartbeat surface can expose before the box falls over.

## How

- **Pure core**: `evaluate(prev, cur diskStat, th Thresholds) Status` — no I/O, no clock, fully deterministic. Precedence: `low-space` reported ahead of `rapid-growth`. Growth is measured as percent-of-capacity per hour between the two most recent samples; usage shrinking never flags.
- **Sampler**: `Monitor` reads free space via `syscall.Statfs` on the DB directory (unix build; graceful `ErrUnsupported` fallback elsewhere), evaluates against the previous sample, and stores the latest `Status`. Runs immediately then on `DISK_HEALTH_INTERVAL`; `Run(ctx)` is non-fatal and logs warnings only.
- **Wear**: best-effort eMMC/SD `life_time` from sysfs on Linux, `nil` (graceful) everywhere else.
- **Config**: `DISK_HEALTH_INTERVAL` (default 5m) and `DISK_MIN_FREE_PERCENT` (default 10%), with a sane growth threshold; invalid values warn and fall back.
- Wired into the dataplane non-fatally next to DB init.

## Tests

- Heavy table over the pure `evaluate`: healthy passes, low-space flagged (incl. at/just-under threshold, full disk), rapid-growth threshold (over/under/at, short windows), precedence, shrinking usage, disabled checks, zero-elapsed.
- `LoadConfig` defaults/overrides/invalid-fallback; `Monitor` sampling with injected readers (deterministic, no real low-disk needed), error-retains-prior-status, growth across samples, wear attachment.
- Linux-only sysfs fixture test for the `life_time` parser.
- `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green; cross-compiles for windows/darwin.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)