### PR TITLE
feat: offline-first bundled blocklist seed (I-080)

### DIFF
--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lopster568/phantomDNS/internal/blocklist"
+	"github.com/lopster568/phantomDNS/internal/blocklist/bundle"
 	"github.com/lopster568/phantomDNS/internal/config"
 	"github.com/lopster568/phantomDNS/internal/diskhealth"
 	"github.com/lopster568/phantomDNS/internal/dnsengine"
@@ -45,6 +46,23 @@ func main() {
 
 	// 3. Blocklist Engine — load from DB sources, refresh periodically
 	blEngine := blocklist.NewEngine(repos.Blocklist)
+
+	// Offline-first: seed the checker from the embedded bundle when the DB has
+	// no blocklist snapshot yet, so the dataplane blocks well-known ad/malware
+	// domains immediately on first boot with no internet. This runs before the
+	// DNS server starts and only fires when nothing has ever been loaded; it
+	// never overwrites data fetched by the online refresh below.
+	if config.BundledBlocklistEnabled() {
+		if seeded, err := bundle.SeedIfEmpty(repos.Blocklist); err != nil {
+			logger.Log.Warnf("Bundled blocklist seed failed: %v", err)
+		} else if seeded {
+			logger.Log.Info("Seeded blocklist from embedded offline bundle (no snapshot present)")
+		} else {
+			logger.Log.Info("Bundled blocklist seed skipped (blocklist snapshot already present)")
+		}
+	} else {
+		logger.Log.Info("Bundled blocklist seeding disabled via BUNDLED_BLOCKLIST")
+	}
 
 	// Initial load in background so DNS starts immediately
 	go func() {

--- a/internal/blocklist/bundle/bundle.go
+++ b/internal/blocklist/bundle/bundle.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package bundle provides an offline-first default blocklist that is embedded
+// directly into the dataplane binary. It lets DNS filtering work from the very
+// first boot with no internet connectivity: on startup, if the database has no
+// blocklist snapshot yet, the dataplane seeds itself from this bundle so the
+// checker blocks immediately. The normal periodic refresh then augments/replaces
+// coverage from the configured upstream sources once the device is online.
+package bundle
+
+import (
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"errors"
+
+	"github.com/lopster568/phantomDNS/internal/blocklist/parser"
+)
+
+// Format is the on-disk format of the embedded bundle and the parser used to
+// decode it. It is intentionally the same "hosts" format the online sources use
+// so the exact same parser handles both paths.
+const Format = "hosts"
+
+//go:embed default_hosts.txt
+var content embed.FS
+
+const bundleFile = "default_hosts.txt"
+
+// Raw returns the raw bytes of the embedded bundle.
+func Raw() ([]byte, error) {
+	return content.ReadFile(bundleFile)
+}
+
+// Checksum returns a stable hex SHA-256 of the embedded bundle. It is used as
+// the snapshot checksum when seeding so a re-seed of identical content is
+// recognisable and deterministic.
+func Checksum() (string, error) {
+	raw, err := Raw()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// Load parses the embedded bundle using the registered hosts parser and returns
+// the parsed entries. It reuses the exact same parser as the online fetch path,
+// so bundled and fetched data are normalised identically.
+func Load() ([]parser.ParsedEntry, error) {
+	p, ok := parser.Get(Format)
+	if !ok {
+		return nil, errors.New("bundle: hosts parser not registered")
+	}
+	raw, err := Raw()
+	if err != nil {
+		return nil, err
+	}
+	return p.Parse(raw)
+}
+
+// Domains parses the embedded bundle and returns just the normalised domain
+// strings. Provided as a convenience for callers/tests that do not need the
+// full ParsedEntry.
+func Domains() ([]string, error) {
+	entries, err := Load()
+	if err != nil {
+		return nil, err
+	}
+	domains := make([]string, len(entries))
+	for i, e := range entries {
+		domains[i] = e.Domain
+	}
+	return domains, nil
+}

--- a/internal/blocklist/bundle/bundle_test.go
+++ b/internal/blocklist/bundle/bundle_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package bundle
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoad_ParsesEmbeddedBundle(t *testing.T) {
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(entries) < 100 {
+		t.Fatalf("expected a substantial bundle (>=100 domains), got %d", len(entries))
+	}
+
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		d := e.Domain
+		if d == "" {
+			t.Errorf("empty domain in bundle")
+		}
+		// Parser must have normalised: lowercase, no trailing dot, no IP prefix.
+		if d != strings.ToLower(d) {
+			t.Errorf("domain %q is not lowercased", d)
+		}
+		if strings.HasSuffix(d, ".") {
+			t.Errorf("domain %q has trailing dot", d)
+		}
+		if strings.ContainsAny(d, " \t") {
+			t.Errorf("domain %q contains whitespace (bad parse)", d)
+		}
+		if strings.HasPrefix(d, "0.0.0.0") || strings.HasPrefix(d, "127.0.0.1") {
+			t.Errorf("domain %q still carries an IP prefix", d)
+		}
+		if seen[d] {
+			t.Errorf("duplicate domain in bundle: %q", d)
+		}
+		seen[d] = true
+	}
+
+	// A few well-known entries that must be present in any sane default seed.
+	mustContain := []string{
+		"doubleclick.net",
+		"google-analytics.com",
+		"googlesyndication.com",
+		"criteo.com",
+		"coinhive.com",
+	}
+	for _, d := range mustContain {
+		if !seen[d] {
+			t.Errorf("expected bundle to contain %q", d)
+		}
+	}
+}
+
+func TestDomains_MatchesLoad(t *testing.T) {
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	domains, err := Domains()
+	if err != nil {
+		t.Fatalf("Domains() error: %v", err)
+	}
+	if len(domains) != len(entries) {
+		t.Fatalf("Domains() len %d != Load() len %d", len(domains), len(entries))
+	}
+	for i := range entries {
+		if domains[i] != entries[i].Domain {
+			t.Errorf("Domains()[%d]=%q != Load()[%d].Domain=%q", i, domains[i], i, entries[i].Domain)
+		}
+	}
+}
+
+func TestChecksum_StableAndNonEmpty(t *testing.T) {
+	c1, err := Checksum()
+	if err != nil {
+		t.Fatalf("Checksum() error: %v", err)
+	}
+	if len(c1) != 64 { // hex SHA-256
+		t.Fatalf("expected 64-char hex checksum, got %d chars", len(c1))
+	}
+	c2, _ := Checksum()
+	if c1 != c2 {
+		t.Errorf("Checksum() not stable: %q != %q", c1, c2)
+	}
+}

--- a/internal/blocklist/bundle/default_hosts.txt
+++ b/internal/blocklist/bundle/default_hosts.txt
@@ -1,0 +1,215 @@
+# PhantomDNS / HydraDNS bundled offline blocklist seed
+# ----------------------------------------------------
+# This is a small, curated, well-known list of ad/tracker/malware domains
+# embedded in the dataplane binary so that filtering works from the very
+# first boot with no internet connectivity. It is intentionally modest and
+# is only a SEED: the normal periodic refresh replaces coverage with the
+# configured upstream sources once the device is online.
+#
+# Format: standard hosts (0.0.0.0 <domain>). One domain per line.
+# License note: these are widely-published, well-known advertising and
+# telemetry endpoints; the list is a small hand-picked default, not a
+# redistribution of any single upstream blocklist.
+
+# --- Ad serving / exchanges ---
+0.0.0.0 doubleclick.net
+0.0.0.0 ad.doubleclick.net
+0.0.0.0 static.doubleclick.net
+0.0.0.0 googleadservices.com
+0.0.0.0 pagead2.googlesyndication.com
+0.0.0.0 googlesyndication.com
+0.0.0.0 partner.googleadservices.com
+0.0.0.0 pubads.g.doubleclick.net
+0.0.0.0 securepubads.g.doubleclick.net
+0.0.0.0 adservice.google.com
+0.0.0.0 ads.google.com
+0.0.0.0 adnxs.com
+0.0.0.0 ib.adnxs.com
+0.0.0.0 secure.adnxs.com
+0.0.0.0 rubiconproject.com
+0.0.0.0 fastlane.rubiconproject.com
+0.0.0.0 pubmatic.com
+0.0.0.0 ads.pubmatic.com
+0.0.0.0 openx.net
+0.0.0.0 us-u.openx.net
+0.0.0.0 casalemedia.com
+0.0.0.0 contextweb.com
+0.0.0.0 33across.com
+0.0.0.0 adform.net
+0.0.0.0 adform.com
+0.0.0.0 smartadserver.com
+0.0.0.0 sascdn.com
+0.0.0.0 criteo.com
+0.0.0.0 criteo.net
+0.0.0.0 static.criteo.net
+0.0.0.0 bidswitch.net
+0.0.0.0 taboola.com
+0.0.0.0 cdn.taboola.com
+0.0.0.0 trc.taboola.com
+0.0.0.0 outbrain.com
+0.0.0.0 widgets.outbrain.com
+0.0.0.0 mgid.com
+0.0.0.0 servicer.mgid.com
+0.0.0.0 revcontent.com
+0.0.0.0 media.net
+0.0.0.0 adsystem.com
+0.0.0.0 amazon-adsystem.com
+0.0.0.0 aax.amazon-adsystem.com
+0.0.0.0 s.amazon-adsystem.com
+0.0.0.0 advertising.com
+0.0.0.0 adtechus.com
+0.0.0.0 adtech.de
+0.0.0.0 yieldmo.com
+0.0.0.0 sharethrough.com
+0.0.0.0 gumgum.com
+0.0.0.0 teads.tv
+0.0.0.0 a.teads.tv
+0.0.0.0 spotxchange.com
+0.0.0.0 spotx.tv
+0.0.0.0 indexww.com
+0.0.0.0 casalemedia.net
+0.0.0.0 3lift.com
+0.0.0.0 adcolony.com
+0.0.0.0 applovin.com
+0.0.0.0 unityads.unity3d.com
+0.0.0.0 vungle.com
+0.0.0.0 inmobi.com
+0.0.0.0 chartboost.com
+0.0.0.0 mopub.com
+0.0.0.0 adsrvr.org
+0.0.0.0 zemanta.com
+0.0.0.0 quantserve.com
+0.0.0.0 quantcount.com
+0.0.0.0 exponential.com
+0.0.0.0 tribalfusion.com
+0.0.0.0 undertone.com
+0.0.0.0 districtm.io
+0.0.0.0 gammaplatform.com
+
+# --- Analytics / telemetry / tracking ---
+0.0.0.0 google-analytics.com
+0.0.0.0 www.google-analytics.com
+0.0.0.0 ssl.google-analytics.com
+0.0.0.0 analytics.google.com
+0.0.0.0 googletagmanager.com
+0.0.0.0 googletagservices.com
+0.0.0.0 www.googletagservices.com
+0.0.0.0 stats.g.doubleclick.net
+0.0.0.0 app-measurement.com
+0.0.0.0 crashlytics.com
+0.0.0.0 settings.crashlytics.com
+0.0.0.0 firebase-settings.crashlytics.com
+0.0.0.0 mixpanel.com
+0.0.0.0 api.mixpanel.com
+0.0.0.0 segment.com
+0.0.0.0 api.segment.io
+0.0.0.0 cdn.segment.com
+0.0.0.0 amplitude.com
+0.0.0.0 api.amplitude.com
+0.0.0.0 hotjar.com
+0.0.0.0 static.hotjar.com
+0.0.0.0 script.hotjar.com
+0.0.0.0 fullstory.com
+0.0.0.0 rs.fullstory.com
+0.0.0.0 mouseflow.com
+0.0.0.0 crazyegg.com
+0.0.0.0 scorecardresearch.com
+0.0.0.0 sb.scorecardresearch.com
+0.0.0.0 chartbeat.com
+0.0.0.0 static.chartbeat.com
+0.0.0.0 newrelic.com
+0.0.0.0 bam.nr-data.net
+0.0.0.0 js-agent.newrelic.com
+0.0.0.0 nr-data.net
+0.0.0.0 branch.io
+0.0.0.0 app.link
+0.0.0.0 adjust.com
+0.0.0.0 app.adjust.com
+0.0.0.0 appsflyer.com
+0.0.0.0 t.appsflyer.com
+0.0.0.0 kochava.com
+0.0.0.0 bugsnag.com
+0.0.0.0 sessions.bugsnag.com
+0.0.0.0 sentry.io
+0.0.0.0 optimizely.com
+0.0.0.0 logx.optimizely.com
+0.0.0.0 heap.io
+0.0.0.0 heapanalytics.com
+0.0.0.0 cdn.heapanalytics.com
+0.0.0.0 matomo.cloud
+0.0.0.0 clarity.ms
+0.0.0.0 c.clarity.ms
+0.0.0.0 track.hubspot.com
+0.0.0.0 stats.wp.com
+0.0.0.0 pixel.wp.com
+0.0.0.0 metrics.apple.com
+0.0.0.0 supersonicads.com
+0.0.0.0 flurry.com
+0.0.0.0 data.flurry.com
+0.0.0.0 cdn.flurry.com
+
+# --- Social / cross-site trackers ---
+0.0.0.0 connect.facebook.net
+0.0.0.0 an.facebook.com
+0.0.0.0 pixel.facebook.com
+0.0.0.0 analytics.twitter.com
+0.0.0.0 ads-twitter.com
+0.0.0.0 static.ads-twitter.com
+0.0.0.0 t.co
+0.0.0.0 ads.linkedin.com
+0.0.0.0 px.ads.linkedin.com
+0.0.0.0 analytics.tiktok.com
+0.0.0.0 ads.tiktok.com
+0.0.0.0 business-api.tiktok.com
+0.0.0.0 ads.pinterest.com
+0.0.0.0 log.pinterest.com
+0.0.0.0 ads.yahoo.com
+0.0.0.0 analytics.yahoo.com
+0.0.0.0 ads.reddit.com
+0.0.0.0 events.redditmedia.com
+0.0.0.0 snap.com
+0.0.0.0 tr.snapchat.com
+0.0.0.0 sc-static.net
+
+# --- Malware / phishing / scam (well-known bad TLD parkers & C2 patterns) ---
+0.0.0.0 malwaredomainlist.com
+0.0.0.0 malware.wicar.org
+0.0.0.0 secure-login-verify.com
+0.0.0.0 account-verify-secure.com
+0.0.0.0 free-gift-card-winner.com
+0.0.0.0 your-device-has-virus.com
+0.0.0.0 tech-support-alert.com
+0.0.0.0 fast-download-now.net
+0.0.0.0 clickhere-forprize.com
+0.0.0.0 coin-miner-pool.net
+0.0.0.0 coinhive.com
+0.0.0.0 coin-hive.com
+0.0.0.0 cryptoloot.pro
+0.0.0.0 crypto-loot.com
+0.0.0.0 webminepool.com
+0.0.0.0 minero.cc
+0.0.0.0 authedmine.com
+0.0.0.0 jsecoin.com
+0.0.0.0 miner.pr0gramm.com
+0.0.0.0 coinimp.com
+0.0.0.0 www.coinimp.com
+
+# --- Misc telemetry / notification spam / push-ad networks ---
+0.0.0.0 onesignal.com
+0.0.0.0 cdn.onesignal.com
+0.0.0.0 pushcrew.com
+0.0.0.0 pushengage.com
+0.0.0.0 izooto.com
+0.0.0.0 propellerads.com
+0.0.0.0 propu.sh
+0.0.0.0 propellerpops.com
+0.0.0.0 popads.net
+0.0.0.0 popcash.net
+0.0.0.0 adcash.com
+0.0.0.0 admaven.com
+0.0.0.0 hilltopads.net
+0.0.0.0 clickadu.com
+0.0.0.0 exoclick.com
+0.0.0.0 juicyads.com
+0.0.0.0 trafficjunky.net
+0.0.0.0 trafficfactory.biz

--- a/internal/blocklist/bundle/seed.go
+++ b/internal/blocklist/bundle/seed.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package bundle
+
+import (
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+)
+
+const (
+	// SourceID is the synthetic source ID under which the embedded bundle is
+	// persisted when seeded. It is disabled and has no URL so the periodic
+	// refresh never attempts to fetch it.
+	SourceID = "bundled-default"
+	// SourceName is a human-readable name for the seeded source.
+	SourceName = "Bundled Offline Default"
+	// Category groups the seeded entries.
+	Category = "default"
+)
+
+// SeedIfEmpty seeds the blocklist repository from the embedded offline bundle,
+// but only when no blocklist snapshot exists yet. This makes filtering work
+// from the first boot with no internet, while guaranteeing it never overwrites
+// data that was already fetched from an online source: as soon as ANY snapshot
+// exists (bundled or fetched, current or historical) seeding is skipped.
+//
+// It returns true when it actually seeded, false when it was skipped because a
+// snapshot already existed.
+func SeedIfEmpty(repo repositories.BlocklistRepository) (bool, error) {
+	n, err := repo.CountSnapshots()
+	if err != nil {
+		return false, err
+	}
+	if n > 0 {
+		// A snapshot already exists — either a prior bundled seed or real
+		// fetched data. Never overwrite it.
+		return false, nil
+	}
+
+	entries, err := Load()
+	if err != nil {
+		return false, err
+	}
+
+	checksum, err := Checksum()
+	if err != nil {
+		return false, err
+	}
+
+	now := time.Now()
+	src := models.BlocklistSource{
+		ID:        SourceID,
+		Name:      SourceName,
+		URL:       "", // embedded — nothing to fetch
+		Format:    Format,
+		Category:  Category,
+		Enabled:   false, // keep the periodic refresher from touching it
+		Priority:  0,
+		CreatedAt: now,
+	}
+
+	modelEntries := make([]models.BlocklistEntry, len(entries))
+	for i, e := range entries {
+		modelEntries[i] = models.BlocklistEntry{
+			Domain:    e.Domain,
+			SourceID:  SourceID,
+			Category:  Category,
+			CreatedAt: now,
+		}
+	}
+
+	if _, err := repo.SaveSnapshotWithEntries(src, checksum, modelEntries); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/blocklist/bundle/seed_test.go
+++ b/internal/blocklist/bundle/seed_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package bundle
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+)
+
+// mockBlocklistRepo is a deterministic in-memory stand-in for
+// repositories.BlocklistRepository. Only the methods the seeder touches carry
+// behaviour; the rest satisfy the interface.
+type mockBlocklistRepo struct {
+	snapshotCount int64
+	countErr      error
+	saveErr       error
+
+	saveCalls    int
+	savedSource  models.BlocklistSource
+	savedEntries []models.BlocklistEntry
+}
+
+var _ repositories.BlocklistRepository = (*mockBlocklistRepo)(nil)
+
+func (m *mockBlocklistRepo) CountSnapshots() (int64, error) {
+	return m.snapshotCount, m.countErr
+}
+
+func (m *mockBlocklistRepo) SaveSnapshotWithEntries(src models.BlocklistSource, checksum string, entries []models.BlocklistEntry) (models.BlocklistSnapshot, error) {
+	m.saveCalls++
+	m.savedSource = src
+	m.savedEntries = entries
+	if m.saveErr != nil {
+		return models.BlocklistSnapshot{}, m.saveErr
+	}
+	m.snapshotCount++
+	return models.BlocklistSnapshot{ID: uint(m.snapshotCount), SourceID: src.ID, Size: len(entries), Checksum: checksum}, nil
+}
+
+// --- unused interface methods ---
+func (m *mockBlocklistRepo) GetAll() ([]string, error)                      { return nil, nil }
+func (m *mockBlocklistRepo) IsBlocked(string) (bool, error)                 { return false, nil }
+func (m *mockBlocklistRepo) ListSources() ([]models.BlocklistSource, error) { return nil, nil }
+func (m *mockBlocklistRepo) GetSource(string) (*models.BlocklistSource, error) {
+	return nil, nil
+}
+func (m *mockBlocklistRepo) CreateSource(*models.BlocklistSource) error { return nil }
+func (m *mockBlocklistRepo) DeleteSource(string) error                  { return nil }
+func (m *mockBlocklistRepo) CountEntriesBySource(string) (int64, error) {
+	return 0, nil
+}
+func (m *mockBlocklistRepo) CountEntriesGroupedBySource() (map[string]int64, error) {
+	return nil, nil
+}
+func (m *mockBlocklistRepo) GetRecentSnapshots(sourceID string, limit int) ([]models.BlocklistSnapshot, error) {
+	return nil, nil
+}
+
+func TestSeedIfEmpty_SeedsWhenNoSnapshot(t *testing.T) {
+	repo := &mockBlocklistRepo{snapshotCount: 0}
+
+	seeded, err := SeedIfEmpty(repo)
+	if err != nil {
+		t.Fatalf("SeedIfEmpty() error: %v", err)
+	}
+	if !seeded {
+		t.Fatal("expected seeded=true when DB has no snapshot")
+	}
+	if repo.saveCalls != 1 {
+		t.Fatalf("expected exactly 1 save call, got %d", repo.saveCalls)
+	}
+
+	// The synthetic source must be disabled and URL-less so the periodic
+	// refresher never tries to fetch it.
+	if repo.savedSource.ID != SourceID {
+		t.Errorf("saved source ID = %q, want %q", repo.savedSource.ID, SourceID)
+	}
+	if repo.savedSource.Enabled {
+		t.Error("bundled source must be Enabled=false")
+	}
+	if repo.savedSource.URL != "" {
+		t.Errorf("bundled source URL must be empty, got %q", repo.savedSource.URL)
+	}
+
+	// Entries must match the parsed bundle exactly, all tagged to the source.
+	want, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repo.savedEntries) != len(want) {
+		t.Fatalf("saved %d entries, want %d", len(repo.savedEntries), len(want))
+	}
+	for i, e := range repo.savedEntries {
+		if e.Domain != want[i].Domain {
+			t.Errorf("entry[%d] domain = %q, want %q", i, e.Domain, want[i].Domain)
+		}
+		if e.SourceID != SourceID {
+			t.Errorf("entry[%d] SourceID = %q, want %q", i, e.SourceID, SourceID)
+		}
+	}
+}
+
+func TestSeedIfEmpty_SkipsWhenSnapshotExists(t *testing.T) {
+	repo := &mockBlocklistRepo{snapshotCount: 3} // fetched data already present
+
+	seeded, err := SeedIfEmpty(repo)
+	if err != nil {
+		t.Fatalf("SeedIfEmpty() error: %v", err)
+	}
+	if seeded {
+		t.Fatal("expected seeded=false when a snapshot already exists")
+	}
+	if repo.saveCalls != 0 {
+		t.Errorf("expected no save calls when snapshot exists, got %d", repo.saveCalls)
+	}
+}
+
+func TestSeedIfEmpty_IdempotentAcrossBoots(t *testing.T) {
+	repo := &mockBlocklistRepo{snapshotCount: 0}
+
+	// First boot: seeds.
+	if seeded, err := SeedIfEmpty(repo); err != nil || !seeded {
+		t.Fatalf("first SeedIfEmpty() = (%v, %v), want (true, nil)", seeded, err)
+	}
+	// Second boot: the seed created a snapshot, so it must skip and not
+	// overwrite the previously seeded/fetched data.
+	seeded, err := SeedIfEmpty(repo)
+	if err != nil {
+		t.Fatalf("second SeedIfEmpty() error: %v", err)
+	}
+	if seeded {
+		t.Error("expected second boot to skip seeding")
+	}
+	if repo.saveCalls != 1 {
+		t.Errorf("expected exactly 1 total save across two boots, got %d", repo.saveCalls)
+	}
+}
+
+func TestSeedIfEmpty_PropagatesCountError(t *testing.T) {
+	repo := &mockBlocklistRepo{countErr: errors.New("db down")}
+
+	if _, err := SeedIfEmpty(repo); err == nil {
+		t.Error("expected error to propagate from CountSnapshots")
+	}
+	if repo.saveCalls != 0 {
+		t.Errorf("must not save when snapshot count is unknown, got %d save calls", repo.saveCalls)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -315,3 +315,20 @@ func configPath() string {
 	}
 	return "/app/configs/config.yaml"
 }
+
+// BundledBlocklistEnabled reports whether the embedded offline blocklist should
+// seed the DB on first boot. It is ON by default and can be disabled by setting
+// BUNDLED_BLOCKLIST to a falsey value (e.g. "false", "0"). An unset or
+// unparseable value keeps the default-on behaviour.
+func BundledBlocklistEnabled() bool {
+	v := os.Getenv("BUNDLED_BLOCKLIST")
+	if v == "" {
+		return true
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		logger.Log.Warnf("invalid BUNDLED_BLOCKLIST value %q; defaulting to enabled", v)
+		return true
+	}
+	return enabled
+}

--- a/internal/storage/repositories/blocklist.go
+++ b/internal/storage/repositories/blocklist.go
@@ -14,6 +14,7 @@ type BlocklistRepository interface {
 	SaveSnapshotWithEntries(src models.BlocklistSource, checksum string, entries []models.BlocklistEntry) (models.BlocklistSnapshot, error)
 	GetAll() ([]string, error)
 	IsBlocked(domain string) (bool, error)
+	CountSnapshots() (int64, error)
 	ListSources() ([]models.BlocklistSource, error)
 	GetSource(id string) (*models.BlocklistSource, error)
 	CreateSource(src *models.BlocklistSource) error
@@ -59,6 +60,15 @@ func (r *BlocklistRepo) GetAll() ([]string, error) {
 		return nil, err
 	}
 	return domains, nil
+}
+
+// CountSnapshots returns the total number of blocklist snapshots persisted.
+// It is used to decide whether the offline bundle should seed the DB: a count
+// of zero means no blocklist data has ever been loaded (bundled or fetched).
+func (r *BlocklistRepo) CountSnapshots() (int64, error) {
+	var count int64
+	err := r.db.Model(&models.BlocklistSnapshot{}).Count(&count).Error
+	return count, err
 }
 
 func (r *BlocklistRepo) SaveSnapshotWithEntries(src models.BlocklistSource, checksum string, entries []models.BlocklistEntry) (models.BlocklistSnapshot, error) {

--- a/internal/storage/repositories/repositories_test.go
+++ b/internal/storage/repositories/repositories_test.go
@@ -175,6 +175,34 @@ func TestBlocklistRepo_GetRecentSnapshots(t *testing.T) {
 	}
 }
 
+func TestBlocklistRepo_CountSnapshots(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewBlocklistRepo(db)
+
+	// Fresh DB — no snapshots yet (drives the offline bundle seed decision).
+	n, err := repo.CountSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 snapshots on fresh DB, got %d", n)
+	}
+
+	src := models.BlocklistSource{ID: "src1", Name: "Test", URL: "http://x", Format: "hosts", Enabled: true, CreatedAt: time.Now()}
+	db.Create(&src)
+	if _, err := repo.SaveSnapshotWithEntries(src, "hash", []models.BlocklistEntry{{Domain: "a.com", SourceID: "src1"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err = repo.CountSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 snapshot after save, got %d", n)
+	}
+}
+
 func TestBlocklistRepo_GetAll_Empty(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewBlocklistRepo(db)


### PR DESCRIPTION
## What
Adds an offline-first default blocklist that is **embedded into the dataplane binary** (`go:embed`) and seeds the checker on first boot, so DNS filtering works from the very first boot with **no internet connectivity**.

- New package `internal/blocklist/bundle`:
  - `default_hosts.txt` — a modest, hand-curated seed of ~193 well-known ad / tracker / telemetry / cryptojacking domains in standard hosts format. Clearly labelled as a seed, not a redistribution of any single upstream list.
  - `bundle.go` — `//go:embed` + a loader that parses the bundle through the **existing** `parser.Get("hosts")` path, so bundled and fetched data are normalised identically. Also exposes `Domains()` and a stable `Checksum()`.
  - `seed.go` — `SeedIfEmpty(repo)`: seeds a snapshot from the bundle **only when no blocklist snapshot exists**, persisted under a synthetic disabled, URL-less source (`bundled-default`) so the periodic refresher never tries to fetch it.
- `internal/storage/repositories`: new `CountSnapshots()` on `BlocklistRepository` (interface + gorm impl) to drive the seed decision.
- `cmd/dataplane/main.go`: seeds synchronously at startup (before the DNS server accepts queries) when enabled.
- `internal/config`: `BundledBlocklistEnabled()` — reads env `BUNDLED_BLOCKLIST`, **default ON**, disable with `BUNDLED_BLOCKLIST=false`.

## Why
On a fresh appliance with no upstream reachable yet, the dataplane previously served zero blocks until the first 6h refresh succeeded. Seeding from an embedded bundle closes that first-boot gap so well-known ad/malware domains are blocked immediately.

## How
On startup, if `BUNDLED_BLOCKLIST` is enabled and `CountSnapshots() == 0`, the embedded bundle is parsed and saved as one snapshot + entries. As soon as **any** snapshot exists (a prior seed or real fetched data) seeding is skipped — it never overwrites fetched data, and the normal 6h refresh augments/replaces coverage once online.

## Tests
- Bundle parses to the expected domains: count, lowercase/trailing-dot/IP-prefix normalisation, no duplicates, presence of known entries; `Domains()`/`Load()` agreement; stable checksum.
- Seeding **occurs** when the DB is empty (asserts entries, disabled URL-less source), is **skipped** when a snapshot exists, is idempotent across boots, and propagates a count error without saving. Deterministic via a mock `BlocklistRepository`.
- Real gorm `CountSnapshots()` covered against an in-memory SQLite DB.
- `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)