### PR TITLE
feat: passive LAN device inventory (I-016)

### DIFF
--- a/cmd/controlplane/handlers/devices.go
+++ b/cmd/controlplane/handlers/devices.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/inventory"
+)
+
+type ResponseDevices struct {
+	Status string             `json:"status"`
+	Data   []inventory.Device `json:"data"`
+	Error  *string            `json:"error"`
+}
+
+// GetDevices handles GET /api/v1/devices, returning the passive LAN device
+// inventory. When the inventory feature is disabled (nil), an empty list is
+// returned so clients get a stable shape.
+func (h *APIHandler) GetDevices(c *gin.Context) {
+	devices := []inventory.Device{}
+	if h.Inventory != nil {
+		devices = h.Inventory.Devices()
+	}
+	c.JSON(http.StatusOK, ResponseDevices{
+		Status: "success",
+		Data:   devices,
+	})
+}

--- a/cmd/controlplane/handlers/handlers.go
+++ b/cmd/controlplane/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	client "github.com/lopster568/phantomDNS/internal/grpc/controlplane"
+	"github.com/lopster568/phantomDNS/internal/inventory"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 )
 
@@ -9,14 +10,19 @@ import (
 type APIHandler struct {
 	Store           repositories.Store
 	DataPlaneClient *client.Client
+	// Inventory is the passive LAN device inventory. It may be nil when the
+	// feature is disabled; handlers must treat that as an empty inventory.
+	Inventory *inventory.Inventory
 }
 
 func NewAPIHandler(
 	store repositories.Store,
 	dataPlaneClient *client.Client,
+	deviceInventory *inventory.Inventory,
 ) *APIHandler {
 	return &APIHandler{
 		Store:           store,
 		DataPlaneClient: dataPlaneClient,
+		Inventory:       deviceInventory,
 	}
 }

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lopster568/phantomDNS/cmd/controlplane/routes"
 	"github.com/lopster568/phantomDNS/internal/config"
 	client "github.com/lopster568/phantomDNS/internal/grpc/controlplane"
+	"github.com/lopster568/phantomDNS/internal/inventory"
 	"github.com/lopster568/phantomDNS/internal/storage/db"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 
@@ -39,8 +40,14 @@ func main() {
 	}
 	c.SetAcceptQueries(state.DNSEnabled)
 
+	// Passive LAN device inventory (disabled by default; configured via
+	// INVENTORY_ENABLED and DHCP_LEASES_PATH).
+	deviceInventory := inventory.New(inventory.ConfigFromEnv(), nil)
+	deviceInventory.Start()
+	defer deviceInventory.Stop()
+
 	// Initialize Gin router
-	apiHandler := handlers.NewAPIHandler(*repos, c)
+	apiHandler := handlers.NewAPIHandler(*repos, c, deviceInventory)
 	r := gin.Default()
 	r.Use(middlewares.Logger())
 

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -57,5 +57,11 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 			analytics.GET("/summary", apiHandler.GetAnalyticsSummary)
 			analytics.GET("/audits", apiHandler.GetAuditLogs)
 		}
+
+		// Device inventory endpoints
+		devices := api.Group("/devices")
+		{
+			devices.GET("", apiHandler.GetDevices)
+		}
 	}
 }

--- a/internal/inventory/arp.go
+++ b/internal/inventory/arp.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package inventory
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+// arpEntry is a single resolved IP -> MAC binding from the ARP table.
+type arpEntry struct {
+	IP  string
+	MAC string
+}
+
+// emptyMAC is the placeholder MAC the kernel reports for incomplete entries.
+const emptyMAC = "00:00:00:00:00:00"
+
+// parseARP parses the contents of a Linux /proc/net/arp file into resolved
+// entries. It is a pure function over the file bytes so it can be tested
+// without touching the real filesystem or requiring privileges.
+//
+// The file looks like:
+//
+//	IP address       HW type     Flags       HW address            Mask     Device
+//	192.168.1.1      0x1         0x2         aa:bb:cc:dd:ee:ff     *        eth0
+//	192.168.1.9      0x1         0x0         00:00:00:00:00:00     *        eth0
+//
+// The header line, incomplete entries (Flags 0x0) and placeholder MACs are
+// skipped.
+func parseARP(data []byte) []arpEntry {
+	var out []arpEntry
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		// Skip the column header.
+		if strings.HasPrefix(line, "IP address") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		ip := fields[0]
+		flags := fields[2]
+		mac := strings.ToLower(fields[3])
+		// Flags 0x0 means the entry is incomplete (no MAC learned yet).
+		if flags == "0x0" {
+			continue
+		}
+		if mac == "" || mac == emptyMAC {
+			continue
+		}
+		out = append(out, arpEntry{IP: ip, MAC: mac})
+	}
+	return out
+}

--- a/internal/inventory/arp_linux.go
+++ b/internal/inventory/arp_linux.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package inventory
+
+import "os"
+
+// procNetARP is the kernel-exported ARP table on Linux. It is a package
+// variable only so tests could point it elsewhere if ever needed; production
+// code never overrides it.
+var procNetARP = "/proc/net/arp"
+
+// readARPTable reads the live ARP table on Linux. On read failure it returns
+// nil so a refresh cycle simply observes no ARP entries.
+func readARPTable() []arpEntry {
+	data, err := os.ReadFile(procNetARP)
+	if err != nil {
+		return nil
+	}
+	return parseARP(data)
+}

--- a/internal/inventory/arp_other.go
+++ b/internal/inventory/arp_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package inventory
+
+// readARPTable is a graceful no-op on non-Linux platforms: the kernel ARP
+// table is not read, so ARP-based discovery contributes no entries. DHCP lease
+// parsing (if configured) still works everywhere.
+func readARPTable() []arpEntry { return nil }

--- a/internal/inventory/dhcp.go
+++ b/internal/inventory/dhcp.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package inventory
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+// dhcpLease is a single binding read from a dnsmasq-style lease file.
+type dhcpLease struct {
+	IP       string
+	MAC      string
+	Hostname string
+}
+
+// parseDHCPLeases parses a dnsmasq-style DHCP lease file. Each active lease is
+// a whitespace-separated line:
+//
+//	<expiry-epoch> <mac> <ip> <hostname> <client-id>
+//
+// e.g. "1750000000 aa:bb:cc:dd:ee:ff 192.168.1.100 my-laptop 01:aa:bb:cc:dd:ee:ff"
+//
+// A hostname of "*" means unknown and is treated as empty. Parsing is a pure
+// function over the file bytes so it is testable without real files.
+func parseDHCPLeases(data []byte) []dhcpLease {
+	var out []dhcpLease
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		// Need at least expiry, mac and ip.
+		if len(fields) < 3 {
+			continue
+		}
+		mac := strings.ToLower(fields[1])
+		ip := fields[2]
+		hostname := ""
+		if len(fields) >= 4 && fields[3] != "*" {
+			hostname = fields[3]
+		}
+		out = append(out, dhcpLease{IP: ip, MAC: mac, Hostname: hostname})
+	}
+	return out
+}

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package inventory maintains a passive map of devices seen on the local
+// network. It is the identity foundation for per-client policy and
+// infected-device alerting.
+//
+// The inventory is built from the kernel ARP table (Linux) and, optionally, a
+// dnsmasq-style DHCP lease file. Entries are keyed by IP and carry the MAC,
+// hostname and first/last-seen timestamps. Collection is passive (read-only)
+// and disabled by default.
+package inventory
+
+import (
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+// DefaultRefreshInterval is used when a Config does not specify one.
+const DefaultRefreshInterval = 60 * time.Second
+
+// Device is a single host observed on the LAN, keyed by its IP address.
+type Device struct {
+	IP        string    `json:"ip"`
+	MAC       string    `json:"mac"`
+	Hostname  string    `json:"hostname"`
+	FirstSeen time.Time `json:"first_seen"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+// Clock abstracts time so that seen timestamps are deterministic in tests.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// Config controls the inventory collector.
+type Config struct {
+	// Enabled turns collection on. Default false (off).
+	Enabled bool
+	// DHCPLeasesPath, when set, is a dnsmasq-style lease file that is parsed
+	// on each refresh to enrich devices with hostnames. Empty disables DHCP
+	// enrichment.
+	DHCPLeasesPath string
+	// RefreshInterval is how often the ARP/DHCP sources are re-read. A value
+	// <= 0 falls back to DefaultRefreshInterval.
+	RefreshInterval time.Duration
+}
+
+// ConfigFromEnv builds a Config from environment variables:
+//
+//	INVENTORY_ENABLED   ("1"/"true"/"yes"/"on") enables collection (default off)
+//	DHCP_LEASES_PATH    path to a dnsmasq-style lease file (optional)
+func ConfigFromEnv() Config {
+	cfg := Config{RefreshInterval: DefaultRefreshInterval}
+	if v := os.Getenv("INVENTORY_ENABLED"); v != "" {
+		cfg.Enabled = parseBool(v)
+	}
+	if p := os.Getenv("DHCP_LEASES_PATH"); p != "" {
+		cfg.DHCPLeasesPath = p
+	}
+	return cfg
+}
+
+func parseBool(v string) bool {
+	switch v {
+	case "1", "t", "T", "true", "TRUE", "True", "yes", "YES", "on", "ON":
+		return true
+	default:
+		return false
+	}
+}
+
+// Inventory is a thread-safe device map with periodic refresh.
+type Inventory struct {
+	cfg   Config
+	clock Clock
+
+	mu      sync.RWMutex
+	devices map[string]Device // IP -> Device
+
+	stopCh chan struct{}
+	stop   sync.Once
+	wg     sync.WaitGroup
+}
+
+// New constructs an Inventory. A nil clock defaults to wall-clock time.
+func New(cfg Config, clock Clock) *Inventory {
+	if clock == nil {
+		clock = realClock{}
+	}
+	if cfg.RefreshInterval <= 0 {
+		cfg.RefreshInterval = DefaultRefreshInterval
+	}
+	return &Inventory{
+		cfg:     cfg,
+		clock:   clock,
+		devices: make(map[string]Device),
+		stopCh:  make(chan struct{}),
+	}
+}
+
+// Enabled reports whether collection is on.
+func (inv *Inventory) Enabled() bool { return inv.cfg.Enabled }
+
+// Start performs an initial refresh and then refreshes on a ticker until
+// Stop is called. It is a no-op when the inventory is disabled.
+func (inv *Inventory) Start() {
+	if !inv.cfg.Enabled {
+		return
+	}
+	inv.refresh()
+	inv.wg.Add(1)
+	go func() {
+		defer inv.wg.Done()
+		ticker := time.NewTicker(inv.cfg.RefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-inv.stopCh:
+				return
+			case <-ticker.C:
+				inv.refresh()
+			}
+		}
+	}()
+}
+
+// Stop halts the background refresh loop and waits for it to exit. Safe to
+// call multiple times and safe when Start was never called.
+func (inv *Inventory) Stop() {
+	inv.stop.Do(func() { close(inv.stopCh) })
+	inv.wg.Wait()
+}
+
+// Devices returns a snapshot of the inventory sorted by IP. The returned
+// slice is a copy and safe for the caller to mutate.
+func (inv *Inventory) Devices() []Device {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+	out := make([]Device, 0, len(inv.devices))
+	for _, d := range inv.devices {
+		out = append(out, d)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].IP < out[j].IP })
+	return out
+}
+
+// refresh re-reads the enabled sources and merges them into the device map.
+// It is a no-op when disabled so that no system files are touched.
+func (inv *Inventory) refresh() {
+	if !inv.cfg.Enabled {
+		return
+	}
+	arps := readARPTable()
+
+	var leases []dhcpLease
+	if inv.cfg.DHCPLeasesPath != "" {
+		if data, err := os.ReadFile(inv.cfg.DHCPLeasesPath); err == nil {
+			leases = parseDHCPLeases(data)
+		} else {
+			logger.Log.Warnf("inventory: failed to read DHCP leases (%s): %v", inv.cfg.DHCPLeasesPath, err)
+		}
+	}
+
+	inv.merge(arps, leases)
+}
+
+// observation is the merged view of what a single IP looked like this cycle.
+type observation struct {
+	MAC      string
+	Hostname string
+}
+
+// merge folds a set of ARP entries and DHCP leases into the device map,
+// preserving FirstSeen for known IPs and stamping LastSeen for every IP seen
+// this cycle. ARP supplies MAC addresses; DHCP supplies hostnames (and MAC as
+// a fallback).
+func (inv *Inventory) merge(arps []arpEntry, leases []dhcpLease) {
+	obs := make(map[string]observation)
+	for _, a := range arps {
+		o := obs[a.IP]
+		if a.MAC != "" {
+			o.MAC = a.MAC
+		}
+		obs[a.IP] = o
+	}
+	for _, l := range leases {
+		o := obs[l.IP]
+		if l.MAC != "" {
+			o.MAC = l.MAC
+		}
+		if l.Hostname != "" {
+			o.Hostname = l.Hostname
+		}
+		obs[l.IP] = o
+	}
+
+	now := inv.clock.Now()
+	inv.mu.Lock()
+	defer inv.mu.Unlock()
+	for ip, o := range obs {
+		d, ok := inv.devices[ip]
+		if !ok {
+			inv.devices[ip] = Device{
+				IP:        ip,
+				MAC:       o.MAC,
+				Hostname:  o.Hostname,
+				FirstSeen: now,
+				LastSeen:  now,
+			}
+			continue
+		}
+		if o.MAC != "" {
+			d.MAC = o.MAC
+		}
+		if o.Hostname != "" {
+			d.Hostname = o.Hostname
+		}
+		d.LastSeen = now
+		inv.devices[ip] = d
+	}
+}

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package inventory
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeClock is a controllable Clock for deterministic seen timestamps.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time { return c.t }
+
+func (c *fakeClock) Advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func TestParseARP(t *testing.T) {
+	input := []byte(`IP address       HW type     Flags       HW address            Mask     Device
+192.168.1.1      0x1         0x2         AA:BB:CC:DD:EE:01     *        eth0
+192.168.1.2      0x1         0x2         aa:bb:cc:dd:ee:02     *        eth0
+192.168.1.9      0x1         0x0         00:00:00:00:00:00     *        eth0
+
+10.0.0.5         0x1         0x2         de:ad:be:ef:00:05     *        wlan0
+garbage line without enough fields
+`)
+
+	got := parseARP(input)
+
+	want := []arpEntry{
+		{IP: "192.168.1.1", MAC: "aa:bb:cc:dd:ee:01"}, // MAC lowercased
+		{IP: "192.168.1.2", MAC: "aa:bb:cc:dd:ee:02"},
+		{IP: "10.0.0.5", MAC: "de:ad:be:ef:00:05"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseARP returned %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseARP_Empty(t *testing.T) {
+	// Header only -> no entries.
+	if got := parseARP([]byte("IP address  HW type  Flags  HW address  Mask  Device\n")); len(got) != 0 {
+		t.Errorf("expected 0 entries from header-only input, got %d", len(got))
+	}
+	if got := parseARP(nil); len(got) != 0 {
+		t.Errorf("expected 0 entries from nil input, got %d", len(got))
+	}
+}
+
+func TestParseDHCPLeases(t *testing.T) {
+	input := []byte(`1750000000 AA:BB:CC:DD:EE:01 192.168.1.100 my-laptop 01:aa:bb:cc:dd:ee:01
+1750000500 aa:bb:cc:dd:ee:02 192.168.1.101 * 01:aa:bb:cc:dd:ee:02
+1750000900 aa:bb:cc:dd:ee:03 192.168.1.102 printer
+
+short line
+`)
+
+	got := parseDHCPLeases(input)
+
+	want := []dhcpLease{
+		{IP: "192.168.1.100", MAC: "aa:bb:cc:dd:ee:01", Hostname: "my-laptop"},
+		{IP: "192.168.1.101", MAC: "aa:bb:cc:dd:ee:02", Hostname: ""}, // "*" -> empty
+		{IP: "192.168.1.102", MAC: "aa:bb:cc:dd:ee:03", Hostname: "printer"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseDHCPLeases returned %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("lease[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMerge_NewAndUpdate(t *testing.T) {
+	t0 := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	clk := &fakeClock{t: t0}
+	inv := New(Config{Enabled: true}, clk)
+
+	// First cycle: ARP sees the device (MAC only).
+	inv.merge([]arpEntry{{IP: "192.168.1.10", MAC: "aa:bb:cc:dd:ee:10"}}, nil)
+
+	devs := inv.Devices()
+	if len(devs) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(devs))
+	}
+	d := devs[0]
+	if d.IP != "192.168.1.10" || d.MAC != "aa:bb:cc:dd:ee:10" {
+		t.Fatalf("unexpected device: %+v", d)
+	}
+	if !d.FirstSeen.Equal(t0) || !d.LastSeen.Equal(t0) {
+		t.Fatalf("expected FirstSeen==LastSeen==t0, got first=%v last=%v", d.FirstSeen, d.LastSeen)
+	}
+	if d.Hostname != "" {
+		t.Fatalf("expected empty hostname, got %q", d.Hostname)
+	}
+
+	// Second cycle later: DHCP lease enriches with hostname; LastSeen advances
+	// but FirstSeen is preserved.
+	clk.Advance(5 * time.Minute)
+	inv.merge(
+		[]arpEntry{{IP: "192.168.1.10", MAC: "aa:bb:cc:dd:ee:10"}},
+		[]dhcpLease{{IP: "192.168.1.10", MAC: "aa:bb:cc:dd:ee:10", Hostname: "roshan-laptop"}},
+	)
+
+	devs = inv.Devices()
+	if len(devs) != 1 {
+		t.Fatalf("expected still 1 device, got %d", len(devs))
+	}
+	d = devs[0]
+	if d.Hostname != "roshan-laptop" {
+		t.Errorf("expected hostname enriched to roshan-laptop, got %q", d.Hostname)
+	}
+	if !d.FirstSeen.Equal(t0) {
+		t.Errorf("FirstSeen should be preserved as t0, got %v", d.FirstSeen)
+	}
+	wantLast := t0.Add(5 * time.Minute)
+	if !d.LastSeen.Equal(wantLast) {
+		t.Errorf("LastSeen = %v, want %v", d.LastSeen, wantLast)
+	}
+}
+
+func TestMerge_MultipleDevicesSortedAndCopied(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_750_000_000, 0).UTC()}
+	inv := New(Config{Enabled: true}, clk)
+
+	inv.merge([]arpEntry{
+		{IP: "192.168.1.30", MAC: "aa:bb:cc:dd:ee:30"},
+		{IP: "192.168.1.10", MAC: "aa:bb:cc:dd:ee:10"},
+		{IP: "192.168.1.20", MAC: "aa:bb:cc:dd:ee:20"},
+	}, nil)
+
+	devs := inv.Devices()
+	if len(devs) != 3 {
+		t.Fatalf("expected 3 devices, got %d", len(devs))
+	}
+	wantOrder := []string{"192.168.1.10", "192.168.1.20", "192.168.1.30"}
+	for i, ip := range wantOrder {
+		if devs[i].IP != ip {
+			t.Errorf("devices not sorted by IP: pos %d = %s, want %s", i, devs[i].IP, ip)
+		}
+	}
+
+	// Mutating the returned snapshot must not affect internal state.
+	devs[0].Hostname = "mutated"
+	if again := inv.Devices(); again[0].Hostname != "" {
+		t.Errorf("Devices() returned a shared reference; internal state was mutated")
+	}
+}
+
+func TestDHCPOnlyDevice(t *testing.T) {
+	// A device present in DHCP but not (yet) in ARP should still be recorded.
+	clk := &fakeClock{t: time.Unix(1_750_000_000, 0).UTC()}
+	inv := New(Config{Enabled: true}, clk)
+
+	inv.merge(nil, []dhcpLease{{IP: "192.168.1.200", MAC: "aa:bb:cc:dd:ee:c8", Hostname: "iot-bulb"}})
+
+	devs := inv.Devices()
+	if len(devs) != 1 {
+		t.Fatalf("expected 1 device from DHCP-only, got %d", len(devs))
+	}
+	if devs[0].Hostname != "iot-bulb" || devs[0].MAC != "aa:bb:cc:dd:ee:c8" {
+		t.Errorf("unexpected DHCP-only device: %+v", devs[0])
+	}
+}
+
+func TestDisabled_RefreshIsNoOp(t *testing.T) {
+	// Disabled inventory must not read any system files. A bogus DHCP path
+	// would surface as an error if refresh actually ran; here it must be
+	// skipped entirely.
+	inv := New(Config{Enabled: false, DHCPLeasesPath: "/nonexistent/does/not/exist"}, &fakeClock{t: time.Now()})
+
+	inv.refresh() // no-op
+	inv.Start()   // no-op
+	inv.Stop()    // safe even though Start launched nothing
+
+	if got := inv.Devices(); len(got) != 0 {
+		t.Errorf("disabled inventory should have no devices, got %d", len(got))
+	}
+	if inv.Enabled() {
+		t.Errorf("Enabled() should report false")
+	}
+}
+
+func TestConfigFromEnv(t *testing.T) {
+	t.Setenv("INVENTORY_ENABLED", "true")
+	t.Setenv("DHCP_LEASES_PATH", "/var/lib/misc/dnsmasq.leases")
+	cfg := ConfigFromEnv()
+	if !cfg.Enabled {
+		t.Errorf("expected Enabled=true")
+	}
+	if cfg.DHCPLeasesPath != "/var/lib/misc/dnsmasq.leases" {
+		t.Errorf("unexpected DHCPLeasesPath: %q", cfg.DHCPLeasesPath)
+	}
+	if cfg.RefreshInterval != DefaultRefreshInterval {
+		t.Errorf("expected default refresh interval, got %v", cfg.RefreshInterval)
+	}
+}
+
+func TestConfigFromEnv_DefaultOff(t *testing.T) {
+	t.Setenv("INVENTORY_ENABLED", "")
+	t.Setenv("DHCP_LEASES_PATH", "")
+	if cfg := ConfigFromEnv(); cfg.Enabled {
+		t.Errorf("inventory should default to disabled")
+	}
+}


### PR DESCRIPTION
## What
Adds a passive LAN device inventory in core — the identity foundation for
per-client policy and infected-device alerting. A new `internal/inventory`
package builds a device map keyed by IP, each carrying MAC, hostname, and
first/last-seen timestamps. **Disabled by default.**

Also exposes an optional `GET /api/v1/devices` control-plane endpoint that
returns the current inventory (empty list when the feature is off).

## Why
Before we can do per-client policy or flag an infected device, core needs a
stable notion of *which devices are on the network and who they are*. This is
the passive, read-only first step: no active scanning, no probing — just what
the kernel and DHCP already know.

## How
- **ARP table (Linux):** parses `/proc/net/arp` behind a `//go:build linux`
  tag; a `//go:build !linux` no-op keeps the build green everywhere and lets
  DHCP-only enrichment still work. The parser is a pure function over bytes,
  independent of the build tag, so it is fully testable off-Linux.
- **DHCP leases (optional):** parses a dnsmasq-style lease file at a
  configurable path to enrich devices with hostnames.
- **Merge:** thread-safe map (`sync.RWMutex`); ARP supplies MACs, DHCP supplies
  hostnames. `FirstSeen` is preserved across cycles, `LastSeen` is stamped each
  refresh. Timestamps come from an injectable `Clock` so tests are
  deterministic. Refresh runs on a ticker; `Devices()` returns a sorted copy.
- **Config (env):** `INVENTORY_ENABLED` (default `false`), `DHCP_LEASES_PATH`.
- **API:** `Inventory` is wired into `APIHandler` (nil-safe) and started in the
  control-plane `main`.

## Tests
- ARP parser over a sample `/proc/net/arp` string (header skip, incomplete
  `0x0` flag skip, placeholder-MAC skip, MAC lowercasing).
- DHCP lease parser over sample leases (`*` hostname → empty, short lines
  skipped).
- Merge/refresh: new device stamping, `FirstSeen` preserved while `LastSeen`
  advances via a fake clock, DHCP hostname enrichment, DHCP-only devices,
  sorted + copied snapshots.
- Disabled = off: `refresh()`/`Start()` are no-ops and touch no system files.
- Config-from-env defaults and overrides.

All tests are pure-parser/merge tests over in-memory strings — they never read
real system files or require privileges. `gofmt`, `go build ./...`,
`go vet ./...`, and `go test ./...` are all green; the package also
cross-compiles for darwin and windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
