### PR TITLE
feat(dataplane): newly-registered-domain blocking via feed (I-021)

### DIFF
--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/heartbeat"
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"github.com/lopster568/phantomDNS/internal/metrics/promexport"
+	"github.com/lopster568/phantomDNS/internal/nrd"
 	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/db"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
@@ -176,6 +177,22 @@ func main() {
 		DBPath:   dbPath,
 	}, engine.Metrics(), engine, repos.Blocklist)
 	hb.Start(context.Background())
+
+	// 6d. Newly-registered-domain (NRD) feed — inert unless NRD_FEED_URL is set.
+	// Kept separate from user blocklists; refreshed periodically like blocklists.
+	nrdCfg := nrd.Config{
+		FeedURL: config.DefaultConfig.DataPlane.NRDFeedURL,
+		Block:   config.DefaultConfig.DataPlane.NRDBlock,
+	}
+	if iv, err := time.ParseDuration(config.DefaultConfig.DataPlane.NRDRefreshInterval); err == nil && iv > 0 {
+		nrdCfg.RefreshInterval = iv
+	}
+	nrdChecker := nrd.New(nrdCfg)
+	if nrdChecker.Enabled() {
+		logger.Log.Infof("NRD feed enabled (block=%v): %s", nrdCfg.Block, nrdCfg.FeedURL)
+		go nrdChecker.Run(context.Background())
+	}
+	engine.AttachNRDChecker(nrdChecker)
 
 	// 7. Attach blocklist checker and start DNS server
 	engine.AttachBlocklistChecker(repos.Blocklist)

--- a/internal/blocklist/parser/domain_parser.go
+++ b/internal/blocklist/parser/domain_parser.go
@@ -1,1 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 package parser
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"time"
+)
+
+// DomainsParser parses feeds with one domain per line. Blank lines and lines
+// beginning with '#' or ';' are ignored. Only the first whitespace-separated
+// field of each line is used, so simple "domain <extra>" columns are tolerated.
+// A leading "*." wildcard and a trailing dot are stripped. This format suits
+// plain domain lists such as newly-registered-domain (NRD) feeds.
+type DomainsParser struct{}
+
+func (d *DomainsParser) Format() string { return "domains" }
+
+func (d *DomainsParser) Parse(data []byte) ([]ParsedEntry, error) {
+	s := bufio.NewScanner(bytes.NewReader(data))
+	var out []ParsedEntry
+	now := time.Now()
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if idx := strings.IndexAny(line, " \t"); idx >= 0 {
+			line = line[:idx]
+		}
+		domain := strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(line, "*."), "."))
+		if domain == "" {
+			continue
+		}
+		out = append(out, ParsedEntry{
+			Domain:  domain,
+			Fetched: now,
+		})
+	}
+	return out, s.Err()
+}
+
+func init() {
+	Register(&DomainsParser{})
+}

--- a/internal/blocklist/parser/parser_test.go
+++ b/internal/blocklist/parser/parser_test.go
@@ -80,3 +80,54 @@ func TestRegistry_GetUnknown(t *testing.T) {
 		t.Error("expected false for nonexistent parser")
 	}
 }
+
+func TestDomainsParser_Parse(t *testing.T) {
+	input := []byte(`# comment line
+evil.com
+Bad-Domain.NET.
+
+*.wildcard.org
+with.extra columns.here
+; semicolon comment
+   spaced.example.com
+`)
+
+	p := &DomainsParser{}
+	entries, err := p.Parse(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"evil.com", "bad-domain.net", "wildcard.org", "with.extra", "spaced.example.com"}
+	if len(entries) != len(want) {
+		t.Fatalf("expected %d entries, got %d", len(want), len(entries))
+	}
+	for i, e := range entries {
+		if e.Domain != want[i] {
+			t.Errorf("entry[%d] = %q, want %q", i, e.Domain, want[i])
+		}
+	}
+}
+
+func TestDomainsParser_EmptyAndCommentsOnly(t *testing.T) {
+	p := &DomainsParser{}
+	for _, in := range [][]byte{[]byte(""), []byte("# only\n; comments\n\n")} {
+		entries, err := p.Parse(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("expected 0 entries, got %d", len(entries))
+		}
+	}
+}
+
+func TestDomainsParser_Registered(t *testing.T) {
+	p, ok := Get("domains")
+	if !ok {
+		t.Fatal("domains parser not registered")
+	}
+	if p.Format() != "domains" {
+		t.Errorf("unexpected format: %s", p.Format())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,11 @@ type DataPlaneConfig struct {
 	HeartbeatInterval string `yaml:"heartbeat_interval"`
 
 	GeoIP GeoIPConfig `yaml:"geoip"`
+
+	// Newly-registered-domain (NRD) feed. Empty NRDFeedURL leaves NRD inert.
+	NRDFeedURL         string `yaml:"nrd_feed_url"`
+	NRDBlock           bool   `yaml:"nrd_block"`
+	NRDRefreshInterval string `yaml:"nrd_refresh_interval"`
 }
 
 // GeoIPConfig configures optional ASN/GeoIP answer filtering. It is disabled
@@ -229,6 +234,7 @@ func defaultConfig() *Config {
 			FastFluxDetection:        false,
 			FastFluxIPThreshold:      8,
 			FastFluxTTLMaxSec:        300,
+			NRDRefreshInterval:       "6h",
 			GRPCServer: GRPCServerConfig{
 				Port:       50051,
 				ListenAddr: "localhost:50051",
@@ -387,6 +393,19 @@ var DefaultConfig = func() *Config {
 		if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
 			cfg.DataPlane.GeoIP.Block = b
 		}
+	}
+	if url := os.Getenv("NRD_FEED_URL"); url != "" {
+		cfg.DataPlane.NRDFeedURL = url
+	}
+	if v := os.Getenv("NRD_BLOCK"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.NRDBlock = b
+		} else {
+			logger.Log.Warnf("Invalid NRD_BLOCK value %q, ignoring", v)
+		}
+	}
+	if interval := os.Getenv("NRD_REFRESH_INTERVAL"); interval != "" {
+		cfg.DataPlane.NRDRefreshInterval = interval
 	}
 	return cfg
 }()

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -30,6 +30,17 @@ type upstreamExchanger interface {
 	Close()
 }
 
+// NRDChecker reports whether a domain appears on the operator-configured
+// newly-registered-domain (NRD) feed, and whether matches should be blocked or
+// merely flagged. It is kept entirely separate from user blocklists. A nil
+// checker (or one with no feed loaded) is inert.
+type NRDChecker interface {
+	// IsListed reports whether the domain or its registrable parent is on the feed.
+	IsListed(domain string) bool
+	// BlockMode reports whether listed domains are blocked (true) or flagged (false).
+	BlockMode() bool
+}
+
 type RuntimeState struct {
 	acceptQueries atomic.Bool
 	// policyEnabled atomic.Bool
@@ -40,6 +51,7 @@ type Engine struct {
 	upstreamManager upstreamExchanger
 	policyEngine    *policy.Engine
 	blocklist       BlocklistChecker
+	nrd             NRDChecker
 	state           *RuntimeState
 	metrics         *metrics.QueryMetrics
 	queryLog        repositories.QueryLogRepository
@@ -116,6 +128,12 @@ func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
 // (the default) leaves the engine's allow path unchanged and adds no overhead.
 func (e *Engine) AttachGeoFilter(f *geoip.Filter) {
 	e.geo = f
+}
+
+// AttachNRDChecker wires the newly-registered-domain feed checker onto the
+// engine. Passing a checker with no feed configured leaves NRD inert.
+func (e *Engine) AttachNRDChecker(n NRDChecker) {
+	e.nrd = n
 }
 
 func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *policy.Engine) (*Engine, error) {
@@ -539,6 +557,23 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
+	// --- Step 1.5: Newly-registered-domain (NRD) feed ---
+	// The NRD set is kept entirely separate from user blocklists. In block mode a
+	// match is treated like a blocklist hit and short-circuits here; in flag mode
+	// the query continues and is flagged on the allow path below. Inert when no
+	// feed is configured.
+	nrdListed := false
+	if e.nrd != nil {
+		nrdListed = e.nrd.IsListed(domainName)
+		if nrdListed && e.nrd.BlockMode() {
+			logger.Log.Infof("Blocked by NRD feed: %s", domainName)
+			e.logQuery(domainName, clientIP, "block", "nrd", threatResult)
+			e.respondBlocked(w, r, domainName, "nrd")
+			success = true
+			return
+		}
+	}
+
 	// --- Step 2: Evaluate policy ---
 	decision, err := e.policyEngine.Evaluate(domainName)
 	if err != nil {
@@ -640,6 +675,14 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			action = "flagged"
 			reason = threatResult.DetectionMethod
 			logger.Log.Warnf("Suspicious domain allowed: %s (score=%.2f, method=%s)", domainName, threatResult.ThreatScore, threatResult.DetectionMethod)
+		} else if nrdListed {
+			// Flag mode: forward the query but mark it as newly-registered.
+			threatResult.IsSuspicious = true
+			threatResult.DetectionMethod = "nrd"
+			threatResult.Reason = "newly-registered domain (on NRD feed)"
+			action = "flagged"
+			reason = threatResult.DetectionMethod
+			logger.Log.Warnf("Newly-registered domain allowed (flagged): %s", domainName)
 		}
 		// Forward first so the fast-flux heuristic and the optional GeoIP filter
 		// can inspect the answer, then log — a tripped domain is flagged/blocked

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lopster568/phantomDNS/internal/metrics"
+	"github.com/lopster568/phantomDNS/internal/nrd"
 	"github.com/lopster568/phantomDNS/internal/policy"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"github.com/lopster568/phantomDNS/internal/threat"
@@ -834,5 +835,100 @@ func TestProcessDNSQuery_SafeSearchDoesNotOverrideBlock(t *testing.T) {
 	}
 	if got := cnameTarget(w.msg); got != "" {
 		t.Errorf("expected no CNAME on blocked host, got CNAME to %q", got)
+	}
+}
+
+// --- NRD (newly-registered-domain) feed tests ---
+
+// isServfail reports whether the response is a SERVFAIL, which is what
+// forwardUpstream produces with an empty (no-resolver) upstream manager. It lets
+// the allow/flag path be exercised deterministically without any network.
+func isServfail(m *dns.Msg) bool {
+	return m != nil && m.Rcode == dns.RcodeServerFailure
+}
+
+func TestProcessDNSQuery_NRDBlock(t *testing.T) {
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.nrd = nrd.NewWithSet(nrd.NewSet([]string{"freshdomain.com"}), true) // block mode
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("freshdomain.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected response for NRD-listed domain in block mode")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected blocked (0.0.0.0) for NRD domain in block mode, got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_NRDBlock_ParentMatch(t *testing.T) {
+	// Feed lists the registrable parent; a subdomain query must be blocked.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.nrd = nrd.NewWithSet(nrd.NewSet([]string{"freshdomain.com"}), true)
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("login.freshdomain.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected response for NRD parent-domain match")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected blocked (0.0.0.0) for NRD parent match, got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_NRDFlag_NotBlocked(t *testing.T) {
+	// Flag mode: a listed domain must NOT be blocked; it reaches the allow/forward
+	// path. With an empty upstream manager, forwardUpstream returns SERVFAIL,
+	// which confirms the query was forwarded rather than blocked.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.nrd = nrd.NewWithSet(nrd.NewSet([]string{"freshdomain.com"}), false) // flag mode
+	e.upstreamManager = &UpstreamManager{}                                 // no resolvers, no network
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("freshdomain.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response in flag mode")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("flag mode must not block; expected forward path, got a 0.0.0.0 block")
+	}
+	if !isServfail(w.msg) {
+		t.Errorf("expected SERVFAIL from forward path, got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_NRDNotListed_Passes(t *testing.T) {
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.nrd = nrd.NewWithSet(nrd.NewSet([]string{"freshdomain.com"}), true) // block mode
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("well-established.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response for a non-listed domain")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("non-listed domain must not be blocked by NRD")
+	}
+}
+
+func TestProcessDNSQuery_NRDNoFeed_Inert(t *testing.T) {
+	// A checker with no feed configured must be inert: the domain passes through.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.nrd = nrd.New(nrd.Config{}) // no FeedURL, no data loaded
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("freshdomain.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response with an inert NRD checker")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("inert NRD checker (no feed) must not block")
 	}
 }

--- a/internal/nrd/checker.go
+++ b/internal/nrd/checker.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package nrd
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/blocklist/fetcher"
+	"github.com/lopster568/phantomDNS/internal/blocklist/parser"
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+const (
+	defaultRefreshInterval = 6 * time.Hour
+	// defaultFormat is the parser format used for NRD feeds. Feeds are typically
+	// one registrable domain per line, handled by the "domains" parser.
+	defaultFormat = "domains"
+)
+
+// Config controls NRD feed behavior. A zero Config (empty FeedURL) is inert.
+type Config struct {
+	// FeedURL is the operator-configured URL of the newly-registered-domain feed.
+	// Empty disables NRD entirely.
+	FeedURL string
+	// Block reports whether listed domains are blocked (true) or only flagged
+	// (false). Defaults to false (flag) to fail open.
+	Block bool
+	// RefreshInterval is how often the feed is re-fetched. Defaults to 6h.
+	RefreshInterval time.Duration
+	// Format selects the parser used for the feed body. Defaults to "domains".
+	Format string
+}
+
+// Checker holds the current NRD set and refreshes it from the configured feed.
+// It reuses the blocklist fetcher (ETag/conditional-GET) and parser registry but
+// keeps its set entirely separate from user blocklists. The zero value is not
+// usable; construct with New or NewWithSet.
+type Checker struct {
+	cfg     Config
+	fetcher *fetcher.HTTPFetcher
+	set     atomic.Pointer[Set]
+	etag    atomic.Pointer[string]
+}
+
+// New constructs a Checker from cfg, applying defaults for the refresh interval
+// and feed format. The checker starts with an empty set and is inert until the
+// feed is refreshed. When FeedURL is empty the checker stays permanently inert.
+func New(cfg Config) *Checker {
+	if cfg.RefreshInterval <= 0 {
+		cfg.RefreshInterval = defaultRefreshInterval
+	}
+	if cfg.Format == "" {
+		cfg.Format = defaultFormat
+	}
+	c := &Checker{cfg: cfg, fetcher: fetcher.NewHTTPFetcher()}
+	c.set.Store(NewSet(nil))
+	return c
+}
+
+// NewWithSet builds a Checker backed by a fixed set. It performs no fetching and
+// is intended for tests and manual wiring.
+func NewWithSet(set *Set, block bool) *Checker {
+	c := New(Config{Block: block})
+	if set == nil {
+		set = NewSet(nil)
+	}
+	c.set.Store(set)
+	return c
+}
+
+// Enabled reports whether a feed URL is configured.
+func (c *Checker) Enabled() bool {
+	return c != nil && c.cfg.FeedURL != ""
+}
+
+// BlockMode reports whether listed domains should be blocked (true) or flagged
+// (false).
+func (c *Checker) BlockMode() bool {
+	return c != nil && c.cfg.Block
+}
+
+// IsListed reports whether the domain or its registrable parent is on the feed.
+// It is inert (always false) when no feed data has been loaded.
+func (c *Checker) IsListed(domain string) bool {
+	if c == nil {
+		return false
+	}
+	return c.set.Load().Contains(domain)
+}
+
+// Len reports the number of domains currently loaded from the feed.
+func (c *Checker) Len() int {
+	if c == nil {
+		return 0
+	}
+	return c.set.Load().Len()
+}
+
+// load parses a raw feed body and atomically swaps in the resulting set.
+func (c *Checker) load(data []byte) error {
+	p, ok := parser.Get(c.cfg.Format)
+	if !ok {
+		return fmt.Errorf("nrd: no parser for format %q", c.cfg.Format)
+	}
+	entries, err := p.Parse(data)
+	if err != nil {
+		return fmt.Errorf("nrd: parse feed: %w", err)
+	}
+	domains := make([]string, len(entries))
+	for i, e := range entries {
+		domains[i] = e.Domain
+	}
+	c.set.Store(NewSet(domains))
+	return nil
+}
+
+// Refresh fetches the feed once and swaps in the new set. It honors ETag /
+// If-None-Match: a 304 response leaves the current set untouched. It is a no-op
+// when no feed is configured.
+func (c *Checker) Refresh(ctx context.Context) error {
+	if !c.Enabled() {
+		return nil
+	}
+
+	knownETag := ""
+	if p := c.etag.Load(); p != nil {
+		knownETag = *p
+	}
+
+	src := parser.SourceConfig{
+		ID:     "nrd",
+		Name:   "nrd-feed",
+		URL:    c.cfg.FeedURL,
+		Format: c.cfg.Format,
+	}
+	body, etag, err := c.fetcher.Fetch(ctx, src, knownETag)
+	if err != nil {
+		return fmt.Errorf("nrd: fetch feed: %w", err)
+	}
+	if body == nil {
+		// Not modified; keep the existing set.
+		return nil
+	}
+	if err := c.load(body); err != nil {
+		return err
+	}
+	c.etag.Store(&etag)
+	logger.Log.Infof("NRD feed refreshed: %d domains (block=%v)", c.Len(), c.cfg.Block)
+	return nil
+}
+
+// Run performs an initial refresh and then re-fetches on RefreshInterval until
+// ctx is cancelled. It returns immediately when no feed is configured.
+func (c *Checker) Run(ctx context.Context) {
+	if !c.Enabled() {
+		return
+	}
+	if err := c.Refresh(ctx); err != nil {
+		logger.Log.Errorf("initial NRD feed refresh failed: %v", err)
+	}
+
+	ticker := time.NewTicker(c.cfg.RefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			if err := c.Refresh(rctx); err != nil {
+				logger.Log.Errorf("NRD feed refresh failed: %v", err)
+			}
+			cancel()
+		}
+	}
+}

--- a/internal/nrd/nrd_test.go
+++ b/internal/nrd/nrd_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package nrd
+
+import "testing"
+
+func TestSet_Contains(t *testing.T) {
+	s := NewSet([]string{"evil.com", "bad-domain.net", "Newly.Registered.IO."})
+
+	tests := []struct {
+		name   string
+		domain string
+		want   bool
+	}{
+		{"exact match", "evil.com", true},
+		{"parent-domain match", "login.evil.com", true},
+		{"deep parent-domain match", "a.b.c.evil.com", true},
+		{"fqdn trailing dot", "evil.com.", true},
+		{"uppercase query normalized", "EVIL.COM", true},
+		{"listed entry normalized on load", "newly.registered.io", true},
+		{"not in set", "good.com", false},
+		{"tld only is never a match", "com", false},
+		{"sibling not matched", "notevil.com", false},
+		{"empty query", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.Contains(tt.domain); got != tt.want {
+				t.Errorf("Contains(%q) = %v, want %v", tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSet_Empty_Inert(t *testing.T) {
+	empty := NewSet(nil)
+	if empty.Len() != 0 {
+		t.Fatalf("expected empty set, got len %d", empty.Len())
+	}
+	if empty.Contains("anything.com") {
+		t.Error("empty set must match nothing")
+	}
+}
+
+func TestSet_Nil(t *testing.T) {
+	var s *Set
+	if s.Len() != 0 {
+		t.Errorf("nil set Len = %d, want 0", s.Len())
+	}
+	if s.Contains("evil.com") {
+		t.Error("nil set must match nothing")
+	}
+}
+
+func TestSet_DeduplicatesAndDropsBlanks(t *testing.T) {
+	s := NewSet([]string{"evil.com", "EVIL.COM", "evil.com.", "  ", ""})
+	if s.Len() != 1 {
+		t.Errorf("expected 1 unique domain, got %d", s.Len())
+	}
+}
+
+func TestChecker_NoFeed_Inert(t *testing.T) {
+	c := New(Config{}) // no FeedURL
+	if c.Enabled() {
+		t.Error("checker with no feed URL must not be enabled")
+	}
+	if c.IsListed("evil.com") {
+		t.Error("checker with no loaded feed must be inert")
+	}
+	if c.BlockMode() {
+		t.Error("default checker must be flag mode (BlockMode=false)")
+	}
+	if c.Len() != 0 {
+		t.Errorf("expected 0 loaded domains, got %d", c.Len())
+	}
+}
+
+func TestChecker_Defaults(t *testing.T) {
+	c := New(Config{FeedURL: "https://example.test/nrd.txt"})
+	if !c.Enabled() {
+		t.Error("checker with feed URL must be enabled")
+	}
+	if c.cfg.RefreshInterval != defaultRefreshInterval {
+		t.Errorf("RefreshInterval = %v, want default %v", c.cfg.RefreshInterval, defaultRefreshInterval)
+	}
+	if c.cfg.Format != defaultFormat {
+		t.Errorf("Format = %q, want default %q", c.cfg.Format, defaultFormat)
+	}
+}
+
+func TestChecker_BlockVsFlag(t *testing.T) {
+	block := NewWithSet(NewSet([]string{"evil.com"}), true)
+	if !block.BlockMode() {
+		t.Error("expected BlockMode=true")
+	}
+	if !block.IsListed("evil.com") {
+		t.Error("expected evil.com listed in block-mode checker")
+	}
+
+	flag := NewWithSet(NewSet([]string{"evil.com"}), false)
+	if flag.BlockMode() {
+		t.Error("expected BlockMode=false (flag)")
+	}
+	if !flag.IsListed("sub.evil.com") {
+		t.Error("expected parent-domain match in flag-mode checker")
+	}
+}
+
+func TestChecker_LoadFeed(t *testing.T) {
+	feed := []byte(`# newly registered domains
+evil.com
+bad.net
+
+*.wildcard.org
+notes.example.io   2026-07-19
+; semicolon comment
+`)
+	c := New(Config{FeedURL: "https://example.test/nrd.txt"}) // format defaults to "domains"
+	if err := c.load(feed); err != nil {
+		t.Fatalf("load feed: %v", err)
+	}
+
+	if got, want := c.Len(), 4; got != want {
+		t.Fatalf("loaded %d domains, want %d", got, want)
+	}
+	for _, d := range []string{"evil.com", "bad.net", "wildcard.org", "notes.example.io"} {
+		if !c.IsListed(d) {
+			t.Errorf("expected %q to be listed after load", d)
+		}
+	}
+	// Parent match through a loaded feed entry.
+	if !c.IsListed("mail.evil.com") {
+		t.Error("expected parent-domain match for mail.evil.com")
+	}
+	if c.IsListed("clean.com") {
+		t.Error("unlisted domain must not match")
+	}
+}
+
+func TestChecker_LoadFeed_ReplacesSet(t *testing.T) {
+	c := New(Config{FeedURL: "https://example.test/nrd.txt"})
+	if err := c.load([]byte("first.com\n")); err != nil {
+		t.Fatal(err)
+	}
+	if !c.IsListed("first.com") {
+		t.Fatal("first.com should be listed after initial load")
+	}
+	if err := c.load([]byte("second.com\n")); err != nil {
+		t.Fatal(err)
+	}
+	if c.IsListed("first.com") {
+		t.Error("first.com should be gone after set replacement")
+	}
+	if !c.IsListed("second.com") {
+		t.Error("second.com should be listed after replacement")
+	}
+}
+
+func TestChecker_Nil(t *testing.T) {
+	var c *Checker
+	if c.Enabled() || c.BlockMode() || c.IsListed("evil.com") || c.Len() != 0 {
+		t.Error("nil checker must be fully inert")
+	}
+}

--- a/internal/nrd/set.go
+++ b/internal/nrd/set.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package nrd implements newly-registered-domain (NRD) blocking.
+//
+// An NRD feed is an operator-configured list of recently registered domains
+// (external registration-date truth). It is maintained entirely separately from
+// user blocklists and from the local first-seen ledger. When a feed is
+// configured, a query whose domain or registrable parent appears on the feed is
+// either blocked (respondBlocked reason "nrd") or, in flag mode, forwarded but
+// flagged. With no feed configured the checker is inert.
+package nrd
+
+import "strings"
+
+// Set is an immutable, read-optimized in-memory set of NRD domains. A nil or
+// empty Set matches nothing, which makes the "no feed" case naturally inert.
+type Set struct {
+	domains map[string]struct{}
+}
+
+// NewSet builds a Set from a list of domains, normalizing and de-duplicating
+// each entry. Blank entries are dropped.
+func NewSet(domains []string) *Set {
+	m := make(map[string]struct{}, len(domains))
+	for _, d := range domains {
+		if d = normalize(d); d != "" {
+			m[d] = struct{}{}
+		}
+	}
+	return &Set{domains: m}
+}
+
+// Len reports the number of domains in the set. Safe on a nil receiver.
+func (s *Set) Len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.domains)
+}
+
+// Contains reports whether the domain, or any of its parent domains down to the
+// registrable parent, is present in the set. NRD feeds list registrable domains,
+// so a hit on "evil.com" also matches "login.evil.com". Safe on a nil receiver.
+func (s *Set) Contains(domain string) bool {
+	if s == nil || len(s.domains) == 0 {
+		return false
+	}
+	d := normalize(domain)
+	if d == "" {
+		return false
+	}
+	// Exact match first, then walk up the parent labels but stop before the TLD:
+	// "www.ads.evil.com" -> "ads.evil.com" -> "evil.com".
+	parts := strings.Split(d, ".")
+	for i := 0; i < len(parts)-1; i++ {
+		if _, ok := s.domains[strings.Join(parts[i:], ".")]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// normalize lowercases, trims surrounding whitespace, and strips a trailing dot.
+func normalize(d string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(d)), ".")
+}


### PR DESCRIPTION
## What
Adds newly-registered-domain (NRD) blocking: an operator-configurable feed of recently registered domains that is either **blocked** or **flagged** at query time. Distinct from the local first-seen ledger — this relies on external registration-date truth. Default **OFF**: with no feed configured the feature is completely inert.

## Why
Freshly registered domains are a strong signal for phishing, malware C2, and typosquatting campaigns, which frequently rotate to brand-new domains hours after registration. Letting operators subscribe to an NRD feed gives an early, low-false-positive block/flag layer that user blocklists (which lag registration) cannot provide.

## How
- **`internal/nrd` (new package)**
  - `Set`: immutable, read-optimized in-memory domain set. `Contains` matches the exact domain or any parent down to the registrable parent (`login.evil.com` → `evil.com`). Nil/empty sets match nothing, so "no feed" is naturally inert.
  - `Checker`: holds the current set behind `atomic.Pointer`, refreshing it periodically. It **reuses the blocklist HTTP fetcher** (ETag / conditional-GET) and the **parser registry**, keeping the NRD set entirely separate from user blocklists.
- **`domains` parser**: fills the existing empty parser stub — one registrable domain per line, tolerating comments (`#`/`;`), blank lines, `*.` wildcards, trailing dots, and trailing columns. Used as the default NRD feed format.
- **Config**: `NRD_FEED_URL`, `NRD_BLOCK` (bool, default `false` = flag), `NRD_REFRESH_INTERVAL` (default `6h`), via both env and YAML (`nrd_feed_url`, `nrd_block`, `nrd_refresh_interval`).
- **Engine wiring**: after the user-blocklist check, if the domain or its registrable parent is on the NRD set — block via `respondBlocked` reason `"nrd"` (block mode), or flag on the allow path (flag mode). The dataplane constructs the checker from config, attaches it to the engine, and only starts the refresh loop when a feed URL is set.

## Tests
Deterministic, no live network — feed/set data is mocked:
- `internal/nrd`: exact match, parent-domain match, not-in-set, empty/no-feed inert, block vs flag, feed load + set replacement, nil/normalization safety.
- `internal/blocklist/parser`: `domains` parser parsing, comment/blank handling, registry registration.
- `internal/dnsengine`: NRD block (exact + parent match) → `0.0.0.0`; flag mode not blocked (forwarded); not-listed passes; no-feed inert. Flag/allow paths use an empty upstream manager so they resolve to SERVFAIL without any network.

`gofmt`, `go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)