### PR TITLE
feat(dataplane): optional DNSSEC validation (I-025)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,6 +6,11 @@ dataplane:
   anonymization:
     secret: "${PHANTOM_ANON_SECRET:-change-me-in-production}"
   blocklist_update_interval: "6h"
+  # Optional DNSSEC validation of upstream answers. Default false (off): resolution
+  # behaviour is unchanged unless enabled. When true, the DO bit is set on upstream
+  # queries and RRSIG signatures over answer RRsets are validated; answers that fail
+  # (BOGUS) return SERVFAIL, unsigned/insecure zones pass through. Env: DNSSEC_VALIDATION.
+  dnssec_validation: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 // SPDX-License-Identifier: GPL-3.0-or-later
 import (
 	"os"
+	"strconv"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,9 @@ type DataPlaneConfig struct {
 	UpstreamResolvers       []string         `yaml:"upstream_resolvers"`
 	GRPCServer              GRPCServerConfig `yaml:"grpc_server"`
 	BlocklistUpdateInterval string           `yaml:"blocklist_update_interval"`
+	// DNSSECValidation enables validation of RRSIG signatures over upstream answer
+	// RRsets. Default false (off): resolution behaviour is unchanged unless enabled.
+	DNSSECValidation bool `yaml:"dnssec_validation"`
 }
 
 type ControlPlaneConfig struct {
@@ -70,8 +74,22 @@ var DefaultConfig = func() *Config {
 	if interval := os.Getenv("BLOCKLIST_UPDATE_INTERVAL"); interval != "" {
 		cfg.DataPlane.BlocklistUpdateInterval = interval
 	}
+	if v := os.Getenv("DNSSEC_VALIDATION"); v != "" {
+		cfg.DataPlane.DNSSECValidation = parseBoolEnv(v, cfg.DataPlane.DNSSECValidation)
+	}
 	return cfg
 }()
+
+// parseBoolEnv parses a boolean environment variable, falling back to def on an
+// unparseable value (and logging a warning) rather than silently flipping a flag.
+func parseBoolEnv(v string, def bool) bool {
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		logger.Log.Warnf("invalid boolean env value %q, using %v", v, def)
+		return def
+	}
+	return b
+}
 
 func configPath() string {
 	if p := os.Getenv("PHANTOM_CONFIG"); p != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package config
+
+import "testing"
+
+func TestParseBoolEnv(t *testing.T) {
+	tests := []struct {
+		in   string
+		def  bool
+		want bool
+	}{
+		{"true", false, true},
+		{"1", false, true},
+		{"false", true, false},
+		{"0", true, false},
+		{"", true, true},           // empty is not parseable -> default
+		{"nonsense", false, false}, // invalid -> default
+		{"nonsense", true, true},   // invalid -> default
+	}
+	for _, tt := range tests {
+		if got := parseBoolEnv(tt.in, tt.def); got != tt.want {
+			t.Errorf("parseBoolEnv(%q, %v) = %v, want %v", tt.in, tt.def, got, tt.want)
+		}
+	}
+}

--- a/internal/dnsengine/dnssec.go
+++ b/internal/dnsengine/dnssec.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Optional DNSSEC validation of upstream responses (feature I-025).
+//
+// SCOPE (validated vs not):
+//
+//	Validated:
+//	  - RRSIG signatures over each signed RRset present in the Answer section are
+//	    cryptographically verified against the signer zone's DNSKEY RRset
+//	    (RFC 4034/4035 §5.3), including RRSIG validity-period (inception/expiration)
+//	    checks and KeyTag/Algorithm matching.
+//	  - Answers whose signatures fail (tampered, expired, or wrong key) are BOGUS.
+//	  - Answers with no signatures are treated as INSECURE and pass through unchanged.
+//
+//	NOT validated (documented follow-ups, out of scope here):
+//	  - The DNSKEY RRset itself is not chained to the parent DS record nor to a root
+//	    trust anchor. We validate answer RRSIGs against the DNSKEY served for the
+//	    signer zone; full delegation-chain-to-root-anchor validation is a follow-up.
+//	  - Negative responses (NXDOMAIN/NODATA) are not authenticated via NSEC/NSEC3.
+//	  - If the DNSKEY RRset cannot be retrieved, the answer soft-fails to INSECURE
+//	    (pass through) rather than SERVFAIL, to keep a partial validator from
+//	    breaking resolution.
+//
+// The core classification logic below is pure and hermetically unit-tested with
+// static, in-test signed fixtures (no live network, no live resolvers).
+package dnsengine
+
+import (
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// ValidationStatus is the DNSSEC validation outcome for a response.
+type ValidationStatus int
+
+const (
+	// StatusInsecure means the answer carried no DNSSEC signatures (unsigned/insecure
+	// zone), or nothing validatable was present. Such answers pass through unchanged.
+	StatusInsecure ValidationStatus = iota
+	// StatusSecure means at least one signed RRset in the answer verified against a
+	// DNSKEY and no signed RRset failed. The answer passes through unchanged.
+	StatusSecure
+	// StatusBogus means the answer contained DNSSEC signatures but at least one signed
+	// RRset failed validation (bad signature, wrong key, or outside its validity
+	// period). Bogus answers are rejected with SERVFAIL.
+	StatusBogus
+)
+
+func (s ValidationStatus) String() string {
+	switch s {
+	case StatusSecure:
+		return "SECURE"
+	case StatusBogus:
+		return "BOGUS"
+	default:
+		return "INSECURE"
+	}
+}
+
+// keyFetcher returns the DNSKEY RRset for a signer zone. The live implementation
+// queries the upstream resolver; tests inject a hermetic stub.
+type keyFetcher func(signer string) ([]*dns.DNSKEY, error)
+
+// coveredRRSet is a group of Answer records sharing an owner name, type and class,
+// together with the RRSIG record(s) that cover them.
+type coveredRRSet struct {
+	name   string
+	rtype  uint16
+	rrset  []dns.RR
+	rrsigs []*dns.RRSIG
+}
+
+// groupSignedRRSets partitions the Answer section into RRsets and attaches the
+// RRSIG(s) that cover each. RRsets with no covering RRSIG are still returned (with
+// an empty rrsigs slice) so callers can distinguish "unsigned" from "absent".
+func groupSignedRRSets(answer []dns.RR) []coveredRRSet {
+	type key struct {
+		name  string
+		rtype uint16
+		class uint16
+	}
+	order := make([]key, 0)
+	sets := make(map[key]*coveredRRSet)
+	var sigs []*dns.RRSIG
+
+	for _, rr := range answer {
+		if sig, ok := rr.(*dns.RRSIG); ok {
+			sigs = append(sigs, sig)
+			continue
+		}
+		h := rr.Header()
+		k := key{strings.ToLower(h.Name), h.Rrtype, h.Class}
+		cs, exists := sets[k]
+		if !exists {
+			cs = &coveredRRSet{name: h.Name, rtype: h.Rrtype}
+			sets[k] = cs
+			order = append(order, k)
+		}
+		cs.rrset = append(cs.rrset, rr)
+	}
+
+	for _, sig := range sigs {
+		k := key{strings.ToLower(sig.Header().Name), sig.TypeCovered, sig.Header().Class}
+		if cs, ok := sets[k]; ok {
+			cs.rrsigs = append(cs.rrsigs, sig)
+		}
+	}
+
+	out := make([]coveredRRSet, 0, len(order))
+	for _, k := range order {
+		out = append(out, *sets[k])
+	}
+	return out
+}
+
+// validateRRSet verifies the RRSIG(s) covering a single RRset against a candidate
+// DNSKEY set at time now. It is the pure cryptographic heart of the validator.
+//
+//	StatusInsecure — no RRSIGs cover the RRset (unsigned).
+//	StatusSecure   — at least one RRSIG is within its validity period AND verifies
+//	                 against a DNSKEY whose KeyTag and Algorithm match.
+//	StatusBogus    — RRSIGs exist but none validate (tampered, expired, or wrong key).
+func validateRRSet(cs coveredRRSet, keys []*dns.DNSKEY, now time.Time) ValidationStatus {
+	if len(cs.rrsigs) == 0 {
+		return StatusInsecure
+	}
+	for _, sig := range cs.rrsigs {
+		if !sig.ValidityPeriod(now) {
+			continue // expired or not yet valid
+		}
+		for _, k := range keys {
+			if k == nil || k.KeyTag() != sig.KeyTag || k.Algorithm != sig.Algorithm {
+				continue
+			}
+			if err := sig.Verify(k, cs.rrset); err == nil {
+				return StatusSecure
+			}
+		}
+	}
+	return StatusBogus
+}
+
+// classifyResponse determines the DNSSEC status of resp's Answer section. It fetches
+// the DNSKEY RRset for each distinct signer via fetch (cached per call) and returns
+// the "worst" outcome: BOGUS if any signed RRset fails, SECURE if at least one signed
+// RRset validates and none fail, INSECURE if nothing was signed (or keys were
+// unavailable — see package scope note on soft-failing).
+func classifyResponse(resp *dns.Msg, fetch keyFetcher, now time.Time) ValidationStatus {
+	if resp == nil {
+		return StatusInsecure
+	}
+
+	keyCache := make(map[string][]*dns.DNSKEY)
+	sawSecure := false
+
+	for _, g := range groupSignedRRSets(resp.Answer) {
+		if len(g.rrsigs) == 0 {
+			continue // unsigned RRset: nothing to prove here
+		}
+
+		signer := g.rrsigs[0].SignerName
+		keys, cached := keyCache[signer]
+		if !cached {
+			fetched, err := fetch(signer)
+			if err != nil || len(fetched) == 0 {
+				// Keys unavailable: soft-fail to insecure rather than break
+				// resolution for a partial validator (documented limitation).
+				keyCache[signer] = nil
+				continue
+			}
+			keys = fetched
+			keyCache[signer] = keys
+		}
+		if keys == nil {
+			continue
+		}
+
+		switch validateRRSet(g, keys, now) {
+		case StatusBogus:
+			return StatusBogus
+		case StatusSecure:
+			sawSecure = true
+		}
+	}
+
+	if sawSecure {
+		return StatusSecure
+	}
+	return StatusInsecure
+}
+
+// setDO ensures the DNSSEC OK (DO) bit is set on an outgoing query so upstream
+// resolvers return RRSIG records. It preserves any existing EDNS0 OPT record.
+func setDO(m *dns.Msg) {
+	if opt := m.IsEdns0(); opt != nil {
+		opt.SetDo(true)
+		if opt.UDPSize() < dns.MinMsgSize {
+			opt.SetUDPSize(4096)
+		}
+		return
+	}
+	m.SetEdns0(4096, true)
+}
+
+// extractDNSKEYs pulls the DNSKEY records out of a DNSKEY response's Answer section.
+func extractDNSKEYs(resp *dns.Msg) []*dns.DNSKEY {
+	if resp == nil {
+		return nil
+	}
+	var keys []*dns.DNSKEY
+	for _, rr := range resp.Answer {
+		if k, ok := rr.(*dns.DNSKEY); ok {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}

--- a/internal/dnsengine/dnssec_test.go
+++ b/internal/dnsengine/dnssec_test.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"crypto"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/config"
+	"github.com/lopster568/phantomDNS/internal/policy"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"github.com/miekg/dns"
+)
+
+const testZone = "example.com."
+
+// baseTime is a fixed reference instant so signature validity windows are fully
+// deterministic (no reliance on wall-clock time).
+var baseTime = time.Unix(1_700_000_000, 0).UTC()
+
+func mustRR(t *testing.T, s string) dns.RR {
+	t.Helper()
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		t.Fatalf("parse RR %q: %v", s, err)
+	}
+	return rr
+}
+
+// makeSignedFixture builds a signed A RRset for example.com using a freshly
+// generated ECDSA P256 key. Fully hermetic: no network, no live resolver. The
+// inception/expiration offsets are relative to baseTime so callers can craft
+// expired or not-yet-valid vectors.
+func makeSignedFixture(t *testing.T, inceptionOffset, expirationOffset time.Duration) (*dns.DNSKEY, []dns.RR, *dns.RRSIG) {
+	t.Helper()
+
+	key := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: testZone, Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: dns.ECDSAP256SHA256,
+	}
+	priv, err := key.Generate(256)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, ok := priv.(crypto.Signer)
+	if !ok {
+		t.Fatalf("private key does not implement crypto.Signer")
+	}
+
+	rrset := []dns.RR{mustRR(t, testZone+" 3600 IN A 93.184.216.34")}
+
+	sig := &dns.RRSIG{
+		Hdr:         dns.RR_Header{Name: testZone, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+		TypeCovered: dns.TypeA,
+		Algorithm:   key.Algorithm,
+		Labels:      uint8(dns.CountLabel(testZone)),
+		OrigTtl:     3600,
+		Inception:   uint32(baseTime.Add(inceptionOffset).Unix()),
+		Expiration:  uint32(baseTime.Add(expirationOffset).Unix()),
+		KeyTag:      key.KeyTag(),
+		SignerName:  testZone,
+	}
+	if err := sig.Sign(signer, rrset); err != nil {
+		t.Fatalf("sign RRset: %v", err)
+	}
+	return key, rrset, sig
+}
+
+func msgWithAnswer(rrs ...dns.RR) *dns.Msg {
+	m := new(dns.Msg)
+	m.Answer = append(m.Answer, rrs...)
+	return m
+}
+
+// --- Core validateRRSet tests (pure, no network) ---
+
+func TestValidateRRSet_ValidSecure(t *testing.T) {
+	key, rrset, sig := makeSignedFixture(t, -time.Hour, 24*time.Hour)
+	cs := coveredRRSet{name: testZone, rtype: dns.TypeA, rrset: rrset, rrsigs: []*dns.RRSIG{sig}}
+
+	if got := validateRRSet(cs, []*dns.DNSKEY{key}, baseTime); got != StatusSecure {
+		t.Fatalf("valid signature: want SECURE, got %s", got)
+	}
+}
+
+func TestValidateRRSet_TamperedAnswerBogus(t *testing.T) {
+	key, _, sig := makeSignedFixture(t, -time.Hour, 24*time.Hour)
+	// The answer the client would receive has been altered in transit; the RRSIG
+	// no longer covers it.
+	tampered := []dns.RR{mustRR(t, testZone+" 3600 IN A 6.6.6.6")}
+	cs := coveredRRSet{name: testZone, rtype: dns.TypeA, rrset: tampered, rrsigs: []*dns.RRSIG{sig}}
+
+	if got := validateRRSet(cs, []*dns.DNSKEY{key}, baseTime); got != StatusBogus {
+		t.Fatalf("tampered answer: want BOGUS, got %s", got)
+	}
+}
+
+func TestValidateRRSet_WrongKeyBogus(t *testing.T) {
+	_, rrset, sig := makeSignedFixture(t, -time.Hour, 24*time.Hour)
+	// An unrelated key: its KeyTag will not match the RRSIG, so validation cannot
+	// succeed.
+	otherKey, _, _ := makeSignedFixture(t, -time.Hour, 24*time.Hour)
+	cs := coveredRRSet{name: testZone, rtype: dns.TypeA, rrset: rrset, rrsigs: []*dns.RRSIG{sig}}
+
+	if got := validateRRSet(cs, []*dns.DNSKEY{otherKey}, baseTime); got != StatusBogus {
+		t.Fatalf("wrong key: want BOGUS, got %s", got)
+	}
+}
+
+func TestValidateRRSet_ExpiredBogus(t *testing.T) {
+	// Signature expired one hour before baseTime.
+	key, rrset, sig := makeSignedFixture(t, -48*time.Hour, -time.Hour)
+	cs := coveredRRSet{name: testZone, rtype: dns.TypeA, rrset: rrset, rrsigs: []*dns.RRSIG{sig}}
+
+	if got := validateRRSet(cs, []*dns.DNSKEY{key}, baseTime); got != StatusBogus {
+		t.Fatalf("expired signature: want BOGUS, got %s", got)
+	}
+}
+
+func TestValidateRRSet_UnsignedInsecure(t *testing.T) {
+	rrset := []dns.RR{mustRR(t, testZone+" 3600 IN A 93.184.216.34")}
+	cs := coveredRRSet{name: testZone, rtype: dns.TypeA, rrset: rrset}
+
+	if got := validateRRSet(cs, nil, baseTime); got != StatusInsecure {
+		t.Fatalf("unsigned RRset: want INSECURE, got %s", got)
+	}
+}
+
+// --- classifyResponse tests (message-level, injected key fetcher) ---
+
+func TestClassifyResponse_SecurePassthrough(t *testing.T) {
+	key, rrset, sig := makeSignedFixture(t, -time.Hour, 24*time.Hour)
+	resp := msgWithAnswer(append(rrset, sig)...)
+	fetch := func(string) ([]*dns.DNSKEY, error) { return []*dns.DNSKEY{key}, nil }
+
+	if got := classifyResponse(resp, fetch, baseTime); got != StatusSecure {
+		t.Fatalf("want SECURE, got %s", got)
+	}
+}
+
+func TestClassifyResponse_BogusServfail(t *testing.T) {
+	key, _, sig := makeSignedFixture(t, -time.Hour, 24*time.Hour)
+	tampered := mustRR(t, testZone+" 3600 IN A 6.6.6.6")
+	resp := msgWithAnswer(tampered, sig)
+	fetch := func(string) ([]*dns.DNSKEY, error) { return []*dns.DNSKEY{key}, nil }
+
+	if got := classifyResponse(resp, fetch, baseTime); got != StatusBogus {
+		t.Fatalf("tampered answer: want BOGUS, got %s", got)
+	}
+}
+
+func TestClassifyResponse_UnsignedInsecure(t *testing.T) {
+	resp := msgWithAnswer(mustRR(t, testZone+" 3600 IN A 1.2.3.4"))
+	fetch := func(string) ([]*dns.DNSKEY, error) {
+		t.Fatal("key fetch must not be called for an unsigned answer")
+		return nil, nil
+	}
+
+	if got := classifyResponse(resp, fetch, baseTime); got != StatusInsecure {
+		t.Fatalf("unsigned answer: want INSECURE, got %s", got)
+	}
+}
+
+func TestClassifyResponse_KeyFetchFailSoftInsecure(t *testing.T) {
+	_, rrset, sig := makeSignedFixture(t, -time.Hour, 24*time.Hour)
+	resp := msgWithAnswer(append(rrset, sig)...)
+	fetch := func(string) ([]*dns.DNSKEY, error) { return nil, errors.New("DNSKEY fetch failed") }
+
+	// Keys unavailable soft-fails to INSECURE (passthrough) rather than SERVFAIL,
+	// so a partial validator cannot break resolution on a transient failure.
+	if got := classifyResponse(resp, fetch, baseTime); got != StatusInsecure {
+		t.Fatalf("key fetch failure: want INSECURE (soft-fail), got %s", got)
+	}
+}
+
+func TestClassifyResponse_NilInsecure(t *testing.T) {
+	if got := classifyResponse(nil, nil, baseTime); got != StatusInsecure {
+		t.Fatalf("nil response: want INSECURE, got %s", got)
+	}
+}
+
+// --- helpers: DO bit + DNSKEY extraction ---
+
+func TestSetDO(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion(testZone, dns.TypeA)
+
+	setDO(m)
+	opt := m.IsEdns0()
+	if opt == nil {
+		t.Fatal("expected an OPT record after setDO")
+	}
+	if !opt.Do() {
+		t.Fatal("expected DO bit to be set")
+	}
+
+	// Idempotent: calling again keeps the DO bit set and does not add a second OPT.
+	setDO(m)
+	if !m.IsEdns0().Do() {
+		t.Fatal("DO bit lost after second setDO")
+	}
+	if len(m.Extra) != 1 {
+		t.Fatalf("expected exactly one OPT record, got %d Extra RRs", len(m.Extra))
+	}
+}
+
+func TestExtractDNSKEYs(t *testing.T) {
+	key, _, _ := makeSignedFixture(t, -time.Hour, 24*time.Hour)
+	resp := msgWithAnswer(key, mustRR(t, testZone+" 3600 IN A 1.2.3.4"))
+
+	keys := extractDNSKEYs(resp)
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 DNSKEY, got %d", len(keys))
+	}
+	if extractDNSKEYs(nil) != nil {
+		t.Fatal("expected nil for nil response")
+	}
+}
+
+// --- engine wiring: default OFF, opt-in ON ---
+
+func TestNewDNSEngine_DNSSECDefaultOff(t *testing.T) {
+	repos := &repositories.Store{}
+	pe := policy.NewPolicyEngine()
+	// No DNSSECValidation set -> zero value false.
+	cfg := config.DataPlaneConfig{UpstreamResolvers: []string{"127.0.0.1:53"}}
+
+	e, err := NewDNSEngine(cfg, repos, pe)
+	if err != nil {
+		t.Fatalf("NewDNSEngine: %v", err)
+	}
+	defer e.Shutdown()
+
+	if e.dnssecEnabled {
+		t.Fatal("DNSSEC validation must default to OFF")
+	}
+}
+
+func TestNewDNSEngine_DNSSECOptIn(t *testing.T) {
+	repos := &repositories.Store{}
+	pe := policy.NewPolicyEngine()
+	cfg := config.DataPlaneConfig{
+		UpstreamResolvers: []string{"127.0.0.1:53"},
+		DNSSECValidation:  true,
+	}
+
+	e, err := NewDNSEngine(cfg, repos, pe)
+	if err != nil {
+		t.Fatalf("NewDNSEngine: %v", err)
+	}
+	defer e.Shutdown()
+
+	if !e.dnssecEnabled {
+		t.Fatal("DNSSEC validation must be ON when opted in")
+	}
+}

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -35,6 +35,9 @@ type Engine struct {
 	queryLog        repositories.QueryLogRepository
 	statistics      repositories.StatisticsRepository
 	threatDetector  *threat.Detector
+	// dnssecEnabled turns on optional DNSSEC validation of upstream answers.
+	// Default false — resolution behaviour is unchanged unless an operator opts in.
+	dnssecEnabled bool
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -50,6 +53,9 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 	if err != nil {
 		return nil, err
 	}
+	if cfg.DNSSECValidation {
+		logger.Log.Info("DNSSEC validation enabled (answer-RRset RRSIG validation)")
+	}
 	return &Engine{
 		upstreamManager: mgr,
 		policyEngine:    pE,
@@ -58,6 +64,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		queryLog:        repos.QueryLogs,
 		statistics:      repos.Statistics,
 		threatDetector:  threat.NewDetector(),
+		dnssecEnabled:   cfg.DNSSECValidation,
 	}, nil
 }
 
@@ -113,6 +120,12 @@ func (e *Engine) respondRedirect(w dns.ResponseWriter, r *dns.Msg, domain, ip st
 }
 
 func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string) {
+	// When DNSSEC validation is enabled, request signatures from the upstream by
+	// setting the DO bit. This is a no-op on the query path when disabled.
+	if e.dnssecEnabled {
+		setDO(r)
+	}
+
 	resp, err := e.upstreamManager.Exchange(r, 5, 2)
 	if err != nil {
 		logger.Log.Error("Upstream query failed: " + err.Error())
@@ -128,9 +141,39 @@ func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string
 		_ = w.WriteMsg(m)
 		return
 	}
+
+	// Validate signed answers. Only BOGUS (signatures present but failing) is
+	// rejected; INSECURE (unsigned) and SECURE both pass through unchanged.
+	if e.dnssecEnabled {
+		if status := classifyResponse(resp, e.fetchDNSKEYs, time.Now()); status == StatusBogus {
+			logger.Log.Warnf("DNSSEC validation BOGUS for %s → SERVFAIL", domain)
+			m := new(dns.Msg)
+			m.SetRcode(r, dns.RcodeServerFailure)
+			if err := w.WriteMsg(m); err != nil {
+				logger.Log.Error("Failed to write SERVFAIL response: " + err.Error())
+			}
+			return
+		}
+	}
 	if err := w.WriteMsg(resp); err != nil {
 		logger.Log.Error("Failed to write DNS response: " + err.Error())
 	}
+}
+
+// fetchDNSKEYs retrieves the DNSKEY RRset for a signer zone from the upstream
+// resolver (with the DO bit set). It satisfies the keyFetcher contract used by
+// classifyResponse. Note: the returned keys are used to validate answer RRSIGs but
+// are not themselves chained to the parent DS / root trust anchor (see dnssec.go
+// scope note) — that is a documented follow-up.
+func (e *Engine) fetchDNSKEYs(signer string) ([]*dns.DNSKEY, error) {
+	q := new(dns.Msg)
+	q.SetQuestion(dns.Fqdn(signer), dns.TypeDNSKEY)
+	setDO(q)
+	resp, err := e.upstreamManager.Exchange(q, 5, 2)
+	if err != nil {
+		return nil, err
+	}
+	return extractDNSKEYs(resp), nil
 }
 
 // normalizeDomain lowercases and strips the trailing dot from a DNS FQDN.


### PR DESCRIPTION
## Summary

Adds **optional DNSSEC validation** of upstream responses to the data plane, gated
behind a new config flag that is **OFF by default**. With the flag off (the default),
the resolve path is byte-for-byte unchanged — no DO bit, no extra queries, no new
failure modes.

## Why

DNSSEC lets a resolver detect answers that were tampered with in transit (cache
poisoning / on-path spoofing). This lands the mechanism as an opt-in so it can be
validated in the field before ever affecting real resolution.

## How

- **Config** (`internal/config`): new `DataPlaneConfig.DNSSECValidation` — yaml
  `dnssec_validation`, env `DNSSEC_VALIDATION`, default `false`. Documented in
  `configs/config.yaml`.
- **Query path** (`internal/dnsengine/engine.go`): when enabled, `setDO` sets the
  EDNS0 DO bit on the outgoing query so upstreams return RRSIGs. When disabled, the
  query is untouched.
- **Response path**: `classifyResponse` inspects the answer and returns
  `SECURE` / `INSECURE` / `BOGUS`. Only **BOGUS** is rejected (SERVFAIL);
  `INSECURE` (unsigned) and `SECURE` both pass through unchanged.
- **Pure validation core** (`internal/dnsengine/dnssec.go`): `groupSignedRRSets`,
  `validateRRSet`, `classifyResponse` are pure functions (key fetching is injected),
  so the crypto is unit-testable with static fixtures and no network.
- Signer DNSKEYs are fetched from the upstream via `Engine.fetchDNSKEYs` (a DNSKEY
  query with the DO bit set).

## Validation scope (what is and is NOT validated)

**Validated:**
- RRSIG signatures over each signed RRset in the Answer section are cryptographically
  verified against the signer zone's DNSKEY RRset (RFC 4034/4035 §5.3).
- RRSIG validity-period (inception/expiration) is enforced, plus KeyTag/Algorithm
  matching.
- Tampered / expired / wrong-key signatures ⇒ **BOGUS** ⇒ SERVFAIL.
- Unsigned answers ⇒ **INSECURE** ⇒ pass through (never blocked).

**NOT validated (explicit follow-ups — this is a correct subset, not a full validator):**
- The DNSKEY RRset itself is **not** chained to the parent DS record or to a root
  trust anchor. We validate answer RRSIGs against the DNSKEY served for the signer
  zone; **full delegation-chain-to-root-anchor validation is a follow-up.**
- Negative responses (NXDOMAIN/NODATA) are **not** authenticated via NSEC/NSEC3.
- If the DNSKEY RRset cannot be retrieved, the answer **soft-fails to INSECURE**
  (pass through) rather than SERVFAIL, so a partial validator cannot break
  resolution on a transient failure.

The code does not claim more than it verifies; the limitations above are also
documented in the package doc comment of `dnssec.go`.

## Default-off / blast radius

`DNSSEC_VALIDATION` defaults to `false`. With it off, none of the new code runs on
the resolve path. An incomplete validator therefore cannot break resolution unless
an operator explicitly opts in.

## Tests

Hermetic — static, in-test signed fixtures (freshly generated ECDSA P256 key,
signed RRset, fixed validity window). **No live network, no live resolvers.**

- valid RRSIG/DNSKEY ⇒ SECURE
- tampered answer ⇒ BOGUS
- wrong key ⇒ BOGUS
- expired signature ⇒ BOGUS
- unsigned ⇒ INSECURE (pass through)
- `classifyResponse`: secure passthrough / bogus SERVFAIL / unsigned / key-fetch
  soft-fail / nil
- DO-bit set + idempotent, DNSKEY extraction
- engine wiring: DNSSEC **default OFF**, opt-in ON
- config: `parseBoolEnv` env parsing

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
