### PR TITLE
feat: LOCAL_ONLY custody master-switch (I-061)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -19,6 +19,8 @@ import (
 )
 
 func main() {
+	config.LogCustodyMode()
+
 	// Initialize database
 	dbPath := "/app/data/phantomdns.db"
 	if p := os.Getenv("PHANTOM_DB"); p != "" {

--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -26,6 +26,7 @@ import (
 
 func main() {
 	logger.Log.Info("Starting PhantomDNS Data Plane...")
+	config.LogCustodyMode()
 
 	// 1. Initialize DB
 	dbPath := "/app/data/phantomdns.db"

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,3 +1,10 @@
+# local_only: data-custody master switch (I-061).
+# When true, all non-resolution outbound ("phone-home") calls are disabled:
+# telemetry, update checks, crash reporting, remote config, heartbeats.
+# Core DNS resolution and operator-configured blocklist fetches still work.
+# Overridable at runtime via the LOCAL_ONLY environment variable. Default: false.
+local_only: false
+
 dataplane:
   listen_addr: "0.0.0.0:1053"
   upstream_resolvers:

--- a/internal/blocklist/fetcher/http_client.go
+++ b/internal/blocklist/fetcher/http_client.go
@@ -24,6 +24,11 @@ func NewHTTPFetcher() *HTTPFetcher {
 }
 
 // Fetch returns body bytes, etag string, and error.
+//
+// Custody note (LOCAL_ONLY / I-061): this outbound request is ALLOWED even
+// under LOCAL_ONLY. Pulling operator-configured blocklist sources is a core
+// filtering function, not a phone-home, so it is intentionally NOT gated by
+// config.LocalOnly(). See internal/config/local_only.go for the contract.
 func (h *HTTPFetcher) Fetch(ctx context.Context, src parser.SourceConfig, knownETag string) ([]byte, string, error) {
 	var body []byte
 	var etag string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,15 @@ import (
 type Config struct {
 	DataPlane    DataPlaneConfig    `yaml:"dataplane"`
 	ControlPlane ControlPlaneConfig `yaml:"controlplane"`
+
+	// LocalOnly is the data-custody master switch. When true, every
+	// non-resolution outbound ("phone-home") network call MUST be
+	// short-circuited. Default false.
+	//
+	// Do NOT read this field directly from outbound code paths; consult the
+	// LocalOnly() accessor (env override aware) and AssertLocalOnlyRespected()
+	// guard instead. See internal/config/local_only.go for the full contract.
+	LocalOnly bool `yaml:"local_only"`
 }
 
 type GRPCServerConfig struct {

--- a/internal/config/local_only.go
+++ b/internal/config/local_only.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package config
+
+import (
+	"os"
+	"strings"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+// ============================================================================
+// LOCAL_ONLY — data-custody master switch (I-061)
+// ============================================================================
+//
+// HydraDNS makes a provable data-custody guarantee: when LOCAL_ONLY is engaged,
+// the appliance performs NO non-resolution outbound network traffic. Nothing
+// "phones home" — no telemetry, no usage analytics, no update pings, no crash
+// reports, no remote config pulls. Only the traffic required to actually
+// resolve and filter DNS leaves the box.
+//
+// THE CONTRACT
+// ------------
+// Any code path that makes a NON-RESOLUTION outbound network request MUST call
+// AssertLocalOnlyRespected (or check LocalOnly()) FIRST and skip / no-op the
+// request when custody mode is engaged. This is a hard requirement, not a
+// best-effort. New outbound features are reviewed against this contract.
+//
+// ALLOWED under LOCAL_ONLY (core resolution/filtering — NEVER gated):
+//   - DNS resolution to configured upstream resolvers
+//     (internal/dnsengine/*, e.g. connections.go net.Dial).
+//   - Blocklist source fetch over HTTP(S)
+//     (internal/blocklist/fetcher/http_client.go). This is a core filtering
+//     function pulling operator-configured blocklists, not a phone-home.
+//   - Intra-appliance gRPC between control plane and data plane
+//     (internal/grpc/*), which stays on localhost.
+//
+// GATED under LOCAL_ONLY (non-resolution / phone-home — MUST no-op when true):
+//   - Telemetry / usage analytics reporting (see internal/telemetry).
+//   - Software update / version checks.
+//   - Crash / error reporting to any remote sink.
+//   - Remote managed-config or license/heartbeat calls.
+//   - Any future feature that sends data off-box for a reason other than
+//     resolving or filtering a DNS query.
+//
+// Some of the gated features live on other branches; the accessor, the guard,
+// and this contract land on main so those branches have a single switch to
+// consult. internal/telemetry ships the reference implementation of the guard
+// pattern.
+
+// LocalOnly reports whether the data-custody master switch is engaged.
+//
+// Precedence: the LOCAL_ONLY environment variable (if set to a recognized
+// boolean) overrides the yaml/config value; otherwise the configured value is
+// used. Default is false (normal operation).
+//
+// Outbound, non-resolution code paths MUST consult this (or
+// AssertLocalOnlyRespected) and no-op when it returns true.
+func LocalOnly() bool {
+	if v, ok := envBool("LOCAL_ONLY"); ok {
+		return v
+	}
+	return DefaultConfig.LocalOnly
+}
+
+// AssertLocalOnlyRespected is the guard that non-resolution outbound features
+// MUST call before performing a phone-home request. It returns true when the
+// caller MAY proceed with the outbound request, and false when LOCAL_ONLY
+// custody mode requires the caller to skip / no-op it.
+//
+// The feature argument is a short identifier (e.g. "telemetry.Report") used
+// only for logging when a call is suppressed.
+//
+// Canonical usage:
+//
+//	if !config.AssertLocalOnlyRespected("telemetry.Report") {
+//	    return nil // custody mode: no-op, make no outbound request
+//	}
+//	// ... perform the outbound request ...
+func AssertLocalOnlyRespected(feature string) (mayProceed bool) {
+	if LocalOnly() {
+		logger.Log.Warnf("LOCAL_ONLY custody mode engaged: suppressing outbound feature %q", feature)
+		return false
+	}
+	return true
+}
+
+// LogCustodyMode emits a single startup log line stating the current custody
+// mode. Call it once during process startup (data plane and control plane).
+func LogCustodyMode() {
+	if LocalOnly() {
+		logger.Log.Info("data custody: LOCAL_ONLY mode ENGAGED — all non-resolution outbound (phone-home) calls are disabled")
+	} else {
+		logger.Log.Info("data custody: LOCAL_ONLY mode disabled — non-resolution outbound calls permitted (default)")
+	}
+}
+
+// envBool reads a boolean-ish environment variable. ok is false when the
+// variable is unset, empty, or not a recognized boolean (in which case the
+// caller should fall back to the configured value).
+func envBool(key string) (value bool, ok bool) {
+	raw, present := os.LookupEnv(key)
+	if !present {
+		return false, false
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "on":
+		return true, true
+	case "0", "false", "no", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}

--- a/internal/config/local_only_test.go
+++ b/internal/config/local_only_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package config
+
+import "testing"
+
+func TestLocalOnly_DefaultIsFalse(t *testing.T) {
+	t.Setenv("LOCAL_ONLY", "")
+	// With no env override and the default config, custody mode is off.
+	DefaultConfig.LocalOnly = false
+	if LocalOnly() {
+		t.Fatalf("LocalOnly() = true, want false by default")
+	}
+	if !AssertLocalOnlyRespected("test.feature") {
+		t.Fatalf("AssertLocalOnlyRespected() = false, want true when custody mode is off")
+	}
+}
+
+func TestLocalOnly_EnvOverridesConfig(t *testing.T) {
+	// Config says false, env forces custody mode on.
+	DefaultConfig.LocalOnly = false
+
+	truthy := []string{"1", "true", "TRUE", "yes", "on"}
+	for _, v := range truthy {
+		t.Setenv("LOCAL_ONLY", v)
+		if !LocalOnly() {
+			t.Fatalf("LocalOnly() = false for LOCAL_ONLY=%q, want true", v)
+		}
+		if AssertLocalOnlyRespected("test.feature") {
+			t.Fatalf("AssertLocalOnlyRespected() = true for LOCAL_ONLY=%q, want false", v)
+		}
+	}
+
+	falsy := []string{"0", "false", "no", "off"}
+	for _, v := range falsy {
+		t.Setenv("LOCAL_ONLY", v)
+		if LocalOnly() {
+			t.Fatalf("LocalOnly() = true for LOCAL_ONLY=%q, want false", v)
+		}
+	}
+}
+
+func TestLocalOnly_ReflectsConfigWhenEnvUnset(t *testing.T) {
+	t.Setenv("LOCAL_ONLY", "") // present-but-empty => unrecognized => fall back to config
+	DefaultConfig.LocalOnly = true
+	defer func() { DefaultConfig.LocalOnly = false }()
+	if !LocalOnly() {
+		t.Fatalf("LocalOnly() = false, want true when config LocalOnly is set and env is empty")
+	}
+}
+
+func TestLocalOnly_UnrecognizedEnvFallsBackToConfig(t *testing.T) {
+	t.Setenv("LOCAL_ONLY", "maybe")
+	DefaultConfig.LocalOnly = true
+	defer func() { DefaultConfig.LocalOnly = false }()
+	if !LocalOnly() {
+		t.Fatalf("LocalOnly() = false for unrecognized env, want fallback to config value true")
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package telemetry is the REFERENCE IMPLEMENTATION of the LOCAL_ONLY custody
+// contract for non-resolution outbound ("phone-home") features.
+//
+// It performs a representative off-box report. Because that is NOT part of DNS
+// resolution or filtering, every outbound path here first consults
+// config.AssertLocalOnlyRespected and no-ops when custody mode is engaged.
+// New phone-home features (update checks, crash reporting, managed config,
+// heartbeats — some of which live on other branches) should follow this exact
+// gating pattern.
+package telemetry
+
+import (
+	"context"
+
+	"github.com/lopster568/phantomDNS/internal/config"
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+// SendFunc performs the actual outbound request. It is a field so tests can
+// observe whether an outbound attempt was made; in production it POSTs the
+// event to the configured telemetry endpoint.
+type SendFunc func(ctx context.Context, event string) error
+
+// Reporter is a representative non-resolution outbound feature.
+type Reporter struct {
+	// send performs the real network call. If nil, Report is a no-op even when
+	// custody mode is off.
+	send SendFunc
+}
+
+// NewReporter builds a Reporter with the given outbound sender.
+func NewReporter(send SendFunc) *Reporter {
+	return &Reporter{send: send}
+}
+
+// Report sends a telemetry event off-box.
+//
+// It honors the LOCAL_ONLY custody contract: when custody mode is engaged the
+// method makes NO outbound request and returns nil (a successful no-op). This
+// is the canonical shape every phone-home feature must copy.
+func (r *Reporter) Report(ctx context.Context, event string) error {
+	if !config.AssertLocalOnlyRespected("telemetry.Report") {
+		// Custody mode: do not touch the network.
+		return nil
+	}
+	if r.send == nil {
+		logger.Log.Debug("telemetry: no sender configured; skipping report")
+		return nil
+	}
+	return r.send(ctx, event)
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lopster568/phantomDNS/internal/config"
+)
+
+// TestReport_NoOpUnderLocalOnly verifies the gated helper makes NO outbound
+// attempt when custody mode is engaged.
+func TestReport_NoOpUnderLocalOnly(t *testing.T) {
+	t.Setenv("LOCAL_ONLY", "true")
+
+	sent := false
+	r := NewReporter(func(ctx context.Context, event string) error {
+		sent = true
+		return nil
+	})
+
+	if err := r.Report(context.Background(), "startup"); err != nil {
+		t.Fatalf("Report() returned error under LOCAL_ONLY: %v", err)
+	}
+	if sent {
+		t.Fatalf("outbound sender was invoked under LOCAL_ONLY; custody contract violated")
+	}
+}
+
+// TestReport_SendsWhenCustodyOff verifies normal operation (default false)
+// still performs the outbound call.
+func TestReport_SendsWhenCustodyOff(t *testing.T) {
+	t.Setenv("LOCAL_ONLY", "false")
+	config.DefaultConfig.LocalOnly = false
+
+	sent := false
+	var gotEvent string
+	r := NewReporter(func(ctx context.Context, event string) error {
+		sent = true
+		gotEvent = event
+		return nil
+	})
+
+	if err := r.Report(context.Background(), "startup"); err != nil {
+		t.Fatalf("Report() returned error: %v", err)
+	}
+	if !sent {
+		t.Fatalf("outbound sender was not invoked when custody mode is off")
+	}
+	if gotEvent != "startup" {
+		t.Fatalf("sender got event %q, want %q", gotEvent, "startup")
+	}
+}


### PR DESCRIPTION
## What

Adds `LOCAL_ONLY`, a data-custody master switch, plus the accessor, guard, and documented contract that outbound features consult. This is the provable data-custody guarantee: when engaged, the appliance makes **no** non-resolution outbound ("phone-home") network traffic.

- Config `LOCAL_ONLY` (env `LOCAL_ONLY`, yaml `local_only`, **default false**).
- `config.LocalOnly()` accessor — env var overrides yaml; recognizes `1/true/yes/on` and `0/false/no/off`.
- `config.AssertLocalOnlyRespected(feature) bool` — the guard outbound paths call; returns `false` (do not proceed) when custody mode is engaged, logging the suppression.
- `config.LogCustodyMode()` — startup log line stating custody mode, wired into both the data-plane and control-plane entrypoints.
- `internal/telemetry` — reference implementation of the gated-helper pattern for future phone-home features (some of which live on other branches).

## Why

HydraDNS is positioned on data custody. A single, auditable switch — with one accessor and one guard every outbound feature must consult — makes that guarantee provable and reviewable, rather than scattered ad-hoc checks.

## How — the outbound contract

**Contract:** any code path making a non-resolution outbound request MUST call `config.AssertLocalOnlyRespected()` (or check `config.LocalOnly()`) first and skip/no-op when custody mode is engaged. Full text in `internal/config/local_only.go`.

**Allowed under LOCAL_ONLY** (core resolution/filtering — never gated):
- DNS resolution to upstream resolvers (`internal/dnsengine/*`).
- Blocklist source fetch (`internal/blocklist/fetcher`) — a core filtering function pulling operator-configured lists, not a phone-home. Documented inline as intentionally not gated.
- Intra-appliance gRPC between control and data plane (localhost).

**Gated under LOCAL_ONLY** (non-resolution / phone-home — must no-op):
- Telemetry / usage analytics, software update / version checks, crash / error reporting, remote managed-config / license / heartbeat calls, and any future off-box call not serving a DNS query.

On `main` today the only real outbound HTTP is the (allowed) blocklist fetch; the accessor, guard, and contract land here so the phone-home features on other branches have one switch to consult. `internal/telemetry` ships the gated reference implementation.

## Tests

- `internal/config`: accessor reflects env and config, env overrides config, unrecognized/empty env falls back to config, default is false; guard returns correct result.
- `internal/telemetry`: gated helper makes **no** outbound attempt when `LOCAL_ONLY` is engaged; performs the outbound call normally when custody mode is off.

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)