### PR TITLE
feat(controlplane): analytics rollups — top-N, per-client, heatmap, anomaly (I-048/I-115/I-116/I-117)

### DIFF
--- a/cmd/controlplane/handlers/analytics_rollups.go
+++ b/cmd/controlplane/handlers/analytics_rollups.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+)
+
+// RollupWindowInfo echoes the effective window the rollups were computed over,
+// so a client can render the range and paging it actually got.
+type RollupWindowInfo struct {
+	From     *time.Time `json:"from"`
+	To       *time.Time `json:"to"`
+	TopN     int        `json:"top_n"`
+	ClientIP string     `json:"client_ip,omitempty"`
+}
+
+// AnalyticsRollupsData is the payload of GetAnalyticsRollups. The nested slices
+// reuse the repository aggregate structs directly (they already carry JSON
+// tags). ClientTimeline is populated only when a client_ip is supplied; Anomaly
+// is populated only when a full [from, to] window is given (it is compared
+// against the immediately preceding window of equal length).
+type AnalyticsRollupsData struct {
+	Window     RollupWindowInfo              `json:"window"`
+	TopClients []repositories.ClientActivity `json:"top_clients"`
+	TopBlocked []repositories.DomainCount    `json:"top_blocked_domains"`
+	Categories []repositories.CategoryCount  `json:"categories"`
+	Timeline   []repositories.TimeBucket     `json:"client_timeline"`
+	Heatmap    []repositories.HeatmapCell    `json:"heatmap"`
+	Anomaly    *repositories.AnomalyDigest   `json:"anomaly,omitempty"`
+}
+
+// ResponseAnalyticsRollups is the standard envelope for the rollups endpoint.
+type ResponseAnalyticsRollups struct {
+	Status string               `json:"status"`
+	Data   AnalyticsRollupsData `json:"data"`
+	Error  *string              `json:"error"`
+}
+
+// GetAnalyticsRollups handles GET /analytics/rollups.
+//
+// It returns aggregate rollups over the DNS query log: a top-clients
+// leaderboard, top blocked domains, a per-disposition category breakdown, a
+// category x hour-of-day heatmap, an optional per-client activity timeline, and
+// an optional anomaly digest comparing the window against the one before it.
+//
+// Query params (all optional):
+//
+//	from, to   RFC3339 timestamps bounding the window (inclusive)
+//	top        leaderboard size (default 10, max 100)
+//	client_ip  when set, includes that client's hour-bucketed timeline
+func (h *APIHandler) GetAnalyticsRollups(c *gin.Context) {
+	badRequest := func(msg string) {
+		c.JSON(http.StatusBadRequest, ResponseGeneric{Status: "error", Error: &msg})
+	}
+
+	var window repositories.AnalyticsWindow
+
+	if v := c.Query("from"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			badRequest("invalid 'from': must be an RFC3339 timestamp")
+			return
+		}
+		window.From = &t
+	}
+	if v := c.Query("to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			badRequest("invalid 'to': must be an RFC3339 timestamp")
+			return
+		}
+		window.To = &t
+	}
+	if window.From != nil && window.To != nil && window.To.Before(*window.From) {
+		badRequest("invalid range: 'to' must not be before 'from'")
+		return
+	}
+
+	topN := repositories.DefaultAnalyticsTopN
+	if v := c.Query("top"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			badRequest("invalid 'top': must be a positive integer")
+			return
+		}
+		topN = n
+	}
+	topN = repositories.ClampAnalyticsTopN(topN)
+	window.Limit = topN
+
+	clientIP := strings.TrimSpace(c.Query("client_ip"))
+
+	fail := func() {
+		errMsg := "failed to compute analytics rollups"
+		c.JSON(http.StatusInternalServerError, ResponseAnalyticsRollups{Status: "error", Error: &errMsg})
+	}
+
+	topClients, err := h.Store.QueryLogs.TopClients(window)
+	if err != nil {
+		fail()
+		return
+	}
+	topBlocked, err := h.Store.QueryLogs.TopBlockedDomains(window)
+	if err != nil {
+		fail()
+		return
+	}
+	categories, err := h.Store.QueryLogs.CategoryBreakdown(window)
+	if err != nil {
+		fail()
+		return
+	}
+	heatmap, err := h.Store.QueryLogs.CategoryHourHeatmap(window)
+	if err != nil {
+		fail()
+		return
+	}
+
+	timeline := []repositories.TimeBucket{}
+	if clientIP != "" {
+		timeline, err = h.Store.QueryLogs.ClientTimeline(clientIP, window)
+		if err != nil {
+			fail()
+			return
+		}
+	}
+
+	var anomaly *repositories.AnomalyDigest
+	if window.From != nil && window.To != nil {
+		if digest, ok := h.computeAnomaly(window); ok {
+			anomaly = digest
+		} else {
+			fail()
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, ResponseAnalyticsRollups{
+		Status: "success",
+		Data: AnalyticsRollupsData{
+			Window: RollupWindowInfo{
+				From:     window.From,
+				To:       window.To,
+				TopN:     topN,
+				ClientIP: clientIP,
+			},
+			TopClients: topClients,
+			TopBlocked: topBlocked,
+			Categories: categories,
+			Timeline:   timeline,
+			Heatmap:    heatmap,
+			Anomaly:    anomaly,
+		},
+	})
+}
+
+// computeAnomaly compares the given window against the immediately preceding
+// window of equal length and returns the digest. It returns ok=false only on a
+// repository error. The caller guarantees both bounds are set.
+func (h *APIHandler) computeAnomaly(current repositories.AnalyticsWindow) (*repositories.AnomalyDigest, bool) {
+	dur := current.To.Sub(*current.From)
+	priorFrom := current.From.Add(-dur)
+	// The window's To bound is inclusive, so end the prior window one tick
+	// before the current window starts to avoid double-counting a row that sits
+	// exactly on the shared boundary.
+	priorTo := current.From.Add(-time.Nanosecond)
+	prior := repositories.AnalyticsWindow{
+		From:  &priorFrom,
+		To:    &priorTo,
+		Limit: current.Limit,
+	}
+	digest, err := h.Store.QueryLogs.AnomalyDigestBetween(current, prior, repositories.AnomalyThresholds{})
+	if err != nil {
+		return nil, false
+	}
+	return &digest, true
+}

--- a/cmd/controlplane/handlers/analytics_rollups_test.go
+++ b/cmd/controlplane/handlers/analytics_rollups_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func setupRollupHandler(t *testing.T) (*gin.Engine, *gorm.DB) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.DNSQuery{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	h := &APIHandler{
+		Store: repositories.Store{
+			QueryLogs: repositories.NewGormQueryLogRepo(db),
+		},
+	}
+
+	r := gin.New()
+	r.GET("/api/v1/analytics/rollups", h.GetAnalyticsRollups)
+	return r, db
+}
+
+func seedRollupRows(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	ts := func(h, m int) time.Time { return time.Date(2024, 1, 1, h, m, 0, 0, time.UTC) }
+	rows := []models.DNSQuery{
+		{Domain: "ads.example.com", ClientIP: "10.0.0.1", Action: "block", Timestamp: ts(10, 0)},
+		{Domain: "ads.example.com", ClientIP: "10.0.0.2", Action: "block", Timestamp: ts(10, 5)},
+		{Domain: "good.org", ClientIP: "10.0.0.1", Action: "allow", Timestamp: ts(10, 10)},
+		{Domain: "news.example.com", ClientIP: "10.0.0.1", Action: "allow", Timestamp: ts(11, 0)},
+		{Domain: "phish.evil", ClientIP: "10.0.0.3", Action: "flagged", IsSuspicious: true, Timestamp: ts(11, 30)},
+	}
+	for i := range rows {
+		if err := db.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("failed to seed row %d: %v", i, err)
+		}
+	}
+}
+
+func doRollupGET(t *testing.T, r *gin.Engine, target string) (*httptest.ResponseRecorder, ResponseAnalyticsRollups) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var body ResponseAnalyticsRollups
+	if w.Code == http.StatusOK {
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("failed to decode response: %v (body: %s)", err, w.Body.String())
+		}
+	}
+	return w, body
+}
+
+func TestGetAnalyticsRollups_Shape(t *testing.T) {
+	r, db := setupRollupHandler(t)
+	seedRollupRows(t, db)
+
+	w, body := doRollupGET(t, r, "/api/v1/analytics/rollups")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if body.Status != "success" || body.Error != nil {
+		t.Fatalf("unexpected envelope: status=%q err=%v", body.Status, body.Error)
+	}
+	if body.Data.Window.TopN != repositories.DefaultAnalyticsTopN {
+		t.Errorf("expected default top-N %d, got %d", repositories.DefaultAnalyticsTopN, body.Data.Window.TopN)
+	}
+
+	// Top clients: 10.0.0.1 busiest with 3 queries, 1 blocked.
+	if len(body.Data.TopClients) != 3 {
+		t.Fatalf("expected 3 clients, got %d", len(body.Data.TopClients))
+	}
+	if body.Data.TopClients[0].ClientIP != "10.0.0.1" || body.Data.TopClients[0].Total != 3 {
+		t.Errorf("top client wrong: %+v", body.Data.TopClients[0])
+	}
+	if body.Data.TopClients[0].Blocked != 1 {
+		t.Errorf("expected top client blocked=1, got %d", body.Data.TopClients[0].Blocked)
+	}
+
+	// Top blocked domains: ads.example.com blocked twice.
+	if len(body.Data.TopBlocked) != 1 {
+		t.Fatalf("expected 1 blocked domain, got %d (%+v)", len(body.Data.TopBlocked), body.Data.TopBlocked)
+	}
+	if body.Data.TopBlocked[0].Domain != "ads.example.com" || body.Data.TopBlocked[0].Count != 2 {
+		t.Errorf("top blocked wrong: %+v", body.Data.TopBlocked[0])
+	}
+
+	// Categories: block=2, allow=2, flagged=1.
+	catCounts := map[string]int64{}
+	for _, c := range body.Data.Categories {
+		catCounts[c.Category] = c.Count
+	}
+	if catCounts["block"] != 2 || catCounts["allow"] != 2 || catCounts["flagged"] != 1 {
+		t.Errorf("category breakdown wrong: %+v", body.Data.Categories)
+	}
+
+	// Heatmap: hour 10 has block+allow, hour 11 has allow+flagged.
+	if len(body.Data.Heatmap) == 0 {
+		t.Errorf("expected non-empty heatmap")
+	}
+
+	// No client_ip -> empty timeline; no from/to -> no anomaly.
+	if len(body.Data.Timeline) != 0 {
+		t.Errorf("expected empty timeline without client_ip, got %d", len(body.Data.Timeline))
+	}
+	if body.Data.Anomaly != nil {
+		t.Errorf("expected nil anomaly without a full window")
+	}
+}
+
+func TestGetAnalyticsRollups_ClientTimeline(t *testing.T) {
+	r, db := setupRollupHandler(t)
+	seedRollupRows(t, db)
+
+	_, body := doRollupGET(t, r, "/api/v1/analytics/rollups?client_ip=10.0.0.1")
+	if body.Data.Window.ClientIP != "10.0.0.1" {
+		t.Errorf("expected echoed client_ip, got %q", body.Data.Window.ClientIP)
+	}
+	// client 1 active in hour 10 (2 queries) and hour 11 (1 query).
+	if len(body.Data.Timeline) != 2 {
+		t.Fatalf("expected 2 timeline buckets, got %d (%+v)", len(body.Data.Timeline), body.Data.Timeline)
+	}
+	if body.Data.Timeline[0].Total != 2 || body.Data.Timeline[1].Total != 1 {
+		t.Errorf("timeline totals wrong: %+v", body.Data.Timeline)
+	}
+}
+
+func TestGetAnalyticsRollups_TopNClamped(t *testing.T) {
+	r, db := setupRollupHandler(t)
+	seedRollupRows(t, db)
+
+	_, body := doRollupGET(t, r, "/api/v1/analytics/rollups?top=100000")
+	if body.Data.Window.TopN != repositories.MaxAnalyticsTopN {
+		t.Errorf("expected clamped top-N %d, got %d", repositories.MaxAnalyticsTopN, body.Data.Window.TopN)
+	}
+
+	// top=1 limits the leaderboard to the single busiest client.
+	_, body = doRollupGET(t, r, "/api/v1/analytics/rollups?top=1")
+	if len(body.Data.TopClients) != 1 {
+		t.Errorf("expected 1 client with top=1, got %d", len(body.Data.TopClients))
+	}
+}
+
+func TestGetAnalyticsRollups_WithWindowIncludesAnomaly(t *testing.T) {
+	r, db := setupRollupHandler(t)
+	seedRollupRows(t, db)
+
+	// A full [from,to] window must produce an anomaly digest (compared against
+	// the preceding equal-length window, which is empty here).
+	from := "2024-01-01T10:00:00Z"
+	to := "2024-01-01T11:59:00Z"
+	_, body := doRollupGET(t, r, "/api/v1/analytics/rollups?from="+from+"&to="+to)
+	if body.Data.Anomaly == nil {
+		t.Fatal("expected anomaly digest for a full window")
+	}
+	if body.Data.Anomaly.TotalCurrent != 5 {
+		t.Errorf("expected current total 5, got %d", body.Data.Anomaly.TotalCurrent)
+	}
+	if body.Data.Anomaly.TotalPrior != 0 {
+		t.Errorf("expected prior total 0 (empty preceding window), got %d", body.Data.Anomaly.TotalPrior)
+	}
+}
+
+func TestGetAnalyticsRollups_BadParams(t *testing.T) {
+	r, db := setupRollupHandler(t)
+	seedRollupRows(t, db)
+
+	cases := []string{
+		"?from=not-a-time",
+		"?to=2024-13-40",
+		"?top=abc",
+		"?top=0",
+		"?top=-5",
+		"?from=2024-01-02T00:00:00Z&to=2024-01-01T00:00:00Z", // to before from
+	}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/rollups"+q, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("query %q: expected 400, got %d (body: %s)", q, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -65,6 +65,7 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 			analytics.GET("/summary", apiHandler.GetAnalyticsSummary)
 			analytics.GET("/audits", apiHandler.GetAuditLogs)
 			analytics.GET("/logs", apiHandler.GetQueryLogs)
+			analytics.GET("/rollups", apiHandler.GetAnalyticsRollups)
 		}
 
 		// Device inventory endpoints

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -64,6 +64,34 @@ func (m *mockQueryLog) List(filter repositories.QueryLogFilter) ([]models.DNSQue
 	return nil, 0, nil
 }
 
+func (m *mockQueryLog) TopClients(w repositories.AnalyticsWindow) ([]repositories.ClientActivity, error) {
+	return nil, nil
+}
+
+func (m *mockQueryLog) TopBlockedDomains(w repositories.AnalyticsWindow) ([]repositories.DomainCount, error) {
+	return nil, nil
+}
+
+func (m *mockQueryLog) CategoryBreakdown(w repositories.AnalyticsWindow) ([]repositories.CategoryCount, error) {
+	return nil, nil
+}
+
+func (m *mockQueryLog) ClientTimeline(clientIP string, w repositories.AnalyticsWindow) ([]repositories.TimeBucket, error) {
+	return nil, nil
+}
+
+func (m *mockQueryLog) CategoryHourHeatmap(w repositories.AnalyticsWindow) ([]repositories.HeatmapCell, error) {
+	return nil, nil
+}
+
+func (m *mockQueryLog) GatherWindowStats(w repositories.AnalyticsWindow) (repositories.WindowStats, error) {
+	return repositories.WindowStats{}, nil
+}
+
+func (m *mockQueryLog) AnomalyDigestBetween(current, prior repositories.AnalyticsWindow, cfg repositories.AnomalyThresholds) (repositories.AnomalyDigest, error) {
+	return repositories.AnomalyDigest{}, nil
+}
+
 // waitSaved blocks until logQuery's goroutine persists a row (or times out).
 func (m *mockQueryLog) waitSaved(t *testing.T) *models.DNSQuery {
 	t.Helper()

--- a/internal/storage/repositories/analytics.go
+++ b/internal/storage/repositories/analytics.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package repositories
+
+import (
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// Top-N bounds for analytics leaderboards. A caller can never ask an aggregate
+// query for an unbounded number of rows.
+const (
+	// DefaultAnalyticsTopN is used when no (or an invalid) top-N is supplied.
+	DefaultAnalyticsTopN = 10
+	// MaxAnalyticsTopN caps how many rows a single leaderboard may return.
+	MaxAnalyticsTopN = 100
+)
+
+// ClampAnalyticsTopN normalizes a requested leaderboard size into the allowed
+// bounds. Non-positive values fall back to the default; values above the cap
+// are clamped to MaxAnalyticsTopN.
+func ClampAnalyticsTopN(n int) int {
+	if n <= 0 {
+		return DefaultAnalyticsTopN
+	}
+	if n > MaxAnalyticsTopN {
+		return MaxAnalyticsTopN
+	}
+	return n
+}
+
+// AnalyticsWindow scopes an aggregate query to an optional inclusive time range
+// and caps how many rows a "top-N" rollup may return. Zero-value time bounds
+// mean "no bound"; a non-positive Limit falls back to DefaultAnalyticsTopN.
+//
+// The window reuses the same indexed Timestamp column and DNSQuery model that
+// back the query-log listing added on this branch, so every rollup is served
+// from an index and bounded.
+type AnalyticsWindow struct {
+	From  *time.Time
+	To    *time.Time
+	Limit int
+}
+
+// ClientActivity is one row of the top-clients leaderboard: how many queries a
+// client made in the window and how many of them were blocked.
+type ClientActivity struct {
+	ClientIP string `json:"client_ip"`
+	Total    int64  `json:"total"`
+	Blocked  int64  `json:"blocked"`
+}
+
+// DomainCount is one row of the top-blocked-domains leaderboard.
+type DomainCount struct {
+	Domain string `json:"domain"`
+	Count  int64  `json:"count"`
+}
+
+// CategoryCount is one row of the category breakdown. "Category" here is the
+// query's disposition (DNSQuery.Action: allow | block | flagged | redirect) —
+// the only low-cardinality, always-populated, indexed categorical dimension the
+// query log records per row. Content categories live on policies/blocklists and
+// are not stamped onto individual query rows.
+type CategoryCount struct {
+	Category string `json:"category"`
+	Count    int64  `json:"count"`
+}
+
+// TimeBucket is one hour-wide bucket of a per-client activity timeline.
+type TimeBucket struct {
+	Bucket  time.Time `json:"bucket"`
+	Total   int64     `json:"total"`
+	Blocked int64     `json:"blocked"`
+}
+
+// HeatmapCell is one cell of the category x hour-of-day heatmap: for a given
+// hour-of-day (0..23, UTC) and category (disposition), how many queries landed
+// there across the window.
+type HeatmapCell struct {
+	Hour     int    `json:"hour"`
+	Category string `json:"category"`
+	Count    int64  `json:"count"`
+}
+
+// blockedSumExpr counts blocked rows inside an aggregate. Kept as a constant so
+// every rollup reports "blocked" the same way.
+const blockedSumExpr = "SUM(CASE WHEN action = 'block' THEN 1 ELSE 0 END)"
+
+// scopedByWindow builds a fresh *gorm.DB scoped to the DNSQuery table and the
+// window's inclusive time bounds. Both bounds are optional and use the indexed
+// Timestamp column.
+func (r *GormQueryLogRepo) scopedByWindow(w AnalyticsWindow) *gorm.DB {
+	q := r.db.Model(&models.DNSQuery{})
+	if w.From != nil {
+		q = q.Where("timestamp >= ?", *w.From)
+	}
+	if w.To != nil {
+		q = q.Where("timestamp <= ?", *w.To)
+	}
+	return q
+}
+
+// TopClients returns the busiest clients in the window, newest-first by total
+// query volume, capped at the window's clamped top-N. Each row also carries how
+// many of that client's queries were blocked.
+func (r *GormQueryLogRepo) TopClients(w AnalyticsWindow) ([]ClientActivity, error) {
+	var out []ClientActivity
+	err := r.scopedByWindow(w).
+		Select("client_ip, COUNT(*) AS total, " + blockedSumExpr + " AS blocked").
+		Group("client_ip").
+		Order("total DESC, client_ip ASC").
+		Limit(ClampAnalyticsTopN(w.Limit)).
+		Scan(&out).Error
+	return out, err
+}
+
+// TopBlockedDomains returns the most-blocked domains in the window, ordered by
+// block count desc, capped at the window's clamped top-N. Only rows with
+// action = "block" are counted; the action filter is served from an index.
+func (r *GormQueryLogRepo) TopBlockedDomains(w AnalyticsWindow) ([]DomainCount, error) {
+	var out []DomainCount
+	err := r.scopedByWindow(w).
+		Where("action = ?", "block").
+		Select("domain, COUNT(*) AS count").
+		Group("domain").
+		Order("count DESC, domain ASC").
+		Limit(ClampAnalyticsTopN(w.Limit)).
+		Scan(&out).Error
+	return out, err
+}
+
+// CategoryBreakdown returns the per-disposition query counts across the window,
+// ordered by count desc. The result is naturally bounded (one row per distinct
+// action) so no top-N cap is applied.
+func (r *GormQueryLogRepo) CategoryBreakdown(w AnalyticsWindow) ([]CategoryCount, error) {
+	var out []CategoryCount
+	err := r.scopedByWindow(w).
+		Select("action AS category, COUNT(*) AS count").
+		Group("action").
+		Order("count DESC, action ASC").
+		Scan(&out).Error
+	return out, err
+}
+
+// ClientTimeline returns an hour-bucketed activity timeline for a single client
+// over the window, ordered oldest-first. Each bucket carries the total and
+// blocked query counts for that hour. Buckets with no activity are omitted (the
+// caller can fill gaps); the number of buckets is bounded by the window length.
+func (r *GormQueryLogRepo) ClientTimeline(clientIP string, w AnalyticsWindow) ([]TimeBucket, error) {
+	type row struct {
+		Bucket  string
+		Total   int64
+		Blocked int64
+	}
+	var rows []row
+	err := r.scopedByWindow(w).
+		Where("client_ip = ?", clientIP).
+		Select("strftime('%Y-%m-%d %H:00:00', timestamp) AS bucket, COUNT(*) AS total, " + blockedSumExpr + " AS blocked").
+		Group("bucket").
+		Order("bucket ASC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]TimeBucket, 0, len(rows))
+	for _, rr := range rows {
+		t, perr := time.Parse("2006-01-02 15:04:05", rr.Bucket)
+		if perr != nil {
+			// Skip an unparseable bucket rather than failing the whole rollup.
+			continue
+		}
+		out = append(out, TimeBucket{
+			Bucket:  t.UTC(),
+			Total:   rr.Total,
+			Blocked: rr.Blocked,
+		})
+	}
+	return out, nil
+}
+
+// CategoryHourHeatmap returns a category x hour-of-day dataset across the
+// window: for each (hour-of-day 0..23, disposition) pair with at least one
+// query, the number of queries. The result is bounded to at most 24 * (number
+// of distinct actions) cells and ordered deterministically by hour then
+// category.
+func (r *GormQueryLogRepo) CategoryHourHeatmap(w AnalyticsWindow) ([]HeatmapCell, error) {
+	var out []HeatmapCell
+	err := r.scopedByWindow(w).
+		Select("CAST(strftime('%H', timestamp) AS INTEGER) AS hour, action AS category, COUNT(*) AS count").
+		Group("hour, category").
+		Order("hour ASC, category ASC").
+		Scan(&out).Error
+	return out, err
+}

--- a/internal/storage/repositories/analytics_test.go
+++ b/internal/storage/repositories/analytics_test.go
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package repositories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// seedAnalytics inserts a deterministic set of rows spread across known clients,
+// actions, and hours so aggregate results are reproducible.
+//
+// Layout (all on 2024-01-01 UTC):
+//
+//	10.0.0.1: 5 queries -> 3 block (ads/track/malv), 2 allow (good/news)
+//	10.0.0.2: 3 queries -> 1 block (ads2), 2 allow (cdn/api)
+//	10.0.0.3: 1 query   -> 1 flagged (phish)
+//
+// Block totals per domain: "ads.example.com" appears blocked twice.
+func seedAnalytics(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	rows := []models.DNSQuery{
+		// client 1 — hour 10
+		{Domain: "ads.example.com", ClientIP: "10.0.0.1", Action: "block", Timestamp: at(10, 0)},
+		{Domain: "track.example.com", ClientIP: "10.0.0.1", Action: "block", Timestamp: at(10, 5)},
+		{Domain: "good.org", ClientIP: "10.0.0.1", Action: "allow", Timestamp: at(10, 10)},
+		// client 1 — hour 11
+		{Domain: "malware.bad", ClientIP: "10.0.0.1", Action: "block", Timestamp: at(11, 0)},
+		{Domain: "news.example.com", ClientIP: "10.0.0.1", Action: "allow", Timestamp: at(11, 30)},
+		// client 2 — hour 10
+		{Domain: "ads.example.com", ClientIP: "10.0.0.2", Action: "block", Timestamp: at(10, 15)},
+		{Domain: "cdn.good.org", ClientIP: "10.0.0.2", Action: "allow", Timestamp: at(10, 20)},
+		// client 2 — hour 12
+		{Domain: "api.good.org", ClientIP: "10.0.0.2", Action: "allow", Timestamp: at(12, 0)},
+		// client 3 — hour 11
+		{Domain: "phish.evil", ClientIP: "10.0.0.3", Action: "flagged", IsSuspicious: true, Timestamp: at(11, 45)},
+	}
+	for i := range rows {
+		if err := db.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("failed to seed row %d: %v", i, err)
+		}
+	}
+}
+
+// at returns a fixed 2024-01-01 timestamp at the given hour/minute in UTC.
+func at(hour, min int) time.Time {
+	return time.Date(2024, 1, 1, hour, min, 0, 0, time.UTC)
+}
+
+func TestClampAnalyticsTopN(t *testing.T) {
+	tests := []struct {
+		in, want int
+	}{
+		{0, DefaultAnalyticsTopN},
+		{-3, DefaultAnalyticsTopN},
+		{1, 1},
+		{10, 10},
+		{MaxAnalyticsTopN, MaxAnalyticsTopN},
+		{MaxAnalyticsTopN + 1, MaxAnalyticsTopN},
+		{99999, MaxAnalyticsTopN},
+	}
+	for _, tt := range tests {
+		if got := ClampAnalyticsTopN(tt.in); got != tt.want {
+			t.Errorf("ClampAnalyticsTopN(%d) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestAnalytics_TopClients(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	got, err := repo.TopClients(AnalyticsWindow{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ClientActivity{
+		{ClientIP: "10.0.0.1", Total: 5, Blocked: 3},
+		{ClientIP: "10.0.0.2", Total: 3, Blocked: 1},
+		{ClientIP: "10.0.0.3", Total: 1, Blocked: 0},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d clients, got %d (%+v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestAnalytics_TopClients_TopNCap(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	// Top-1 must return only the busiest client.
+	got, err := repo.TopClients(AnalyticsWindow{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 client with Limit=1, got %d", len(got))
+	}
+	if got[0].ClientIP != "10.0.0.1" {
+		t.Errorf("expected busiest client 10.0.0.1, got %q", got[0].ClientIP)
+	}
+
+	// Limit 0 falls back to the default (>= 3 clients here).
+	all, err := repo.TopClients(AnalyticsWindow{Limit: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Errorf("expected 3 clients with default top-N, got %d", len(all))
+	}
+}
+
+func TestAnalytics_TopBlockedDomains(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	got, err := repo.TopBlockedDomains(AnalyticsWindow{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Blocked domains: ads.example.com x2, track.example.com x1, malware.bad x1.
+	if len(got) != 3 {
+		t.Fatalf("expected 3 blocked domains, got %d (%+v)", len(got), got)
+	}
+	if got[0].Domain != "ads.example.com" || got[0].Count != 2 {
+		t.Errorf("expected top blocked ads.example.com=2, got %+v", got[0])
+	}
+	// Non-block dispositions must not appear.
+	for _, d := range got {
+		if d.Domain == "good.org" || d.Domain == "phish.evil" {
+			t.Errorf("non-blocked domain %q leaked into top-blocked", d.Domain)
+		}
+	}
+}
+
+func TestAnalytics_CategoryBreakdown(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	got, err := repo.CategoryBreakdown(AnalyticsWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := map[string]int64{}
+	for _, c := range got {
+		counts[c.Category] = c.Count
+	}
+	want := map[string]int64{"block": 4, "allow": 4, "flagged": 1}
+	for cat, n := range want {
+		if counts[cat] != n {
+			t.Errorf("category %q: expected %d, got %d", cat, n, counts[cat])
+		}
+	}
+	// Ordered by count desc: first row must be one of the count-4 categories.
+	if len(got) > 0 && got[0].Count != 4 {
+		t.Errorf("expected highest count first, got %+v", got[0])
+	}
+}
+
+func TestAnalytics_ClientTimeline(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	got, err := repo.ClientTimeline("10.0.0.1", AnalyticsWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// client 1 has activity in hour 10 (3 queries, 2 blocked) and hour 11 (2, 1).
+	if len(got) != 2 {
+		t.Fatalf("expected 2 hourly buckets, got %d (%+v)", len(got), got)
+	}
+	if !got[0].Bucket.Equal(at(10, 0)) {
+		t.Errorf("expected first bucket at hour 10, got %v", got[0].Bucket)
+	}
+	if got[0].Total != 3 || got[0].Blocked != 2 {
+		t.Errorf("hour 10: expected total=3 blocked=2, got total=%d blocked=%d", got[0].Total, got[0].Blocked)
+	}
+	if !got[1].Bucket.Equal(at(11, 0)) {
+		t.Errorf("expected second bucket at hour 11, got %v", got[1].Bucket)
+	}
+	if got[1].Total != 2 || got[1].Blocked != 1 {
+		t.Errorf("hour 11: expected total=2 blocked=1, got total=%d blocked=%d", got[1].Total, got[1].Blocked)
+	}
+	// Buckets must be oldest-first.
+	if got[0].Bucket.After(got[1].Bucket) {
+		t.Errorf("timeline not ordered oldest-first")
+	}
+}
+
+func TestAnalytics_ClientTimeline_UnknownClient(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	got, err := repo.ClientTimeline("192.168.1.1", AnalyticsWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty timeline for unknown client, got %d buckets", len(got))
+	}
+}
+
+func TestAnalytics_CategoryHourHeatmap(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	got, err := repo.CategoryHourHeatmap(AnalyticsWindow{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Index by hour|category for assertions.
+	type key struct {
+		h int
+		c string
+	}
+	cells := map[key]int64{}
+	for _, cell := range got {
+		cells[key{cell.Hour, cell.Category}] = cell.Count
+	}
+	// Hour 10: block x3 (ads1, track, ads2), allow x2 (good, cdn).
+	if cells[key{10, "block"}] != 3 {
+		t.Errorf("hour 10 block: expected 3, got %d", cells[key{10, "block"}])
+	}
+	if cells[key{10, "allow"}] != 2 {
+		t.Errorf("hour 10 allow: expected 2, got %d", cells[key{10, "allow"}])
+	}
+	// Hour 11: block x1 (malware), allow x1 (news), flagged x1 (phish).
+	if cells[key{11, "block"}] != 1 || cells[key{11, "allow"}] != 1 || cells[key{11, "flagged"}] != 1 {
+		t.Errorf("hour 11 cells wrong: %+v", got)
+	}
+	// Hour 12: allow x1 (api).
+	if cells[key{12, "allow"}] != 1 {
+		t.Errorf("hour 12 allow: expected 1, got %d", cells[key{12, "allow"}])
+	}
+	// Ordering: hours ascending.
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Hour > got[i].Hour {
+			t.Errorf("heatmap not ordered by hour ascending at index %d", i)
+		}
+	}
+}
+
+func TestAnalytics_WindowTimeRange(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	// Restrict to hour 10 only: [10:00, 10:59].
+	from := at(10, 0)
+	to := at(10, 59)
+	w := AnalyticsWindow{From: &from, To: &to, Limit: 10}
+
+	cats, err := repo.CategoryBreakdown(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	total := int64(0)
+	for _, c := range cats {
+		total += c.Count
+	}
+	// Hour 10 has 5 rows (3 block + 2 allow).
+	if total != 5 {
+		t.Errorf("expected 5 rows in hour-10 window, got %d", total)
+	}
+
+	clients, err := repo.TopClients(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only clients active in hour 10: 10.0.0.1 (3) and 10.0.0.2 (2).
+	if len(clients) != 2 {
+		t.Fatalf("expected 2 clients in window, got %d (%+v)", len(clients), clients)
+	}
+	if clients[0].ClientIP != "10.0.0.1" || clients[0].Total != 3 {
+		t.Errorf("expected 10.0.0.1 total=3 in window, got %+v", clients[0])
+	}
+}
+
+func TestGatherWindowStats(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+	seedAnalytics(t, db)
+
+	stats, err := repo.GatherWindowStats(AnalyticsWindow{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Total != 9 {
+		t.Errorf("expected total 9, got %d", stats.Total)
+	}
+	if stats.Blocked != 4 {
+		t.Errorf("expected blocked 4, got %d", stats.Blocked)
+	}
+	if len(stats.Clients) != 3 {
+		t.Errorf("expected 3 clients, got %d", len(stats.Clients))
+	}
+	// BlockedRate = 4/9 * 100 ~= 44.4%.
+	if r := stats.BlockedRate(); r < 44.0 || r > 45.0 {
+		t.Errorf("expected blocked rate ~44.4, got %f", r)
+	}
+}
+
+func TestAnomalyDigestBetween_Integration(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewGormQueryLogRepo(db)
+
+	// Prior window (hour 8): 4 queries, 0 blocked, client A dominant.
+	prior := []models.DNSQuery{
+		{Domain: "a.com", ClientIP: "10.0.0.1", Action: "allow", Timestamp: at(8, 0)},
+		{Domain: "b.com", ClientIP: "10.0.0.1", Action: "allow", Timestamp: at(8, 5)},
+		{Domain: "c.com", ClientIP: "10.0.0.1", Action: "allow", Timestamp: at(8, 10)},
+		{Domain: "d.com", ClientIP: "10.0.0.2", Action: "allow", Timestamp: at(8, 15)},
+	}
+	// Current window (hour 9): 8 queries, 6 blocked -> blocked-rate spike.
+	current := []models.DNSQuery{}
+	for i := 0; i < 6; i++ {
+		current = append(current, models.DNSQuery{Domain: "bad.com", ClientIP: "10.0.0.9", Action: "block", Timestamp: at(9, i)})
+	}
+	current = append(current,
+		models.DNSQuery{Domain: "ok.com", ClientIP: "10.0.0.9", Action: "allow", Timestamp: at(9, 30)},
+		models.DNSQuery{Domain: "ok2.com", ClientIP: "10.0.0.9", Action: "allow", Timestamp: at(9, 31)},
+	)
+	for _, r := range append(prior, current...) {
+		rr := r
+		if err := db.Create(&rr).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	curFrom, curTo := at(9, 0), at(9, 59)
+	priFrom, priTo := at(8, 0), at(8, 59)
+	digest, err := repo.AnomalyDigestBetween(
+		AnalyticsWindow{From: &curFrom, To: &curTo, Limit: 10},
+		AnalyticsWindow{From: &priFrom, To: &priTo, Limit: 10},
+		// Lower the surge floor so the 8-query seed is enough to exercise the
+		// surge path with a lean fixture.
+		AnomalyThresholds{ClientSurgeMinQueries: 5},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest.TotalCurrent != 8 || digest.TotalPrior != 4 {
+		t.Errorf("expected totals cur=8 prior=4, got cur=%d prior=%d", digest.TotalCurrent, digest.TotalPrior)
+	}
+	// Current blocked-rate 6/8=75%, prior 0% -> spike.
+	if !digest.BlockedRateSpike {
+		t.Errorf("expected blocked-rate spike, got delta=%f", digest.BlockedRateDeltaPoints)
+	}
+	// 10.0.0.9 went 0 -> 8 queries: must be reported as a surge.
+	found := false
+	for _, s := range digest.SurgingClients {
+		if s.ClientIP == "10.0.0.9" {
+			found = true
+			if s.Current != 8 || s.Prior != 0 {
+				t.Errorf("surge for 10.0.0.9 wrong: %+v", s)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected 10.0.0.9 flagged as surging, got %+v", digest.SurgingClients)
+	}
+}

--- a/internal/storage/repositories/anomaly.go
+++ b/internal/storage/repositories/anomaly.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package repositories
+
+// This file computes an anomaly digest: notable deltas between a current window
+// and a prior window (e.g. a blocked-rate spike, or a single client surging in
+// volume). The digest is a pure computed struct — delivery/notification of it is
+// intentionally handled elsewhere.
+
+// AnomalyThresholds controls what counts as "notable". Zero-value thresholds are
+// replaced with sensible defaults by DefaultAnomalyThresholds, so callers can
+// pass an empty struct.
+type AnomalyThresholds struct {
+	// BlockedRateSpikePoints is the minimum increase in blocked-rate, in
+	// percentage points (0..100), for the spike flag to trip.
+	BlockedRateSpikePoints float64
+	// ClientSurgeFactor is the minimum current/prior volume ratio for a client
+	// to be reported as surging.
+	ClientSurgeFactor float64
+	// ClientSurgeMinQueries is the minimum current-window volume a client must
+	// have before a surge is reported, so a jump from 1 to 4 queries is ignored.
+	ClientSurgeMinQueries int64
+}
+
+// DefaultAnomalyThresholds returns the tuned defaults used when a threshold is
+// left at its zero value.
+func DefaultAnomalyThresholds() AnomalyThresholds {
+	return AnomalyThresholds{
+		BlockedRateSpikePoints: 10,
+		ClientSurgeFactor:      3,
+		ClientSurgeMinQueries:  20,
+	}
+}
+
+// withDefaults fills any zero-value threshold with its default.
+func (t AnomalyThresholds) withDefaults() AnomalyThresholds {
+	d := DefaultAnomalyThresholds()
+	if t.BlockedRateSpikePoints <= 0 {
+		t.BlockedRateSpikePoints = d.BlockedRateSpikePoints
+	}
+	if t.ClientSurgeFactor <= 0 {
+		t.ClientSurgeFactor = d.ClientSurgeFactor
+	}
+	if t.ClientSurgeMinQueries <= 0 {
+		t.ClientSurgeMinQueries = d.ClientSurgeMinQueries
+	}
+	return t
+}
+
+// WindowStats is the minimal per-window summary the anomaly computation needs:
+// total and blocked volume plus per-client totals. It is produced by
+// GatherWindowStats and consumed by ComputeAnomalyDigest.
+type WindowStats struct {
+	Total   int64
+	Blocked int64
+	Clients []ClientActivity
+}
+
+// BlockedRate returns the blocked share of the window as a percentage (0..100),
+// or 0 when the window is empty.
+func (w WindowStats) BlockedRate() float64 {
+	if w.Total <= 0 {
+		return 0
+	}
+	return float64(w.Blocked) / float64(w.Total) * 100
+}
+
+// ClientSurge describes a single client whose volume grew notably versus the
+// prior window.
+type ClientSurge struct {
+	ClientIP     string  `json:"client_ip"`
+	Current      int64   `json:"current"`
+	Prior        int64   `json:"prior"`
+	GrowthFactor float64 `json:"growth_factor"`
+}
+
+// AnomalyDigest is the computed comparison between a current and a prior window.
+type AnomalyDigest struct {
+	TotalCurrent int64 `json:"total_current"`
+	TotalPrior   int64 `json:"total_prior"`
+	TotalDelta   int64 `json:"total_delta"`
+
+	BlockedRateCurrent float64 `json:"blocked_rate_current"`
+	BlockedRatePrior   float64 `json:"blocked_rate_prior"`
+	// BlockedRateDeltaPoints is current minus prior, in percentage points.
+	BlockedRateDeltaPoints float64 `json:"blocked_rate_delta_points"`
+	BlockedRateSpike       bool    `json:"blocked_rate_spike"`
+
+	SurgingClients []ClientSurge `json:"surging_clients"`
+}
+
+// ComputeAnomalyDigest compares two window summaries and returns the notable
+// deltas. It is pure and deterministic: no clock, no I/O, and surging clients
+// are returned in a stable order (largest growth first, client IP as
+// tie-break). A client with zero prior volume but current volume at or above
+// ClientSurgeMinQueries is treated as a surge (growth factor reported as +Inf's
+// stand-in: current/1).
+func ComputeAnomalyDigest(current, prior WindowStats, cfg AnomalyThresholds) AnomalyDigest {
+	cfg = cfg.withDefaults()
+
+	digest := AnomalyDigest{
+		TotalCurrent:           current.Total,
+		TotalPrior:             prior.Total,
+		TotalDelta:             current.Total - prior.Total,
+		BlockedRateCurrent:     current.BlockedRate(),
+		BlockedRatePrior:       prior.BlockedRate(),
+		BlockedRateDeltaPoints: current.BlockedRate() - prior.BlockedRate(),
+	}
+	digest.BlockedRateSpike = digest.BlockedRateDeltaPoints >= cfg.BlockedRateSpikePoints
+
+	priorByClient := make(map[string]int64, len(prior.Clients))
+	for _, c := range prior.Clients {
+		priorByClient[c.ClientIP] = c.Total
+	}
+
+	var surges []ClientSurge
+	for _, c := range current.Clients {
+		if c.Total < cfg.ClientSurgeMinQueries {
+			continue
+		}
+		priorTotal := priorByClient[c.ClientIP]
+		// Use a floor of 1 for the prior so a brand-new client still yields a
+		// finite, comparable growth factor.
+		denom := priorTotal
+		if denom < 1 {
+			denom = 1
+		}
+		factor := float64(c.Total) / float64(denom)
+		if factor < cfg.ClientSurgeFactor {
+			continue
+		}
+		surges = append(surges, ClientSurge{
+			ClientIP:     c.ClientIP,
+			Current:      c.Total,
+			Prior:        priorTotal,
+			GrowthFactor: factor,
+		})
+	}
+	sortClientSurges(surges)
+	digest.SurgingClients = surges
+	return digest
+}
+
+// sortClientSurges orders surges by growth factor desc, then client IP asc, for
+// deterministic output.
+func sortClientSurges(s []ClientSurge) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0; j-- {
+			a, b := s[j-1], s[j]
+			less := b.GrowthFactor > a.GrowthFactor ||
+				(b.GrowthFactor == a.GrowthFactor && b.ClientIP < a.ClientIP)
+			if !less {
+				break
+			}
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+// GatherWindowStats collects the totals and per-client volumes needed to build
+// an anomaly digest for a single window. It reuses the same indexed, bounded
+// aggregates as the rollup endpoints: the per-client list is capped at the
+// window's clamped top-N so a pathological number of distinct clients cannot
+// blow up the digest.
+func (r *GormQueryLogRepo) GatherWindowStats(w AnalyticsWindow) (WindowStats, error) {
+	var totals struct {
+		Total   int64
+		Blocked int64
+	}
+	if err := r.scopedByWindow(w).
+		Select("COUNT(*) AS total, " + blockedSumExpr + " AS blocked").
+		Scan(&totals).Error; err != nil {
+		return WindowStats{}, err
+	}
+
+	clients, err := r.TopClients(w)
+	if err != nil {
+		return WindowStats{}, err
+	}
+
+	return WindowStats{
+		Total:   totals.Total,
+		Blocked: totals.Blocked,
+		Clients: clients,
+	}, nil
+}
+
+// AnomalyDigestBetween gathers stats for the current and prior windows and
+// returns the computed digest. Delivery of the digest is intentionally out of
+// scope here.
+func (r *GormQueryLogRepo) AnomalyDigestBetween(current, prior AnalyticsWindow, cfg AnomalyThresholds) (AnomalyDigest, error) {
+	cur, err := r.GatherWindowStats(current)
+	if err != nil {
+		return AnomalyDigest{}, err
+	}
+	pri, err := r.GatherWindowStats(prior)
+	if err != nil {
+		return AnomalyDigest{}, err
+	}
+	return ComputeAnomalyDigest(cur, pri, cfg), nil
+}

--- a/internal/storage/repositories/anomaly_test.go
+++ b/internal/storage/repositories/anomaly_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package repositories
+
+import "testing"
+
+func TestComputeAnomalyDigest_BlockedRateSpike(t *testing.T) {
+	current := WindowStats{Total: 100, Blocked: 40} // 40%
+	prior := WindowStats{Total: 100, Blocked: 20}   // 20%
+
+	d := ComputeAnomalyDigest(current, prior, AnomalyThresholds{})
+	if d.BlockedRateCurrent != 40 || d.BlockedRatePrior != 20 {
+		t.Fatalf("rates wrong: cur=%f prior=%f", d.BlockedRateCurrent, d.BlockedRatePrior)
+	}
+	if d.BlockedRateDeltaPoints != 20 {
+		t.Errorf("expected +20 points, got %f", d.BlockedRateDeltaPoints)
+	}
+	if !d.BlockedRateSpike {
+		t.Errorf("expected spike=true for +20 points against default 10-point threshold")
+	}
+	if d.TotalDelta != 0 {
+		t.Errorf("expected total delta 0, got %d", d.TotalDelta)
+	}
+}
+
+func TestComputeAnomalyDigest_NoSpikeBelowThreshold(t *testing.T) {
+	current := WindowStats{Total: 100, Blocked: 25} // 25%
+	prior := WindowStats{Total: 100, Blocked: 20}   // 20%, +5 points < 10
+
+	d := ComputeAnomalyDigest(current, prior, AnomalyThresholds{})
+	if d.BlockedRateSpike {
+		t.Errorf("expected no spike for +5 points, got spike=true (delta=%f)", d.BlockedRateDeltaPoints)
+	}
+}
+
+func TestComputeAnomalyDigest_CustomThreshold(t *testing.T) {
+	current := WindowStats{Total: 100, Blocked: 25}
+	prior := WindowStats{Total: 100, Blocked: 20}
+
+	// Lower the spike threshold to 4 points; +5 now trips it.
+	d := ComputeAnomalyDigest(current, prior, AnomalyThresholds{BlockedRateSpikePoints: 4})
+	if !d.BlockedRateSpike {
+		t.Errorf("expected spike with 4-point threshold and +5 delta")
+	}
+}
+
+func TestComputeAnomalyDigest_EmptyPriorRate(t *testing.T) {
+	// Empty prior window: blocked rate is defined as 0, not NaN.
+	current := WindowStats{Total: 50, Blocked: 30}
+	prior := WindowStats{}
+
+	d := ComputeAnomalyDigest(current, prior, AnomalyThresholds{})
+	if d.BlockedRatePrior != 0 {
+		t.Errorf("expected prior rate 0 for empty window, got %f", d.BlockedRatePrior)
+	}
+	if d.TotalDelta != 50 {
+		t.Errorf("expected total delta 50, got %d", d.TotalDelta)
+	}
+	if !d.BlockedRateSpike {
+		t.Errorf("60%% vs 0%% should be a spike")
+	}
+}
+
+func TestComputeAnomalyDigest_ClientSurge(t *testing.T) {
+	current := WindowStats{
+		Total: 200, Blocked: 10,
+		Clients: []ClientActivity{
+			{ClientIP: "10.0.0.1", Total: 120}, // 30 -> 120 = 4x, above floor
+			{ClientIP: "10.0.0.2", Total: 25},  // 20 -> 25 = 1.25x, not a surge
+			{ClientIP: "10.0.0.3", Total: 60},  // new client, 0 -> 60
+			{ClientIP: "10.0.0.4", Total: 5},   // below min-queries floor, ignored
+		},
+	}
+	prior := WindowStats{
+		Total: 60,
+		Clients: []ClientActivity{
+			{ClientIP: "10.0.0.1", Total: 30},
+			{ClientIP: "10.0.0.2", Total: 20},
+		},
+	}
+
+	d := ComputeAnomalyDigest(current, prior, AnomalyThresholds{})
+
+	if len(d.SurgingClients) != 2 {
+		t.Fatalf("expected 2 surging clients, got %d (%+v)", len(d.SurgingClients), d.SurgingClients)
+	}
+	// New client 10.0.0.3: 0 -> 60 => growth 60 (denom floored to 1) beats 4x.
+	// Ordered by growth factor desc, so it should be first.
+	if d.SurgingClients[0].ClientIP != "10.0.0.3" {
+		t.Errorf("expected new client 10.0.0.3 first by growth, got %+v", d.SurgingClients[0])
+	}
+	if d.SurgingClients[0].Prior != 0 || d.SurgingClients[0].Current != 60 {
+		t.Errorf("10.0.0.3 surge fields wrong: %+v", d.SurgingClients[0])
+	}
+	if d.SurgingClients[1].ClientIP != "10.0.0.1" {
+		t.Errorf("expected 10.0.0.1 as second surge, got %+v", d.SurgingClients[1])
+	}
+	if d.SurgingClients[1].GrowthFactor != 4 {
+		t.Errorf("expected growth factor 4 for 10.0.0.1, got %f", d.SurgingClients[1].GrowthFactor)
+	}
+	// 10.0.0.2 (1.25x) and 10.0.0.4 (below floor) must be excluded.
+	for _, s := range d.SurgingClients {
+		if s.ClientIP == "10.0.0.2" || s.ClientIP == "10.0.0.4" {
+			t.Errorf("client %q should not be reported as surging", s.ClientIP)
+		}
+	}
+}
+
+func TestComputeAnomalyDigest_Deterministic(t *testing.T) {
+	// Same growth factor -> tie-broken by client IP ascending.
+	current := WindowStats{
+		Clients: []ClientActivity{
+			{ClientIP: "10.0.0.5", Total: 40},
+			{ClientIP: "10.0.0.2", Total: 40},
+		},
+	}
+	prior := WindowStats{
+		Clients: []ClientActivity{
+			{ClientIP: "10.0.0.5", Total: 10},
+			{ClientIP: "10.0.0.2", Total: 10},
+		},
+	}
+	d := ComputeAnomalyDigest(current, prior, AnomalyThresholds{})
+	if len(d.SurgingClients) != 2 {
+		t.Fatalf("expected 2 surges, got %d", len(d.SurgingClients))
+	}
+	if d.SurgingClients[0].ClientIP != "10.0.0.2" || d.SurgingClients[1].ClientIP != "10.0.0.5" {
+		t.Errorf("expected IP-ascending tie-break, got %q then %q",
+			d.SurgingClients[0].ClientIP, d.SurgingClients[1].ClientIP)
+	}
+}

--- a/internal/storage/repositories/query_log.go
+++ b/internal/storage/repositories/query_log.go
@@ -52,6 +52,20 @@ type QueryLogRepository interface {
 	// newest-first, along with the total number of rows matching the filter
 	// (ignoring the paging window) so callers can render page info.
 	List(filter QueryLogFilter) ([]models.DNSQuery, int64, error)
+
+	// Analytics rollups over the query log. Each is an indexed, bounded
+	// aggregate scoped to an optional time window (see analytics.go).
+	TopClients(w AnalyticsWindow) ([]ClientActivity, error)
+	TopBlockedDomains(w AnalyticsWindow) ([]DomainCount, error)
+	CategoryBreakdown(w AnalyticsWindow) ([]CategoryCount, error)
+	ClientTimeline(clientIP string, w AnalyticsWindow) ([]TimeBucket, error)
+	CategoryHourHeatmap(w AnalyticsWindow) ([]HeatmapCell, error)
+
+	// GatherWindowStats and AnomalyDigestBetween back the anomaly digest
+	// (see anomaly.go). AnomalyDigestBetween compares a current and a prior
+	// window; delivery of the resulting digest is handled elsewhere.
+	GatherWindowStats(w AnalyticsWindow) (WindowStats, error)
+	AnomalyDigestBetween(current, prior AnalyticsWindow, cfg AnomalyThresholds) (AnomalyDigest, error)
 }
 
 // Implementation


### PR DESCRIPTION
## What

Adds analytics aggregation endpoints over the DNS query log (I-048, I-115, I-116, I-117):

- **Top-clients leaderboard** — busiest clients by volume, with a per-client blocked count.
- **Top-blocked-domains** — most-blocked domains (`action = 'block'`), top-N capped.
- **Top-categories** — per-disposition breakdown of the query log.
- **Per-client activity timeline** — hour-bucketed totals/blocked for one client.
- **Category × hour heatmap** — a bounded dataset for a disposition-by-hour-of-day view.
- **Anomaly digest helper** — a computed struct of notable deltas vs a prior window (blocked-rate spike, surging clients).
- **`GET /analytics/rollups`** — returns all rollups in the standard envelope, with a `from`/`to` date-range param (plus `top` and `client_ip`).

## Why

The query log now supports paginated, filterable reads (#41), but the UI/dashboard needs *aggregate* views — leaderboards, timelines, a heatmap, and an at-a-glance anomaly signal — rather than raw rows. This layer turns the log into the numbers the console actually renders.

## How

- New repo aggregates in `internal/storage/repositories/analytics.go`, built on the same `DNSQuery` model and reusing the indexed columns from #41. An `AnalyticsWindow` scopes every rollup to an optional **indexed** time range and clamps top-N to `[1, 100]`, so no query is unbounded. Hour bucketing uses `strftime`; blocked counts use a single shared `SUM(CASE ...)` expression.
- The aggregate + anomaly methods are added to the `QueryLogRepository` interface so handlers reach them through the existing `Store`.
- Anomaly logic in `internal/storage/repositories/anomaly.go`: `ComputeAnomalyDigest` is **pure and deterministic** (no clock/I/O, stable ordering). `GatherWindowStats` / `AnomalyDigestBetween` collect both windows and compute the struct. **Delivery/notification is intentionally out of scope** here.
- `GET /analytics/rollups` handler + route. A full `[from,to]` window also produces the anomaly digest, compared against the immediately-preceding equal-length window (prior window ends one tick before the current one to avoid double-counting the boundary row).
- **Note on "category":** the query log records a per-row *disposition* (`action`: allow/block/flagged/redirect) — the only low-cardinality, always-populated, indexed categorical dimension on `DNSQuery`. Content categories live on policies/blocklists and are not stamped onto individual query rows, so "category" here means disposition. Documented inline.

## Tests

Temp in-memory sqlite, deterministic seeds:

- **Repo aggregates:** top-N ordering + caps, per-client hourly timeline, category × hour heatmap, time-window scoping, `GatherWindowStats`.
- **Anomaly:** pure delta computation (spike thresholds, client-surge factor + min-query floor, tie-break determinism, empty-window rate) plus a DB-backed integration path.
- **Handler:** envelope/shape, client timeline, top-N clamping, anomaly presence for a full window, and `400`s on bad params.

`gofmt`, `go build ./...`, `go vet ./...`, and `go test ./...` all green.

## Stacking

**Stacks on #41** (`feat/query-log-pagination`, which added `List(filter)` + `/analytics/logs`). This PR's base is that branch — **merge after #41.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
