### PR TITLE
feat: infected-device alerting on repeated C2/malware hits (I-045)

### DIFF
--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lopster568/phantomDNS/internal/alert"
 	"github.com/lopster568/phantomDNS/internal/blocklist"
 	"github.com/lopster568/phantomDNS/internal/blocklist/bundle"
 	"github.com/lopster568/phantomDNS/internal/config"
@@ -16,6 +17,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/geoip"
 	dataplanegrpc "github.com/lopster568/phantomDNS/internal/grpc/dataplane"
 	"github.com/lopster568/phantomDNS/internal/heartbeat"
+	"github.com/lopster568/phantomDNS/internal/inventory"
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"github.com/lopster568/phantomDNS/internal/metrics/promexport"
 	"github.com/lopster568/phantomDNS/internal/nrd"
@@ -121,6 +123,18 @@ func main() {
 	engine, err := dnsengine.NewDNSEngine(config.DefaultConfig.DataPlane, repos, policyEngine)
 	if err != nil {
 		logger.Log.Fatal("Failed to create DNS engine: " + err.Error())
+	}
+
+	// 5a. Infected-device alerting (I-045). Resolve client IPs to devices via
+	// the passive LAN inventory so alerts carry MAC + hostname, and optionally
+	// forward fired alerts to a webhook. Both the inventory (INVENTORY_ENABLED)
+	// and alerting (DEVICE_ALERT_THRESHOLD) are off by default.
+	deviceInventory := inventory.New(inventory.ConfigFromEnv(), nil)
+	deviceInventory.Start()
+	defer deviceInventory.Stop()
+	engine.AttachDeviceResolver(alert.NewInventoryResolver(deviceInventory))
+	if sink := alert.NewWebhookSink(os.Getenv("DEVICE_ALERT_WEBHOOK")); sink != nil {
+		engine.AttachAlertSink(sink)
 	}
 
 	// 5b. Optional ASN/GeoIP answer filtering — inert unless GEOIP_DB_PATH is set.

--- a/internal/alert/alert.go
+++ b/internal/alert/alert.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package alert implements infected-device alerting (I-045).
+//
+// It watches for clients that repeatedly resolve known-malware / C2 domains
+// (blocked hits). When a single client crosses a configurable threshold of
+// blocked hits within a sliding window, the device behind that client IP is
+// marked suspected-compromised and an alert record is produced. Alerts are
+// enriched with device identity (IP + MAC + hostname) resolved from the passive
+// LAN inventory; unknown devices yield an IP-only alert.
+//
+// The feature is off by default: alerting is enabled only when a positive
+// DEVICE_ALERT_THRESHOLD is configured. Time is injected via a Clock and the
+// device lookup via a DeviceResolver so the whole path is deterministic in
+// tests.
+package alert
+
+import (
+	"os"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+// DefaultWindow is the sliding window over which blocked hits are counted when
+// a Config does not specify one.
+const DefaultWindow = 10 * time.Minute
+
+// DeviceInfo is the identity of a device correlated with a client IP. MAC and
+// Hostname are empty when the device is unknown to the inventory.
+type DeviceInfo struct {
+	IP       string `json:"ip"`
+	MAC      string `json:"mac,omitempty"`
+	Hostname string `json:"hostname,omitempty"`
+}
+
+// DeviceResolver maps a client IP to its device identity. It is satisfied by
+// the LAN inventory (see InventoryResolver) and by fakes in tests. A lookup
+// that returns false yields an IP-only alert.
+type DeviceResolver interface {
+	Lookup(ip string) (DeviceInfo, bool)
+}
+
+// Clock abstracts time so windowing is deterministic in tests.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// Alert is a single infected-device alert record.
+type Alert struct {
+	Device    DeviceInfo `json:"device"`
+	Hits      int        `json:"hits"`      // blocked hits in the window at fire time
+	Threshold int        `json:"threshold"` // threshold that was crossed
+	FirstHit  time.Time  `json:"first_hit"` // oldest hit still inside the window
+	FiredAt   time.Time  `json:"fired_at"`  // when the threshold was crossed
+	Domain    string     `json:"domain,omitempty"`
+}
+
+// Config controls the alerter.
+type Config struct {
+	// Threshold is the number of blocked hits from one client within Window
+	// that marks the device suspected-compromised. A value <= 0 disables
+	// alerting entirely (the feature default).
+	Threshold int
+	// Window is the sliding window over which blocked hits are counted. A
+	// value <= 0 falls back to DefaultWindow.
+	Window time.Duration
+}
+
+// ConfigFromEnv builds a Config from environment variables:
+//
+//	DEVICE_ALERT_THRESHOLD  blocked hits within the window before a device is
+//	                        flagged. Default 0 (off); any positive value
+//	                        enables alerting.
+//	DEVICE_ALERT_WINDOW     window duration, e.g. "10m" (default 10m).
+func ConfigFromEnv() Config {
+	cfg := Config{Window: DefaultWindow}
+	if v := os.Getenv("DEVICE_ALERT_THRESHOLD"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Threshold = n
+		}
+	}
+	if v := os.Getenv("DEVICE_ALERT_WINDOW"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.Window = d
+		}
+	}
+	return cfg
+}
+
+// clientCounter tracks the recent blocked-hit timestamps for one client IP.
+type clientCounter struct {
+	hits []time.Time
+}
+
+// Alerter counts per-client blocked hits and fires device alerts on threshold
+// crossings. It is safe for concurrent use.
+type Alerter struct {
+	cfg   Config
+	clock Clock
+
+	mu        sync.Mutex
+	resolver  DeviceResolver
+	sink      func(Alert)
+	counters  map[string]*clientCounter
+	suspected map[string]Alert // clientIP -> latest alert
+}
+
+// NewAlerter constructs an Alerter. A nil clock defaults to wall-clock time; a
+// nil resolver produces IP-only alerts.
+func NewAlerter(cfg Config, resolver DeviceResolver, clock Clock) *Alerter {
+	if clock == nil {
+		clock = realClock{}
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = DefaultWindow
+	}
+	return &Alerter{
+		cfg:       cfg,
+		clock:     clock,
+		resolver:  resolver,
+		counters:  make(map[string]*clientCounter),
+		suspected: make(map[string]Alert),
+	}
+}
+
+// Enabled reports whether alerting is active (a positive threshold is set).
+func (a *Alerter) Enabled() bool { return a.cfg.Threshold > 0 }
+
+// SetResolver attaches (or replaces) the device resolver used to enrich alerts.
+func (a *Alerter) SetResolver(r DeviceResolver) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.resolver = r
+}
+
+// SetSink attaches an optional side-channel (e.g. a webhook) invoked for each
+// fired alert. It is called synchronously while no lock is held; sinks that may
+// block should return quickly or dispatch their own goroutine.
+func (a *Alerter) SetSink(fn func(Alert)) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sink = fn
+}
+
+// RecordBlocked registers one blocked hit for clientIP resolving domain. When
+// the client crosses the configured threshold within the window it returns the
+// fired alert and true; otherwise it returns the zero Alert and false. It is a
+// no-op (false) when alerting is disabled or clientIP is empty.
+func (a *Alerter) RecordBlocked(clientIP, domain string) (Alert, bool) {
+	if a == nil || a.cfg.Threshold <= 0 || clientIP == "" {
+		return Alert{}, false
+	}
+
+	now := a.clock.Now()
+	cutoff := now.Add(-a.cfg.Window)
+
+	a.mu.Lock()
+	c := a.counters[clientIP]
+	if c == nil {
+		c = &clientCounter{}
+		a.counters[clientIP] = c
+	}
+	// Drop hits that have aged out of the sliding window, then record this one.
+	kept := c.hits[:0]
+	for _, t := range c.hits {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	c.hits = append(kept, now)
+
+	if len(c.hits) < a.cfg.Threshold {
+		a.mu.Unlock()
+		return Alert{}, false
+	}
+
+	// Threshold crossed: build the alert, remember the device as suspected and
+	// reset the counter so we do not re-fire on every subsequent hit.
+	alert := Alert{
+		Device:    a.resolveLocked(clientIP),
+		Hits:      len(c.hits),
+		Threshold: a.cfg.Threshold,
+		FirstHit:  c.hits[0],
+		FiredAt:   now,
+		Domain:    domain,
+	}
+	c.hits = c.hits[:0]
+	a.suspected[clientIP] = alert
+	sink := a.sink
+	a.mu.Unlock()
+
+	logger.Log.Warnf(
+		"infected-device alert: client %s crossed %d blocked hits within %s (mac=%q hostname=%q, last domain %q)",
+		alert.Device.IP, alert.Threshold, a.cfg.Window, alert.Device.MAC, alert.Device.Hostname, domain,
+	)
+	if sink != nil {
+		sink(alert)
+	}
+	return alert, true
+}
+
+// resolveLocked builds the DeviceInfo for a client IP. Callers must hold a.mu.
+func (a *Alerter) resolveLocked(clientIP string) DeviceInfo {
+	dev := DeviceInfo{IP: clientIP}
+	if a.resolver != nil {
+		if d, ok := a.resolver.Lookup(clientIP); ok {
+			dev = d
+			if dev.IP == "" {
+				dev.IP = clientIP
+			}
+		}
+	}
+	return dev
+}
+
+// IsSuspected reports whether a client IP has been flagged as compromised.
+func (a *Alerter) IsSuspected(clientIP string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, ok := a.suspected[clientIP]
+	return ok
+}
+
+// Suspected returns a snapshot of the latest alert per suspected device, sorted
+// by IP. The returned slice is a copy and safe for the caller to mutate.
+func (a *Alerter) Suspected() []Alert {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]Alert, 0, len(a.suspected))
+	for _, al := range a.suspected {
+		out = append(out, al)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Device.IP < out[j].Device.IP })
+	return out
+}

--- a/internal/alert/alert_test.go
+++ b/internal/alert/alert_test.go
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package alert
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeClock is a controllable Clock for deterministic windowing.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.t }
+func (c *fakeClock) Advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// fakeResolver is a fake inventory: a static IP -> device map.
+type fakeResolver struct{ devices map[string]DeviceInfo }
+
+func (f fakeResolver) Lookup(ip string) (DeviceInfo, bool) {
+	d, ok := f.devices[ip]
+	return d, ok
+}
+
+var base = time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+// Threshold crossing on repeated blocked hits from one client fires exactly one
+// alert, enriched with the device (IP + MAC + hostname) from the inventory.
+func TestRecordBlocked_ThresholdCrossing_WithDevice(t *testing.T) {
+	clk := &fakeClock{t: base}
+	res := fakeResolver{devices: map[string]DeviceInfo{
+		"192.168.1.50": {IP: "192.168.1.50", MAC: "aa:bb:cc:dd:ee:50", Hostname: "roshan-laptop"},
+	}}
+	a := NewAlerter(Config{Threshold: 3, Window: 10 * time.Minute}, res, clk)
+
+	if !a.Enabled() {
+		t.Fatal("alerter with positive threshold should be enabled")
+	}
+
+	// First two hits stay below the threshold.
+	for i := 1; i <= 2; i++ {
+		if al, fired := a.RecordBlocked("192.168.1.50", "c2.evil.com"); fired {
+			t.Fatalf("hit %d should not fire an alert (got %+v)", i, al)
+		}
+	}
+
+	al, fired := a.RecordBlocked("192.168.1.50", "beacon.evil.com")
+	if !fired {
+		t.Fatal("third hit should cross the threshold and fire")
+	}
+	if al.Device.IP != "192.168.1.50" || al.Device.MAC != "aa:bb:cc:dd:ee:50" || al.Device.Hostname != "roshan-laptop" {
+		t.Errorf("alert not enriched with device: %+v", al.Device)
+	}
+	if al.Hits != 3 || al.Threshold != 3 {
+		t.Errorf("expected hits=3 threshold=3, got hits=%d threshold=%d", al.Hits, al.Threshold)
+	}
+	if !al.FiredAt.Equal(base) || !al.FirstHit.Equal(base) {
+		t.Errorf("expected FiredAt=FirstHit=base, got fired=%v first=%v", al.FiredAt, al.FirstHit)
+	}
+	if al.Domain != "beacon.evil.com" {
+		t.Errorf("expected triggering domain beacon.evil.com, got %q", al.Domain)
+	}
+
+	// Device is now suspected and surfaced by the status accessor.
+	if !a.IsSuspected("192.168.1.50") {
+		t.Error("device should be marked suspected after firing")
+	}
+	susp := a.Suspected()
+	if len(susp) != 1 || susp[0].Device.Hostname != "roshan-laptop" {
+		t.Errorf("Suspected() = %+v, want one entry for roshan-laptop", susp)
+	}
+
+	// The counter resets on fire: a single further hit must not re-fire.
+	if _, fired := a.RecordBlocked("192.168.1.50", "c2.evil.com"); fired {
+		t.Error("counter should reset after firing; single hit re-fired")
+	}
+}
+
+// Below the threshold, no alert is produced and nothing is suspected.
+func TestRecordBlocked_BelowThreshold_NoAlert(t *testing.T) {
+	clk := &fakeClock{t: base}
+	a := NewAlerter(Config{Threshold: 5, Window: 10 * time.Minute}, fakeResolver{}, clk)
+
+	for i := 1; i <= 4; i++ {
+		if _, fired := a.RecordBlocked("10.0.0.9", "malware.example"); fired {
+			t.Fatalf("hit %d should not fire below a threshold of 5", i)
+		}
+	}
+	if a.IsSuspected("10.0.0.9") {
+		t.Error("device below threshold should not be suspected")
+	}
+	if got := a.Suspected(); len(got) != 0 {
+		t.Errorf("expected no suspected devices, got %+v", got)
+	}
+}
+
+// A client that is unknown to the inventory still fires, but the alert is
+// IP-only (no MAC / hostname).
+func TestRecordBlocked_UnknownDevice_IPOnly(t *testing.T) {
+	clk := &fakeClock{t: base}
+
+	cases := map[string]DeviceResolver{
+		"empty inventory": fakeResolver{devices: map[string]DeviceInfo{}},
+		"nil resolver":    nil,
+	}
+	for name, res := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := NewAlerter(Config{Threshold: 2, Window: time.Minute}, res, clk)
+			a.RecordBlocked("172.16.0.4", "c2.evil.com")
+			al, fired := a.RecordBlocked("172.16.0.4", "c2.evil.com")
+			if !fired {
+				t.Fatal("expected alert to fire at threshold")
+			}
+			if al.Device.IP != "172.16.0.4" {
+				t.Errorf("expected IP-only device IP 172.16.0.4, got %q", al.Device.IP)
+			}
+			if al.Device.MAC != "" || al.Device.Hostname != "" {
+				t.Errorf("unknown device should have empty MAC/hostname, got %+v", al.Device)
+			}
+		})
+	}
+}
+
+// A disabled alerter (threshold <= 0) never fires, no matter how many hits.
+func TestRecordBlocked_Disabled_Off(t *testing.T) {
+	clk := &fakeClock{t: base}
+	for _, thr := range []int{0, -1} {
+		a := NewAlerter(Config{Threshold: thr, Window: time.Minute}, fakeResolver{}, clk)
+		if a.Enabled() {
+			t.Errorf("threshold %d should be disabled", thr)
+		}
+		for i := 0; i < 100; i++ {
+			if _, fired := a.RecordBlocked("192.168.1.1", "c2.evil.com"); fired {
+				t.Fatalf("disabled alerter (threshold %d) fired on hit %d", thr, i)
+			}
+		}
+		if got := a.Suspected(); len(got) != 0 {
+			t.Errorf("disabled alerter should have no suspected devices, got %+v", got)
+		}
+	}
+}
+
+// Hits that age out of the sliding window are not counted toward the threshold.
+func TestRecordBlocked_WindowSliding(t *testing.T) {
+	clk := &fakeClock{t: base}
+	a := NewAlerter(Config{Threshold: 3, Window: 10 * time.Minute}, nil, clk)
+
+	a.RecordBlocked("192.168.1.7", "c2.evil.com") // hit @ base
+	clk.Advance(1 * time.Minute)
+	a.RecordBlocked("192.168.1.7", "c2.evil.com") // hit @ base+1m
+
+	// Jump past the window: both earlier hits expire.
+	clk.Advance(11 * time.Minute) // now base+12m, cutoff base+2m
+	if _, fired := a.RecordBlocked("192.168.1.7", "c2.evil.com"); fired {
+		t.Fatal("hit should not fire after earlier hits aged out of the window")
+	}
+
+	// Two more hits inside the fresh window cross the threshold.
+	clk.Advance(1 * time.Minute)
+	a.RecordBlocked("192.168.1.7", "c2.evil.com") // count 2 @ base+13m
+	clk.Advance(1 * time.Minute)
+	al, fired := a.RecordBlocked("192.168.1.7", "c2.evil.com") // count 3 @ base+14m
+	if !fired {
+		t.Fatal("three in-window hits should cross the threshold")
+	}
+	if al.Hits != 3 {
+		t.Errorf("expected hits=3, got %d", al.Hits)
+	}
+	wantFirst := base.Add(12 * time.Minute)
+	if !al.FirstHit.Equal(wantFirst) {
+		t.Errorf("FirstHit = %v, want %v (window start)", al.FirstHit, wantFirst)
+	}
+}
+
+// Distinct clients are counted independently.
+func TestRecordBlocked_PerClientIndependent(t *testing.T) {
+	clk := &fakeClock{t: base}
+	a := NewAlerter(Config{Threshold: 2, Window: time.Minute}, nil, clk)
+
+	a.RecordBlocked("10.0.0.1", "c2.evil.com")
+	// A single hit from a different client must not push .1 over on its own.
+	if _, fired := a.RecordBlocked("10.0.0.2", "c2.evil.com"); fired {
+		t.Fatal("second client should not fire on its first hit")
+	}
+	if _, fired := a.RecordBlocked("10.0.0.1", "c2.evil.com"); !fired {
+		t.Fatal("first client should fire on its own second hit")
+	}
+}
+
+// The optional sink receives each fired alert.
+func TestRecordBlocked_SinkInvoked(t *testing.T) {
+	clk := &fakeClock{t: base}
+	a := NewAlerter(Config{Threshold: 1, Window: time.Minute}, nil, clk)
+
+	got := make(chan Alert, 1)
+	a.SetSink(func(al Alert) { got <- al })
+
+	a.RecordBlocked("10.0.0.5", "c2.evil.com")
+	select {
+	case al := <-got:
+		if al.Device.IP != "10.0.0.5" {
+			t.Errorf("sink got unexpected alert: %+v", al)
+		}
+	default:
+		t.Fatal("sink was not invoked on fire")
+	}
+}
+
+func TestConfigFromEnv(t *testing.T) {
+	t.Setenv("DEVICE_ALERT_THRESHOLD", "5")
+	t.Setenv("DEVICE_ALERT_WINDOW", "2m")
+	cfg := ConfigFromEnv()
+	if cfg.Threshold != 5 {
+		t.Errorf("expected threshold 5, got %d", cfg.Threshold)
+	}
+	if cfg.Window != 2*time.Minute {
+		t.Errorf("expected window 2m, got %v", cfg.Window)
+	}
+}
+
+func TestConfigFromEnv_DefaultOff(t *testing.T) {
+	t.Setenv("DEVICE_ALERT_THRESHOLD", "")
+	t.Setenv("DEVICE_ALERT_WINDOW", "")
+	cfg := ConfigFromEnv()
+	if cfg.Threshold != 0 {
+		t.Errorf("threshold should default to 0 (off), got %d", cfg.Threshold)
+	}
+	if cfg.Window != DefaultWindow {
+		t.Errorf("window should default to %v, got %v", DefaultWindow, cfg.Window)
+	}
+	if NewAlerter(cfg, nil, nil).Enabled() {
+		t.Error("default config should produce a disabled alerter")
+	}
+}
+
+func TestConfigFromEnv_InvalidValuesIgnored(t *testing.T) {
+	t.Setenv("DEVICE_ALERT_THRESHOLD", "not-a-number")
+	t.Setenv("DEVICE_ALERT_WINDOW", "garbage")
+	cfg := ConfigFromEnv()
+	if cfg.Threshold != 0 {
+		t.Errorf("invalid threshold should leave default 0, got %d", cfg.Threshold)
+	}
+	if cfg.Window != DefaultWindow {
+		t.Errorf("invalid window should leave default, got %v", cfg.Window)
+	}
+}

--- a/internal/alert/inventory_resolver.go
+++ b/internal/alert/inventory_resolver.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package alert
+
+import "github.com/lopster568/phantomDNS/internal/inventory"
+
+// InventoryResolver adapts the passive LAN inventory to a DeviceResolver so
+// that infected-device alerts can be enriched with a device's MAC and
+// hostname, keyed by client IP.
+type InventoryResolver struct {
+	inv *inventory.Inventory
+}
+
+// NewInventoryResolver wraps an inventory as a DeviceResolver. A nil inventory
+// is tolerated and simply resolves every IP as unknown.
+func NewInventoryResolver(inv *inventory.Inventory) *InventoryResolver {
+	return &InventoryResolver{inv: inv}
+}
+
+// Lookup implements DeviceResolver by consulting the inventory's IP -> Device
+// map. It returns false when the inventory is absent or the IP is unknown.
+func (r *InventoryResolver) Lookup(ip string) (DeviceInfo, bool) {
+	if r == nil || r.inv == nil {
+		return DeviceInfo{}, false
+	}
+	d, ok := r.inv.Lookup(ip)
+	if !ok {
+		return DeviceInfo{}, false
+	}
+	return DeviceInfo{IP: d.IP, MAC: d.MAC, Hostname: d.Hostname}, true
+}

--- a/internal/alert/webhook.go
+++ b/internal/alert/webhook.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package alert
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+)
+
+// webhookTimeout bounds how long a single alert POST may take.
+const webhookTimeout = 5 * time.Second
+
+// NewWebhookSink returns an alert sink that POSTs the alert as JSON to url. The
+// POST runs in its own goroutine so alerting never blocks the DNS path; failures
+// are logged and dropped. An empty url yields a nil sink (no-op).
+func NewWebhookSink(url string) func(Alert) {
+	if url == "" {
+		return nil
+	}
+	client := &http.Client{Timeout: webhookTimeout}
+	return func(a Alert) {
+		go postAlert(client, url, a)
+	}
+}
+
+func postAlert(client *http.Client, url string, a Alert) {
+	body, err := json.Marshal(a)
+	if err != nil {
+		logger.Log.Errorf("alert webhook: marshal failed: %v", err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), webhookTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		logger.Log.Errorf("alert webhook: build request failed: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Log.Errorf("alert webhook: POST %s failed: %v", url, err)
+		return
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/alert/webhook_test.go
+++ b/internal/alert/webhook_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package alert
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewWebhookSink_Empty(t *testing.T) {
+	if NewWebhookSink("") != nil {
+		t.Error("empty URL should yield a nil (no-op) sink")
+	}
+}
+
+func TestNewWebhookSink_POSTsAlert(t *testing.T) {
+	received := make(chan Alert, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected application/json, got %q", ct)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var a Alert
+		if err := json.Unmarshal(body, &a); err != nil {
+			t.Errorf("failed to decode alert body: %v", err)
+		}
+		received <- a
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL)
+	if sink == nil {
+		t.Fatal("expected a non-nil sink for a valid URL")
+	}
+
+	sink(Alert{
+		Device:    DeviceInfo{IP: "192.168.1.50", MAC: "aa:bb:cc:dd:ee:50", Hostname: "roshan-laptop"},
+		Hits:      3,
+		Threshold: 3,
+		Domain:    "c2.evil.com",
+	})
+
+	select {
+	case a := <-received:
+		if a.Device.IP != "192.168.1.50" || a.Device.Hostname != "roshan-laptop" {
+			t.Errorf("webhook received unexpected alert: %+v", a)
+		}
+		if a.Hits != 3 || a.Domain != "c2.evil.com" {
+			t.Errorf("webhook payload mismatch: %+v", a)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("webhook was not called within timeout")
+	}
+}

--- a/internal/dnsengine/alert_integration_test.go
+++ b/internal/dnsengine/alert_integration_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dnsengine
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/alert"
+)
+
+// fixedClock is a deterministic alert.Clock.
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+// fakeDevResolver is a fake inventory keyed by client IP.
+type fakeDevResolver map[string]alert.DeviceInfo
+
+func (f fakeDevResolver) Lookup(ip string) (alert.DeviceInfo, bool) {
+	d, ok := f[ip]
+	return d, ok
+}
+
+// addrWriter is a mockResponseWriter with a controllable RemoteAddr so the
+// engine can key alerts by a real client IP.
+type addrWriter struct {
+	mockResponseWriter
+	remote net.Addr
+}
+
+func (w *addrWriter) RemoteAddr() net.Addr { return w.remote }
+
+// Repeated blocklist hits from one client cross the alert threshold and produce
+// an alert enriched with the device from the (fake) inventory.
+func TestProcessDNSQuery_FeedsDeviceAlerter(t *testing.T) {
+	bl := &mockBlocklist{blocked: map[string]bool{"c2.evil.com": true}}
+	e := newTestEngine(bl, nil)
+
+	res := fakeDevResolver{
+		"192.168.1.50": {IP: "192.168.1.50", MAC: "aa:bb:cc:dd:ee:50", Hostname: "roshan-laptop"},
+	}
+	e.alerter = alert.NewAlerter(
+		alert.Config{Threshold: 3, Window: time.Hour},
+		res,
+		fixedClock{t: time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)},
+	)
+
+	w := &addrWriter{remote: &net.UDPAddr{IP: net.ParseIP("192.168.1.50"), Port: 5353}}
+
+	// First two blocked resolutions: below threshold.
+	e.ProcessDNSQuery(w, newTestQuery("c2.evil.com"))
+	e.ProcessDNSQuery(w, newTestQuery("c2.evil.com"))
+	if got := e.Alerts(); len(got) != 0 {
+		t.Fatalf("expected no alerts below threshold, got %+v", got)
+	}
+
+	// Third crosses it.
+	e.ProcessDNSQuery(w, newTestQuery("c2.evil.com"))
+	alerts := e.Alerts()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert after crossing threshold, got %d", len(alerts))
+	}
+	dev := alerts[0].Device
+	if dev.IP != "192.168.1.50" || dev.MAC != "aa:bb:cc:dd:ee:50" || dev.Hostname != "roshan-laptop" {
+		t.Errorf("alert not enriched with device identity: %+v", dev)
+	}
+}
+
+// With alerting disabled (default threshold), repeated blocked hits never
+// produce an alert.
+func TestProcessDNSQuery_AlerterDisabledByDefault(t *testing.T) {
+	bl := &mockBlocklist{blocked: map[string]bool{"c2.evil.com": true}}
+	e := newTestEngine(bl, nil)
+	// Default alerter: threshold 0 (off).
+	e.alerter = alert.NewAlerter(alert.Config{}, nil, nil)
+
+	w := &addrWriter{remote: &net.UDPAddr{IP: net.ParseIP("192.168.1.50"), Port: 5353}}
+	for i := 0; i < 20; i++ {
+		e.ProcessDNSQuery(w, newTestQuery("c2.evil.com"))
+	}
+	if got := e.Alerts(); len(got) != 0 {
+		t.Errorf("disabled alerter should produce no alerts, got %+v", got)
+	}
+}
+
+func TestClientIPOnly(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"192.168.1.50:5353", "192.168.1.50"},
+		{"[fe80::1]:53", "fe80::1"},
+		{"192.168.1.50", "192.168.1.50"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := clientIPOnly(tt.in); got != tt.want {
+			t.Errorf("clientIPOnly(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/lopster568/phantomDNS/internal/alert"
 	"github.com/lopster568/phantomDNS/internal/config"
 	"github.com/lopster568/phantomDNS/internal/geoip"
 	"github.com/lopster568/phantomDNS/internal/logger"
@@ -106,6 +107,12 @@ type Engine struct {
 	rateLimiter *rateLimiter
 
 	safeSearch bool
+
+	// alerter tracks repeated C2/malware hits per client and fires infected-
+	// device alerts (I-045). Off by default (nil sink, no resolver) unless
+	// DEVICE_ALERT_THRESHOLD is configured; always non-nil, so callers never
+	// need a nil check before Attach*.
+	alerter *alert.Alerter
 }
 
 // safeSearchTargets maps well-known search/video hostnames to their
@@ -144,6 +151,33 @@ func (e *Engine) AttachGeoFilter(f *geoip.Filter) {
 // engine. Passing a checker with no feed configured leaves NRD inert.
 func (e *Engine) AttachNRDChecker(n NRDChecker) {
 	e.nrd = n
+}
+
+// AttachDeviceResolver wires a device resolver (e.g. the LAN inventory) into
+// the infected-device alerter so alerts are enriched with MAC and hostname.
+// Safe to call with a nil alerter.
+func (e *Engine) AttachDeviceResolver(r alert.DeviceResolver) {
+	if e.alerter != nil {
+		e.alerter.SetResolver(r)
+	}
+}
+
+// AttachAlertSink wires an optional side-channel (e.g. a webhook) that receives
+// each fired infected-device alert. Safe to call with a nil alerter or sink.
+func (e *Engine) AttachAlertSink(fn func(alert.Alert)) {
+	if e.alerter != nil && fn != nil {
+		e.alerter.SetSink(fn)
+	}
+}
+
+// Alerts returns the current set of suspected-compromised devices. It is the
+// status accessor for infected-device alerting and is empty when the feature
+// is disabled.
+func (e *Engine) Alerts() []alert.Alert {
+	if e.alerter == nil {
+		return nil
+	}
+	return e.alerter.Suspected()
 }
 
 func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *policy.Engine) (*Engine, error) {
@@ -205,6 +239,10 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		safeSearch:           cfg.SafeSearch,
 		nodLedger:            ledger,
 		nodBlock:             cfg.NODBlock,
+		// Infected-device alerting (I-045). Off by default: enabled only when a
+		// positive DEVICE_ALERT_THRESHOLD is configured. A device resolver is
+		// attached later via AttachDeviceResolver.
+		alerter: alert.NewAlerter(alert.ConfigFromEnv(), nil, nil),
 	}
 	e.setUpstreamExchanger(mgr)
 	if cfg.ServeStale {
@@ -597,6 +635,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			logger.Log.Infof("Blocked by blocklist: %s", domainName)
 			e.logQuery(domainName, clientIP, "block", "blocklist", threatResult)
 			e.metrics.RecordBlocked()
+			e.recordBlocked(clientIP, domainName)
 			e.respondBlocked(w, r, domainName, "blocklist")
 			success = true
 			return
@@ -638,6 +677,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		logger.Log.Infof("Blocking via policy %s", decision.PolicyID)
 		e.logQuery(domainName, clientIP, "block", decision.PolicyID, threatResult)
 		e.metrics.RecordBlocked()
+		e.recordBlocked(clientIP, domainName)
 		e.respondBlocked(w, r, domainName, decision.PolicyID)
 		success = true
 
@@ -835,6 +875,29 @@ func (e *Engine) logQuery(domain, clientIP, action, reason string, tr threat.Res
 			}
 		}
 	}()
+}
+
+// recordBlocked feeds one blocked resolution into the infected-device alerter,
+// keyed by the client's IP (port stripped). It is a no-op when alerting is
+// disabled. Malware/C2 blocklist hits and policy-deny hits both count.
+func (e *Engine) recordBlocked(clientAddr, domain string) {
+	if e.alerter == nil {
+		return
+	}
+	e.alerter.RecordBlocked(clientIPOnly(clientAddr), domain)
+}
+
+// clientIPOnly strips the transport port from a "host:port" remote address,
+// returning the bare IP used as the inventory key. Inputs without a port are
+// returned unchanged.
+func clientIPOnly(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
 }
 
 func (e *Engine) Metrics() *metrics.QueryMetrics {

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -139,6 +139,17 @@ func (inv *Inventory) Stop() {
 	inv.wg.Wait()
 }
 
+// Lookup returns the device currently known for the given IP. The second
+// return value is false when the IP has not been observed (or collection is
+// disabled). It backs infected-device alerting, which resolves a client IP to
+// its MAC and hostname.
+func (inv *Inventory) Lookup(ip string) (Device, bool) {
+	inv.mu.RLock()
+	defer inv.mu.RUnlock()
+	d, ok := inv.devices[ip]
+	return d, ok
+}
+
 // Devices returns a snapshot of the inventory sorted by IP. The returned
 // slice is a copy and safe for the caller to mutate.
 func (inv *Inventory) Devices() []Device {

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -208,3 +208,24 @@ func TestConfigFromEnv_DefaultOff(t *testing.T) {
 		t.Errorf("inventory should default to disabled")
 	}
 }
+
+func TestLookup(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_750_000_000, 0).UTC()}
+	inv := New(Config{Enabled: true}, clk)
+	inv.merge(
+		[]arpEntry{{IP: "192.168.1.42", MAC: "aa:bb:cc:dd:ee:42"}},
+		[]dhcpLease{{IP: "192.168.1.42", MAC: "aa:bb:cc:dd:ee:42", Hostname: "roshan-laptop"}},
+	)
+
+	d, ok := inv.Lookup("192.168.1.42")
+	if !ok {
+		t.Fatal("expected to find the merged device by IP")
+	}
+	if d.MAC != "aa:bb:cc:dd:ee:42" || d.Hostname != "roshan-laptop" {
+		t.Errorf("unexpected device from Lookup: %+v", d)
+	}
+
+	if _, ok := inv.Lookup("10.0.0.99"); ok {
+		t.Error("Lookup of an unknown IP should report not found")
+	}
+}


### PR DESCRIPTION
## What

Adds infected-device alerting (**I-045**): when a client on the LAN repeatedly resolves known-malware / C2 domains (blocked hits), the device behind that client IP is flagged as **suspected-compromised** and an alert is emitted.

## Why

The blocklist already stops individual malware/C2 lookups, but a host that *keeps* hitting C2 infrastructure is a signal in itself: it is likely infected. Surfacing that per-device (not just per-query) turns the gateway from a passive filter into an early-warning system for compromised endpoints, which is the core value proposition for the SMB/school/hospital deployments.

## How

- New `internal/alert` package:
  - `Alerter` keeps a **per-client sliding-window counter** of blocked hits. Crossing `DEVICE_ALERT_THRESHOLD` within the window marks the device suspected and produces an `Alert` record. The counter resets on fire to avoid alert spam.
  - Alerts are enriched with device identity (**IP + MAC + hostname**) via a `DeviceResolver`. `InventoryResolver` adapts the passive LAN inventory from #57 (keyed by client IP). Unknown devices → **IP-only** alert.
  - Status accessor `Suspected()` / `IsSuspected()`; optional webhook export (`DEVICE_ALERT_WEBHOOK`) reusing a simple JSON POST sink.
  - Time is injected via a `Clock`; the resolver is an interface — the whole path is deterministic.
- `internal/inventory`: added `Lookup(ip) (Device, bool)` so a client IP can be resolved to its device.
- `internal/dnsengine`: the engine feeds both block paths (blocklist hit + policy `DENY`) into the alerter, keyed by the client IP (port stripped). `Alerts()` exposes the current suspected set. **Off by default** (threshold 0).
- Wired into `cmd/dataplane`: constructs the inventory-backed resolver and optional webhook sink; both the inventory (`INVENTORY_ENABLED`) and alerting (`DEVICE_ALERT_THRESHOLD`) stay disabled unless configured.

### Config

| Env | Default | Meaning |
| --- | --- | --- |
| `DEVICE_ALERT_THRESHOLD` | `0` (off) | blocked hits within the window before a device is flagged |
| `DEVICE_ALERT_WINDOW` | `10m` | sliding window over which hits are counted |
| `DEVICE_ALERT_WEBHOOK` | _(unset)_ | optional URL to POST alerts as JSON |

## Tests

Deterministic (injected clock + fake inventory), all green:
- threshold crossing on repeated blocked hits from one client → **alert with device info**
- below threshold → **no alert**
- unknown device → **IP-only** alert (empty inventory and nil resolver)
- disabled (threshold ≤ 0) → **off**, never fires
- sliding-window expiry, per-client independence, counter reset after fire
- `ConfigFromEnv` (default off / invalid values ignored), webhook sink via `httptest`
- engine-level integration: repeated blocklist hits through `ProcessDNSQuery` produce one enriched alert; disabled by default produces none
- `inventory.Lookup` hit/miss

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` (including `-race`) all pass.

---

**Stacks on #57** (`feat/device-inventory`) — base is that branch; **merge after #57**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
