### PR TITLE
feat: category & app-collection filtering catalog (I-013/I-064/I-102/I-154/I-052)

### DIFF
--- a/cmd/controlplane/handlers/categories.go
+++ b/cmd/controlplane/handlers/categories.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/blocklist"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+// categoryFetchBudget bounds how long enabling a category may spend fetching and
+// aggregating its feeds before the request gives up.
+const categoryFetchBudget = 90 * time.Second
+
+// Category is the API representation of a curated filtering category.
+type Category struct {
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	Type         string `json:"type"` // "security" | "content"
+	Enabled      bool   `json:"enabled"`
+	FeedsCount   int    `json:"feeds_count"`
+	DomainsCount int64  `json:"domains_count"`
+}
+
+type CategoryListData struct {
+	TotalCategories   int        `json:"total_categories"`
+	EnabledCategories int        `json:"enabled_categories"`
+	List              []Category `json:"list"`
+}
+
+type ResponseCategoryList struct {
+	Status string           `json:"status"`
+	Data   CategoryListData `json:"data"`
+	Error  *string          `json:"error"`
+}
+
+type ResponseCategorySingle struct {
+	Status string   `json:"status"`
+	Data   Category `json:"data"`
+	Error  *string  `json:"error"`
+}
+
+// ToggleCategoryRequest enables or disables a category.
+type ToggleCategoryRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+// enabledState returns the persisted Enabled flag for a category name, defaulting to
+// false when no row has been created yet (categories are off until enabled).
+func (h *APIHandler) categoryEnabled(name string) bool {
+	if cat, err := h.Store.Categories.GetByName(name); err == nil {
+		return cat.Enabled
+	}
+	return false
+}
+
+// ListCategories handles GET /categories. It reports the full catalog (the source of
+// truth for which categories exist and their feeds) merged with the persisted
+// enable/disable state and the live domain count of each enabled category.
+func (h *APIHandler) ListCategories(c *gin.Context) {
+	defs := h.catalog().Categories
+	counts, err := h.Store.Blocklist.CountEntriesGroupedBySource()
+	if err != nil {
+		counts = map[string]int64{}
+	}
+
+	list := make([]Category, 0, len(defs))
+	enabledCount := 0
+	for _, def := range defs {
+		enabled := h.categoryEnabled(def.Name)
+		if enabled {
+			enabledCount++
+		}
+		list = append(list, Category{
+			Name:         def.Name,
+			Description:  def.Description,
+			Type:         def.Type,
+			Enabled:      enabled,
+			FeedsCount:   len(def.Feeds),
+			DomainsCount: counts[blocklist.CategorySourceID(def.Name)],
+		})
+	}
+
+	c.JSON(http.StatusOK, ResponseCategoryList{
+		Status: "success",
+		Data: CategoryListData{
+			TotalCategories:   len(list),
+			EnabledCategories: enabledCount,
+			List:              list,
+		},
+	})
+}
+
+// GetCategory handles GET /categories/:name.
+func (h *APIHandler) GetCategory(c *gin.Context) {
+	def, ok := h.catalog().Category(c.Param("name"))
+	if !ok {
+		errMsg := "unknown category"
+		c.JSON(http.StatusNotFound, ResponseCategorySingle{Status: "error", Error: &errMsg})
+		return
+	}
+	count, _ := h.Store.Blocklist.CountEntriesBySource(blocklist.CategorySourceID(def.Name))
+	c.JSON(http.StatusOK, ResponseCategorySingle{
+		Status: "success",
+		Data: Category{
+			Name:         def.Name,
+			Description:  def.Description,
+			Type:         def.Type,
+			Enabled:      h.categoryEnabled(def.Name),
+			FeedsCount:   len(def.Feeds),
+			DomainsCount: count,
+		},
+	})
+}
+
+// ToggleCategory handles PATCH /categories/:name. Enabling aggregates the category's
+// curated feeds through the real blocklist engine (dedup across feeds) and stores the
+// result under a namespaced aggregate source; disabling drops those entries so the
+// dataplane stops blocking them. The toggle state is persisted either way.
+func (h *APIHandler) ToggleCategory(c *gin.Context) {
+	name := c.Param("name")
+	def, ok := h.catalog().Category(name)
+	if !ok {
+		errMsg := "unknown category"
+		c.JSON(http.StatusNotFound, ResponseCategorySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	var req ToggleCategoryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errMsg := err.Error()
+		c.JSON(http.StatusBadRequest, ResponseCategorySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	// Seed the row from the catalog so SetEnabled has something to update.
+	row := &models.Category{Name: def.Name, Description: def.Description, Type: def.Type}
+	if err := h.Store.Categories.EnsureExists(row); err != nil {
+		errMsg := "failed to persist category"
+		c.JSON(http.StatusInternalServerError, ResponseCategorySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	sourceID := blocklist.CategorySourceID(def.Name)
+	// Always clear existing aggregated entries first: on enable we rebuild them, on
+	// disable they must go away.
+	if err := h.Store.Blocklist.DeleteEntriesBySource(sourceID); err != nil {
+		log.Printf("failed to clear entries for category %s: %v", name, err)
+	}
+
+	var count int64
+	if req.Enabled {
+		ctx, cancel := context.WithTimeout(context.Background(), categoryFetchBudget)
+		defer cancel()
+		engine := blocklist.NewEngine(h.Store.Blocklist)
+		n, err := engine.AggregateFeeds(ctx, sourceID, "Category: "+def.Name, def.Name, def.Feeds)
+		if err != nil {
+			errMsg := "failed to aggregate category feeds: " + err.Error()
+			c.JSON(http.StatusBadGateway, ResponseCategorySingle{Status: "error", Error: &errMsg})
+			return
+		}
+		count = int64(n)
+	}
+
+	if err := h.Store.Categories.SetEnabled(def.Name, req.Enabled); err != nil {
+		errMsg := "failed to update category state"
+		c.JSON(http.StatusInternalServerError, ResponseCategorySingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	c.JSON(http.StatusOK, ResponseCategorySingle{
+		Status: "success",
+		Data: Category{
+			Name:         def.Name,
+			Description:  def.Description,
+			Type:         def.Type,
+			Enabled:      req.Enabled,
+			FeedsCount:   len(def.Feeds),
+			DomainsCount: count,
+		},
+	})
+}

--- a/cmd/controlplane/handlers/categories_test.go
+++ b/cmd/controlplane/handlers/categories_test.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/lopster568/phantomDNS/internal/blocklist"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"gorm.io/gorm"
+	glog "gorm.io/gorm/logger"
+)
+
+// newCatalogTestHandler builds an APIHandler backed by an in-memory DB with the
+// category/collection tables migrated. The returned feed servers must be closed by the
+// caller.
+func newCatalogTestHandler(t *testing.T) *APIHandler {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: glog.Default.LogMode(glog.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(
+		&models.BlocklistSource{},
+		&models.BlocklistSnapshot{},
+		&models.BlocklistEntry{},
+		&models.Category{},
+		&models.Collection{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewAPIHandler(*repositories.NewStore(db), nil, nil, nil)
+}
+
+func newCatalogRouter(h *APIHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	cat := r.Group("/api/v1/categories")
+	cat.GET("", h.ListCategories)
+	cat.GET("/:name", h.GetCategory)
+	cat.PATCH("/:name", h.ToggleCategory)
+	col := r.Group("/api/v1/collections")
+	col.GET("", h.ListCollections)
+	col.PATCH("/:name", h.ToggleCollection)
+	return r
+}
+
+func decodeCategory(t *testing.T, w *httptest.ResponseRecorder) ResponseCategorySingle {
+	t.Helper()
+	var resp ResponseCategorySingle
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode category: %v (body=%s)", err, w.Body.String())
+	}
+	return resp
+}
+
+// installTwoFeedCategory replaces the handler's catalog with a single "testcat" category
+// backed by two httptest feeds that overlap on one domain, so dedup can be asserted.
+// Returns a close func for the servers.
+func installTwoFeedCategory(t *testing.T, h *APIHandler) func() {
+	t.Helper()
+	feedA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("0.0.0.0 a.example.com\n0.0.0.0 shared.example.com\n"))
+	}))
+	feedB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("0.0.0.0 shared.example.com\n0.0.0.0 b.example.com\n"))
+	}))
+	h.Catalog = &blocklist.Catalog{
+		Categories: []blocklist.CategoryDef{
+			{
+				Name:        "testcat",
+				Description: "test category",
+				Type:        blocklist.CategoryTypeSecurity,
+				Feeds: []blocklist.Feed{
+					{Name: "A", URL: feedA.URL, Format: "hosts"},
+					{Name: "B", URL: feedB.URL, Format: "hosts"},
+				},
+			},
+		},
+		Collections: h.Catalog.Collections,
+	}
+	return func() {
+		feedA.Close()
+		feedB.Close()
+	}
+}
+
+func TestListCategories_DefaultsOff(t *testing.T) {
+	h := newCatalogTestHandler(t)
+	// Use the built-in default catalog.
+	r := newCatalogRouter(h)
+
+	w := doRawJSON(t, r, http.MethodGet, "/api/v1/categories", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp ResponseCategoryList
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "success" {
+		t.Errorf("expected success, got %q", resp.Status)
+	}
+	if len(resp.Data.List) == 0 {
+		t.Fatal("expected built-in categories in list")
+	}
+	if resp.Data.EnabledCategories != 0 {
+		t.Errorf("expected 0 enabled categories by default, got %d", resp.Data.EnabledCategories)
+	}
+	for _, cat := range resp.Data.List {
+		if cat.Enabled {
+			t.Errorf("category %q should be off by default", cat.Name)
+		}
+	}
+}
+
+func TestToggleCategory_EnablePullsFeedsAndDedups(t *testing.T) {
+	h := newCatalogTestHandler(t)
+	closeFeeds := installTwoFeedCategory(t, h)
+	defer closeFeeds()
+	r := newCatalogRouter(h)
+
+	w := doRawJSON(t, r, http.MethodPatch, "/api/v1/categories/testcat", `{"enabled":true}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("enable expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	resp := decodeCategory(t, w)
+	if !resp.Data.Enabled {
+		t.Error("expected category enabled")
+	}
+	// Two feeds overlapping on one domain → 3 unique domains.
+	if resp.Data.DomainsCount != 3 {
+		t.Errorf("expected 3 deduped domains, got %d", resp.Data.DomainsCount)
+	}
+	if resp.Data.FeedsCount != 2 {
+		t.Errorf("expected 2 feeds, got %d", resp.Data.FeedsCount)
+	}
+
+	// The dataplane checker must now block the aggregated domains.
+	for _, d := range []string{"a.example.com", "shared.example.com", "b.example.com"} {
+		if blocked, _ := h.Store.Blocklist.IsBlocked(d); !blocked {
+			t.Errorf("expected %s blocked after enabling category", d)
+		}
+	}
+}
+
+func TestToggleCategory_TogglePersists(t *testing.T) {
+	h := newCatalogTestHandler(t)
+	closeFeeds := installTwoFeedCategory(t, h)
+	defer closeFeeds()
+	r := newCatalogRouter(h)
+
+	// Enable.
+	if w := doRawJSON(t, r, http.MethodPatch, "/api/v1/categories/testcat", `{"enabled":true}`); w.Code != http.StatusOK {
+		t.Fatalf("enable expected 200, got %d", w.Code)
+	}
+
+	// Persistence: a fresh GET reflects enabled + domain count.
+	got := decodeCategory(t, doRawJSON(t, r, http.MethodGet, "/api/v1/categories/testcat", ""))
+	if !got.Data.Enabled {
+		t.Error("expected enabled=true to persist")
+	}
+	if got.Data.DomainsCount != 3 {
+		t.Errorf("expected persisted count 3, got %d", got.Data.DomainsCount)
+	}
+
+	// Disable: entries dropped, state persists.
+	w := doRawJSON(t, r, http.MethodPatch, "/api/v1/categories/testcat", `{"enabled":false}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("disable expected 200, got %d", w.Code)
+	}
+	resp := decodeCategory(t, w)
+	if resp.Data.Enabled {
+		t.Error("expected enabled=false after disable")
+	}
+	if resp.Data.DomainsCount != 0 {
+		t.Errorf("expected 0 domains after disable, got %d", resp.Data.DomainsCount)
+	}
+	if blocked, _ := h.Store.Blocklist.IsBlocked("a.example.com"); blocked {
+		t.Error("expected a.example.com NOT blocked after disable")
+	}
+	got = decodeCategory(t, doRawJSON(t, r, http.MethodGet, "/api/v1/categories/testcat", ""))
+	if got.Data.Enabled {
+		t.Error("expected disabled state to persist")
+	}
+}
+
+func TestToggleCategory_UnknownName(t *testing.T) {
+	h := newCatalogTestHandler(t)
+	r := newCatalogRouter(h)
+
+	w := doRawJSON(t, r, http.MethodPatch, "/api/v1/categories/does-not-exist", `{"enabled":true}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown category, got %d", w.Code)
+	}
+}

--- a/cmd/controlplane/handlers/collections.go
+++ b/cmd/controlplane/handlers/collections.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/blocklist"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+// Collection is the API representation of an app/service domain bundle (I-052).
+type Collection struct {
+	Name         string `json:"name"`
+	App          string `json:"app"`
+	Description  string `json:"description"`
+	Enabled      bool   `json:"enabled"`
+	DomainsCount int64  `json:"domains_count"`
+}
+
+type CollectionListData struct {
+	TotalCollections   int          `json:"total_collections"`
+	EnabledCollections int          `json:"enabled_collections"`
+	List               []Collection `json:"list"`
+}
+
+type ResponseCollectionList struct {
+	Status string             `json:"status"`
+	Data   CollectionListData `json:"data"`
+	Error  *string            `json:"error"`
+}
+
+type ResponseCollectionSingle struct {
+	Status string     `json:"status"`
+	Data   Collection `json:"data"`
+	Error  *string    `json:"error"`
+}
+
+// ToggleCollectionRequest enables or disables an app/service collection.
+type ToggleCollectionRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (h *APIHandler) collectionEnabled(name string) bool {
+	if col, err := h.Store.Collections.GetByName(name); err == nil {
+		return col.Enabled
+	}
+	return false
+}
+
+// ListCollections handles GET /collections.
+func (h *APIHandler) ListCollections(c *gin.Context) {
+	defs := h.catalog().Collections
+	counts, err := h.Store.Blocklist.CountEntriesGroupedBySource()
+	if err != nil {
+		counts = map[string]int64{}
+	}
+
+	list := make([]Collection, 0, len(defs))
+	enabledCount := 0
+	for _, def := range defs {
+		enabled := h.collectionEnabled(def.Name)
+		if enabled {
+			enabledCount++
+		}
+		list = append(list, Collection{
+			Name:         def.Name,
+			App:          def.App,
+			Description:  def.Description,
+			Enabled:      enabled,
+			DomainsCount: counts[blocklist.CollectionSourceID(def.Name)],
+		})
+	}
+
+	c.JSON(http.StatusOK, ResponseCollectionList{
+		Status: "success",
+		Data: CollectionListData{
+			TotalCollections:   len(list),
+			EnabledCollections: enabledCount,
+			List:               list,
+		},
+	})
+}
+
+// ToggleCollection handles PATCH /collections/:name. Enabling stores the collection's
+// curated (deduped) domain bundle under a namespaced aggregate source so the dataplane
+// blocks the whole app as one toggle; disabling drops those entries. The toggle state is
+// persisted either way.
+func (h *APIHandler) ToggleCollection(c *gin.Context) {
+	name := c.Param("name")
+	def, ok := h.catalog().Collection(name)
+	if !ok {
+		errMsg := "unknown collection"
+		c.JSON(http.StatusNotFound, ResponseCollectionSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	var req ToggleCollectionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errMsg := err.Error()
+		c.JSON(http.StatusBadRequest, ResponseCollectionSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	row := &models.Collection{Name: def.Name, App: def.App, Description: def.Description}
+	if err := h.Store.Collections.EnsureExists(row); err != nil {
+		errMsg := "failed to persist collection"
+		c.JSON(http.StatusInternalServerError, ResponseCollectionSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	sourceID := blocklist.CollectionSourceID(def.Name)
+	if err := h.Store.Blocklist.DeleteEntriesBySource(sourceID); err != nil {
+		log.Printf("failed to clear entries for collection %s: %v", name, err)
+	}
+
+	var count int64
+	if req.Enabled {
+		engine := blocklist.NewEngine(h.Store.Blocklist)
+		n, err := engine.StoreDomains(sourceID, "Collection: "+def.App, def.Name, def.Domains)
+		if err != nil {
+			errMsg := "failed to store collection bundle"
+			c.JSON(http.StatusInternalServerError, ResponseCollectionSingle{Status: "error", Error: &errMsg})
+			return
+		}
+		count = int64(n)
+	}
+
+	if err := h.Store.Collections.SetEnabled(def.Name, req.Enabled); err != nil {
+		errMsg := "failed to update collection state"
+		c.JSON(http.StatusInternalServerError, ResponseCollectionSingle{Status: "error", Error: &errMsg})
+		return
+	}
+
+	c.JSON(http.StatusOK, ResponseCollectionSingle{
+		Status: "success",
+		Data: Collection{
+			Name:         def.Name,
+			App:          def.App,
+			Description:  def.Description,
+			Enabled:      req.Enabled,
+			DomainsCount: count,
+		},
+	})
+}

--- a/cmd/controlplane/handlers/collections_test.go
+++ b/cmd/controlplane/handlers/collections_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func decodeCollection(t *testing.T, w *httptest.ResponseRecorder) ResponseCollectionSingle {
+	t.Helper()
+	var resp ResponseCollectionSingle
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode collection: %v (body=%s)", err, w.Body.String())
+	}
+	return resp
+}
+
+func TestListCollections_DefaultsOff(t *testing.T) {
+	h := newCatalogTestHandler(t) // built-in catalog has app collections
+	r := newCatalogRouter(h)
+
+	w := doRawJSON(t, r, http.MethodGet, "/api/v1/collections", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp ResponseCollectionList
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Data.List) == 0 {
+		t.Fatal("expected built-in collections")
+	}
+	if resp.Data.EnabledCollections != 0 {
+		t.Errorf("expected 0 enabled collections by default, got %d", resp.Data.EnabledCollections)
+	}
+}
+
+// TestToggleCollection_BlocksBundle enables the TikTok collection and verifies its whole
+// curated domain bundle is blocked as one toggle (I-052).
+func TestToggleCollection_BlocksBundle(t *testing.T) {
+	h := newCatalogTestHandler(t)
+	r := newCatalogRouter(h)
+
+	w := doRawJSON(t, r, http.MethodPatch, "/api/v1/collections/tiktok", `{"enabled":true}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("enable expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	resp := decodeCollection(t, w)
+	if !resp.Data.Enabled {
+		t.Error("expected collection enabled")
+	}
+	if resp.Data.DomainsCount == 0 {
+		t.Error("expected the TikTok bundle to contribute domains")
+	}
+
+	// The whole bundle blocks under one toggle.
+	for _, d := range []string{"tiktok.com", "tiktokcdn.com"} {
+		if blocked, _ := h.Store.Blocklist.IsBlocked(d); !blocked {
+			t.Errorf("expected %s blocked after enabling TikTok collection", d)
+		}
+	}
+	// A subdomain of a bundled domain is caught by the parent-walk matcher.
+	if blocked, _ := h.Store.Blocklist.IsBlocked("www.tiktok.com"); !blocked {
+		t.Error("expected subdomain www.tiktok.com blocked")
+	}
+}
+
+func TestToggleCollection_TogglePersistsAndDisables(t *testing.T) {
+	h := newCatalogTestHandler(t)
+	r := newCatalogRouter(h)
+
+	// Enable then disable.
+	if w := doRawJSON(t, r, http.MethodPatch, "/api/v1/collections/instagram", `{"enabled":true}`); w.Code != http.StatusOK {
+		t.Fatalf("enable expected 200, got %d", w.Code)
+	}
+	if blocked, _ := h.Store.Blocklist.IsBlocked("instagram.com"); !blocked {
+		t.Fatal("expected instagram.com blocked after enable")
+	}
+
+	w := doRawJSON(t, r, http.MethodPatch, "/api/v1/collections/instagram", `{"enabled":false}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("disable expected 200, got %d", w.Code)
+	}
+	resp := decodeCollection(t, w)
+	if resp.Data.Enabled || resp.Data.DomainsCount != 0 {
+		t.Errorf("expected disabled with 0 domains, got enabled=%v count=%d", resp.Data.Enabled, resp.Data.DomainsCount)
+	}
+	if blocked, _ := h.Store.Blocklist.IsBlocked("instagram.com"); blocked {
+		t.Error("expected instagram.com NOT blocked after disable")
+	}
+
+	// Persisted state reflects in the list.
+	lw := doRawJSON(t, r, http.MethodGet, "/api/v1/collections", "")
+	var list ResponseCollectionList
+	if err := json.Unmarshal(lw.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if list.Data.EnabledCollections != 0 {
+		t.Errorf("expected 0 enabled after disable, got %d", list.Data.EnabledCollections)
+	}
+}
+
+func TestToggleCollection_UnknownName(t *testing.T) {
+	h := newCatalogTestHandler(t)
+	r := newCatalogRouter(h)
+
+	w := doRawJSON(t, r, http.MethodPatch, "/api/v1/collections/nope", `{"enabled":true}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown collection, got %d", w.Code)
+	}
+}

--- a/cmd/controlplane/handlers/handlers.go
+++ b/cmd/controlplane/handlers/handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/lopster568/phantomDNS/internal/blocklist"
 	client "github.com/lopster568/phantomDNS/internal/grpc/controlplane"
 	"github.com/lopster568/phantomDNS/internal/inventory"
 	"github.com/lopster568/phantomDNS/internal/policy"
@@ -20,6 +21,10 @@ type APIHandler struct {
 	// nil, storage remains the source of truth and the dataplane picks up
 	// changes on its next reload.
 	PolicyEngine *policy.Engine
+	// Catalog is the curated category/collection catalog backing the filtering
+	// endpoints. It defaults to blocklist.DefaultCatalog() and is a field so tests can
+	// substitute feeds pointing at local servers.
+	Catalog *blocklist.Catalog
 }
 
 func NewAPIHandler(
@@ -33,5 +38,15 @@ func NewAPIHandler(
 		DataPlaneClient: dataPlaneClient,
 		Inventory:       deviceInventory,
 		PolicyEngine:    policyEngine,
+		Catalog:         blocklist.DefaultCatalog(),
 	}
+}
+
+// catalog returns the handler's catalog, falling back to the built-in default when the
+// field was left unset (e.g. an APIHandler constructed literally in a test).
+func (h *APIHandler) catalog() *blocklist.Catalog {
+	if h.Catalog == nil {
+		h.Catalog = blocklist.DefaultCatalog()
+	}
+	return h.Catalog
 }

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -59,6 +59,23 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 			blocklists.DELETE("/:id", apiHandler.DeleteBlocklist)
 		}
 
+		// Category endpoints — curated feed catalog toggles (I-013/I-064/I-102/I-154)
+		categories := api.Group("/categories")
+		{
+			categories.GET("", apiHandler.ListCategories)
+			categories.GET("/:name", apiHandler.GetCategory)
+			categories.PATCH("/:name", apiHandler.ToggleCategory)
+			categories.PUT("/:name", apiHandler.ToggleCategory)
+		}
+
+		// Collection endpoints — per-app domain bundles (I-052)
+		collections := api.Group("/collections")
+		{
+			collections.GET("", apiHandler.ListCollections)
+			collections.PATCH("/:name", apiHandler.ToggleCollection)
+			collections.PUT("/:name", apiHandler.ToggleCollection)
+		}
+
 		// Analytics endpoints
 		analytics := api.Group("/analytics")
 		{

--- a/internal/blocklist/aggregate.go
+++ b/internal/blocklist/aggregate.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package blocklist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/blocklist/parser"
+	"github.com/lopster568/phantomDNS/internal/logger"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+// aggregateFormat marks a blocklist source whose entries were produced by aggregating a
+// category's feeds or a collection's bundle, rather than by fetching a single raw list.
+const aggregateFormat = "aggregate"
+
+// AggregateFeeds fetches every feed for a category, parses each through the registered
+// parser for its format, dedups the resulting domains across all feeds, and stores them
+// under a single aggregated blocklist source (sourceID). It reuses the same
+// fetch/parse/store engine that individual blocklist sources use.
+//
+// Individual feed failures are tolerated: a single unreachable feed is logged and
+// skipped so one dead mirror does not disable a whole category. An error is returned
+// only when nothing could be aggregated (every feed failed).
+func (e *Engine) AggregateFeeds(ctx context.Context, sourceID, sourceName, category string, feeds []Feed) (int, error) {
+	seen := make(map[string]struct{})
+	var entries []models.BlocklistEntry
+	now := time.Now()
+
+	var lastErr error
+	fetched := 0
+	for _, f := range feeds {
+		body, _, err := e.fetcher.Fetch(ctx, feedConfig(f), "")
+		if err != nil {
+			logger.Log.Warnf("category %s: feed %q fetch failed: %v", category, f.Name, err)
+			lastErr = err
+			continue
+		}
+		if body == nil { // 304 Not Modified — nothing to add.
+			fetched++
+			continue
+		}
+		p, ok := parser.Get(f.Format)
+		if !ok {
+			lastErr = fmt.Errorf("no parser for format %q (feed %q)", f.Format, f.Name)
+			logger.Log.Warnf("category %s: %v", category, lastErr)
+			continue
+		}
+		parsed, err := p.Parse(body)
+		if err != nil {
+			logger.Log.Warnf("category %s: feed %q parse failed: %v", category, f.Name, err)
+			lastErr = err
+			continue
+		}
+		fetched++
+		for _, pe := range parsed {
+			d := normalizeDomain(pe.Domain)
+			if d == "" {
+				continue
+			}
+			if _, dup := seen[d]; dup {
+				continue
+			}
+			seen[d] = struct{}{}
+			entries = append(entries, models.BlocklistEntry{
+				Domain:    d,
+				SourceID:  sourceID,
+				Category:  category,
+				CreatedAt: now,
+			})
+		}
+	}
+
+	if fetched == 0 && lastErr != nil {
+		return 0, fmt.Errorf("category %s: all feeds failed: %w", category, lastErr)
+	}
+
+	if err := e.storeAggregate(sourceID, sourceName, category, entries); err != nil {
+		return 0, err
+	}
+	logger.Log.Infof("aggregated category=%s feeds=%d domains=%d", category, len(feeds), len(entries))
+	return len(entries), nil
+}
+
+// StoreDomains stores a curated, inline domain bundle (an app/service collection, I-052)
+// under an aggregated blocklist source. Domains are deduped and normalized. No network
+// fetch happens — the bundle is defined in the catalog.
+func (e *Engine) StoreDomains(sourceID, sourceName, category string, domains []string) (int, error) {
+	seen := make(map[string]struct{})
+	var entries []models.BlocklistEntry
+	now := time.Now()
+	for _, raw := range domains {
+		d := normalizeDomain(raw)
+		if d == "" {
+			continue
+		}
+		if _, dup := seen[d]; dup {
+			continue
+		}
+		seen[d] = struct{}{}
+		entries = append(entries, models.BlocklistEntry{
+			Domain:    d,
+			SourceID:  sourceID,
+			Category:  category,
+			CreatedAt: now,
+		})
+	}
+	if err := e.storeAggregate(sourceID, sourceName, category, entries); err != nil {
+		return 0, err
+	}
+	return len(entries), nil
+}
+
+// storeAggregate persists the aggregated entries under an (upserted) aggregate source
+// row via the existing snapshot/entries writer, so the dataplane's live blocklist view
+// picks the domains up immediately.
+func (e *Engine) storeAggregate(sourceID, sourceName, category string, entries []models.BlocklistEntry) error {
+	src := models.BlocklistSource{
+		ID:        sourceID,
+		Name:      sourceName,
+		Category:  category,
+		Format:    aggregateFormat,
+		Enabled:   true,
+		CreatedAt: time.Now(),
+	}
+	if _, err := e.repo.SaveSnapshotWithEntries(src, hash([]byte(sourceID+category)), entries); err != nil {
+		return fmt.Errorf("store aggregate %s failed: %w", sourceID, err)
+	}
+	return nil
+}
+
+// normalizeDomain lowercases, trims whitespace and a trailing dot, and rejects tokens
+// that are clearly not bare domains.
+func normalizeDomain(d string) string {
+	d = strings.ToLower(strings.TrimSpace(d))
+	d = strings.TrimSuffix(d, ".")
+	if d == "" || strings.ContainsAny(d, "/\\ ") {
+		return ""
+	}
+	return d
+}
+
+// feedConfig adapts a catalog Feed to the fetcher/parser SourceConfig shape.
+func feedConfig(f Feed) parser.SourceConfig {
+	return parser.SourceConfig{
+		Name:   f.Name,
+		URL:    f.URL,
+		Format: f.Format,
+	}
+}

--- a/internal/blocklist/aggregate_test.go
+++ b/internal/blocklist/aggregate_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package blocklist
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"gorm.io/gorm"
+	glog "gorm.io/gorm/logger"
+)
+
+func newAggRepo(t *testing.T) *repositories.BlocklistRepo {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: glog.Default.LogMode(glog.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(
+		&models.BlocklistSource{},
+		&models.BlocklistSnapshot{},
+		&models.BlocklistEntry{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return repositories.NewBlocklistRepo(db)
+}
+
+func hostsServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// TestAggregateFeeds_DedupAcrossFeeds verifies that enabling a category with two feeds
+// that share a domain stores the union once — the domain overlapping both feeds is not
+// double-stored.
+func TestAggregateFeeds_DedupAcrossFeeds(t *testing.T) {
+	repo := newAggRepo(t)
+	engine := NewEngine(repo)
+
+	// feedA: a, shared   feedB: shared, b  → union {a, shared, b} = 3 unique.
+	feedA := hostsServer(t, "0.0.0.0 a.example.com\n0.0.0.0 shared.example.com\n")
+	defer feedA.Close()
+	feedB := hostsServer(t, "0.0.0.0 shared.example.com\n0.0.0.0 b.example.com\n")
+	defer feedB.Close()
+
+	feeds := []Feed{
+		{Name: "A", URL: feedA.URL, Format: "hosts"},
+		{Name: "B", URL: feedB.URL, Format: "hosts"},
+	}
+
+	srcID := CategorySourceID("malware")
+	n, err := engine.AggregateFeeds(context.Background(), srcID, "Category: malware", "malware", feeds)
+	if err != nil {
+		t.Fatalf("AggregateFeeds: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected 3 deduped domains, got %d", n)
+	}
+
+	// The DB must hold exactly 3 entries for the aggregate source (dedup persisted).
+	count, err := repo.CountEntriesBySource(srcID)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 persisted entries, got %d", count)
+	}
+
+	for _, d := range []string{"a.example.com", "shared.example.com", "b.example.com"} {
+		if blocked, _ := repo.IsBlocked(d); !blocked {
+			t.Errorf("expected %s blocked after aggregation", d)
+		}
+	}
+}
+
+// TestAggregateFeeds_ToleratesFailedFeed verifies one failing feed (here, an
+// unregistered format) does not fail the whole category as long as another feed
+// succeeds.
+func TestAggregateFeeds_ToleratesFailedFeed(t *testing.T) {
+	repo := newAggRepo(t)
+	engine := NewEngine(repo)
+
+	bad := hostsServer(t, "0.0.0.0 ignored.example.com\n")
+	defer bad.Close()
+	good := hostsServer(t, "0.0.0.0 good.example.com\n")
+	defer good.Close()
+
+	feeds := []Feed{
+		{Name: "Bad", URL: bad.URL, Format: "no-such-format"}, // parser lookup fails
+		{Name: "Good", URL: good.URL, Format: "hosts"},
+	}
+
+	n, err := engine.AggregateFeeds(context.Background(), CategorySourceID("phishing"), "Category: phishing", "phishing", feeds)
+	if err != nil {
+		t.Fatalf("expected success despite one failed feed, got: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 domain from the good feed, got %d", n)
+	}
+	if blocked, _ := repo.IsBlocked("good.example.com"); !blocked {
+		t.Error("expected good.example.com blocked")
+	}
+}
+
+// TestStoreDomains_DedupsBundle verifies a collection bundle is deduped and normalized.
+func TestStoreDomains_DedupsBundle(t *testing.T) {
+	repo := newAggRepo(t)
+	engine := NewEngine(repo)
+
+	srcID := CollectionSourceID("tiktok")
+	// "TikTok.com" and "tiktok.com." collapse to one; blank is dropped.
+	n, err := engine.StoreDomains(srcID, "Collection: TikTok", "tiktok",
+		[]string{"tiktok.com", "TikTok.com", "tiktok.com.", "tiktokcdn.com", "  "})
+	if err != nil {
+		t.Fatalf("StoreDomains: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 unique domains, got %d", n)
+	}
+	if blocked, _ := repo.IsBlocked("tiktok.com"); !blocked {
+		t.Error("expected tiktok.com blocked")
+	}
+}

--- a/internal/blocklist/catalog.go
+++ b/internal/blocklist/catalog.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package blocklist
+
+import "strings"
+
+// Category types, used only for grouping/display in the UI.
+const (
+	CategoryTypeSecurity = "security"
+	CategoryTypeContent  = "content"
+)
+
+// Feed is a single curated community source that belongs to a category. When a
+// category is enabled, every one of its feeds is fetched/parsed through the existing
+// blocklist engine and the resulting domains are deduped across feeds.
+type Feed struct {
+	Name   string
+	URL    string
+	Format string // "hosts" or "domains" — must match a registered parser
+}
+
+// CategoryDef is a named toggle that aggregates one or more curated feeds. Categories
+// are additive and default to OFF: nothing is fetched until the category is enabled.
+type CategoryDef struct {
+	Name        string
+	Description string
+	Type        string // CategoryTypeSecurity | CategoryTypeContent
+	Feeds       []Feed
+}
+
+// CollectionDef (I-052) is an app/service bundle: a small, curated set of domains that
+// can be blocked as one toggle (e.g. block "TikTok" or "Instagram"). It is modeled the
+// same way as a category — a named toggle backed by an aggregated blocklist source — but
+// its domains are curated inline rather than fetched from a remote feed.
+type CollectionDef struct {
+	Name        string
+	App         string
+	Description string
+	Domains     []string
+}
+
+// Catalog holds the built-in categories and collections. It is a value (not global
+// mutable state) so tests can substitute feeds pointing at local httptest servers.
+type Catalog struct {
+	Categories  []CategoryDef
+	Collections []CollectionDef
+}
+
+// Category looks up a category definition by name (case-insensitive).
+func (c *Catalog) Category(name string) (CategoryDef, bool) {
+	for _, def := range c.Categories {
+		if strings.EqualFold(def.Name, name) {
+			return def, true
+		}
+	}
+	return CategoryDef{}, false
+}
+
+// Collection looks up a collection definition by name (case-insensitive).
+func (c *Catalog) Collection(name string) (CollectionDef, bool) {
+	for _, def := range c.Collections {
+		if strings.EqualFold(def.Name, name) {
+			return def, true
+		}
+	}
+	return CollectionDef{}, false
+}
+
+// CategorySourceID is the deterministic blocklist-source ID under which a category's
+// aggregated, deduped domains are stored. Namespacing keeps them from colliding with
+// user-created blocklist sources.
+func CategorySourceID(name string) string {
+	return "category:" + strings.ToLower(name)
+}
+
+// CollectionSourceID is the deterministic blocklist-source ID for a collection bundle.
+func CollectionSourceID(name string) string {
+	return "collection:" + strings.ToLower(name)
+}
+
+// DefaultCatalog returns the built-in category and collection catalog: curated
+// community feeds (OISD, URLhaus, ThreatFox, Hagezi, abuse.ch) grouped into security
+// and content categories, plus a set of per-app collections.
+func DefaultCatalog() *Catalog {
+	return &Catalog{
+		Categories: []CategoryDef{
+			{
+				Name:        "ads",
+				Description: "Advertising networks and ad-serving domains.",
+				Type:        CategoryTypeContent,
+				Feeds: []Feed{
+					{Name: "OISD Small", URL: "https://small.oisd.nl/domainswild", Format: "domains"},
+					{Name: "Hagezi Pro", URL: "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/hosts/pro.txt", Format: "hosts"},
+				},
+			},
+			{
+				Name:        "trackers",
+				Description: "Analytics, telemetry, and cross-site tracking domains.",
+				Type:        CategoryTypeContent,
+				Feeds: []Feed{
+					{Name: "Hagezi Pro", URL: "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/hosts/pro.txt", Format: "hosts"},
+				},
+			},
+			{
+				Name:        "malware",
+				Description: "Domains distributing malware and malicious payloads.",
+				Type:        CategoryTypeSecurity,
+				Feeds: []Feed{
+					{Name: "URLhaus", URL: "https://urlhaus.abuse.ch/downloads/hostfile/", Format: "hosts"},
+					{Name: "Hagezi TIF", URL: "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/hosts/tif.txt", Format: "hosts"},
+				},
+			},
+			{
+				Name:        "phishing",
+				Description: "Phishing and credential-harvesting domains.",
+				Type:        CategoryTypeSecurity,
+				Feeds: []Feed{
+					{Name: "OISD NSFW-free Phishing", URL: "https://phishing.army/download/phishing_army_blocklist_extended.txt", Format: "domains"},
+				},
+			},
+			{
+				Name:        "c2",
+				Description: "Command-and-control (C2) and botnet infrastructure.",
+				Type:        CategoryTypeSecurity,
+				Feeds: []Feed{
+					{Name: "ThreatFox", URL: "https://threatfox.abuse.ch/downloads/hostfile/", Format: "hosts"},
+				},
+			},
+			{
+				Name:        "cryptomining",
+				Description: "In-browser cryptomining and coin-hijacking domains.",
+				Type:        CategoryTypeSecurity,
+				Feeds: []Feed{
+					{Name: "Hagezi Cryptojacking", URL: "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.crypto.txt", Format: "domains"},
+				},
+			},
+			{
+				Name:        "adult",
+				Description: "Adult and pornographic content.",
+				Type:        CategoryTypeContent,
+				Feeds: []Feed{
+					{Name: "OISD NSFW", URL: "https://nsfw.oisd.nl/domainswild", Format: "domains"},
+				},
+			},
+			{
+				Name:        "gambling",
+				Description: "Online gambling and betting domains.",
+				Type:        CategoryTypeContent,
+				Feeds: []Feed{
+					{Name: "Hagezi Gambling", URL: "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/gambling.txt", Format: "domains"},
+				},
+			},
+			{
+				Name:        "piracy",
+				Description: "Piracy, warez, and illegal streaming domains.",
+				Type:        CategoryTypeContent,
+				Feeds: []Feed{
+					{Name: "Hagezi Piracy", URL: "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/piracy.txt", Format: "domains"},
+				},
+			},
+		},
+		Collections: []CollectionDef{
+			{
+				Name:        "tiktok",
+				App:         "TikTok",
+				Description: "Block TikTok and its content/telemetry domains.",
+				Domains: []string{
+					"tiktok.com", "tiktokcdn.com", "tiktokv.com", "byteoversea.com",
+					"musical.ly", "tiktokcdn-us.com",
+				},
+			},
+			{
+				Name:        "instagram",
+				App:         "Instagram",
+				Description: "Block Instagram domains.",
+				Domains: []string{
+					"instagram.com", "cdninstagram.com", "instagr.am",
+				},
+			},
+			{
+				Name:        "facebook",
+				App:         "Facebook",
+				Description: "Block Facebook / Meta domains.",
+				Domains: []string{
+					"facebook.com", "fbcdn.net", "fb.com", "fbsbx.com", "facebook.net",
+				},
+			},
+			{
+				Name:        "youtube",
+				App:         "YouTube",
+				Description: "Block YouTube domains.",
+				Domains: []string{
+					"youtube.com", "youtu.be", "ytimg.com", "googlevideo.com",
+				},
+			},
+			{
+				Name:        "snapchat",
+				App:         "Snapchat",
+				Description: "Block Snapchat domains.",
+				Domains: []string{
+					"snapchat.com", "sc-cdn.net", "snap.com",
+				},
+			},
+		},
+	}
+}

--- a/internal/blocklist/parser/domain_parser.go
+++ b/internal/blocklist/parser/domain_parser.go
@@ -9,28 +9,34 @@ import (
 )
 
 // DomainsParser parses feeds with one domain per line. Blank lines and lines
-// beginning with '#' or ';' are ignored. Only the first whitespace-separated
+// beginning with '#', ';', or '!' are ignored. Only the first whitespace-separated
 // field of each line is used, so simple "domain <extra>" columns are tolerated.
-// A leading "*." wildcard and a trailing dot are stripped. This format suits
-// plain domain lists such as newly-registered-domain (NRD) feeds.
+// A leading "*." wildcard and a trailing dot are stripped — several curated feeds
+// (e.g. OISD's "domainswild" export) use that convention. This format suits plain
+// domain lists such as newly-registered-domain (NRD) feeds and most curated
+// community feeds (OISD, Hagezi, abuse.ch, URLhaus/ThreatFox exports) that the
+// category catalog aggregates.
 type DomainsParser struct{}
 
 func (d *DomainsParser) Format() string { return "domains" }
 
 func (d *DomainsParser) Parse(data []byte) ([]ParsedEntry, error) {
 	s := bufio.NewScanner(bytes.NewReader(data))
+	// Some domain lists have long lines; grow the buffer past the 64K default.
+	s.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var out []ParsedEntry
 	now := time.Now()
 	for s.Scan() {
 		line := strings.TrimSpace(s.Text())
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "!") {
 			continue
 		}
 		if idx := strings.IndexAny(line, " \t"); idx >= 0 {
 			line = line[:idx]
 		}
 		domain := strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(line, "*."), "."))
-		if domain == "" {
+		// Reject obviously non-domain tokens (paths, remaining whitespace, etc.).
+		if domain == "" || strings.ContainsAny(domain, "/\\ ") {
 			continue
 		}
 		out = append(out, ParsedEntry{

--- a/internal/storage/db/db.go
+++ b/internal/storage/db/db.go
@@ -49,6 +49,7 @@ func migrate(db *gorm.DB) error {
 		&models.DomainPolicy{},
 		&models.Action{},
 		&models.Category{},
+		&models.Collection{},
 		&models.Statistics{},
 		&models.SystemState{},
 		&models.BlocklistSource{},

--- a/internal/storage/models/category.model.go
+++ b/internal/storage/models/category.model.go
@@ -5,8 +5,10 @@ import "time"
 
 type Category struct {
 	ID          uint   `gorm:"primaryKey"`
-	Name        string `gorm:"uniqueIndex;not null;"` // e.g., "adult", "phishing"
-	Description string `gorm:"type:text;"`            // optional description
+	Name        string `gorm:"uniqueIndex;not null;"`   // e.g., "adult", "phishing"
+	Description string `gorm:"type:text;"`              // optional description
+	Type        string `gorm:"index;"`                  // "security" | "content"
+	Enabled     bool   `gorm:"not null;default:false;"` // additive: categories are off until enabled
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }

--- a/internal/storage/models/collection.model.go
+++ b/internal/storage/models/collection.model.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package models
+
+import "time"
+
+// Collection is an app/service domain bundle (I-052): a small curated set of domains
+// blocked as a single toggle (e.g. "TikTok", "Instagram"). It is modeled the same way
+// as a Category — a named toggle backed by an aggregated blocklist source — but its
+// domains are curated inline in the catalog rather than fetched from a remote feed.
+type Collection struct {
+	ID          uint   `gorm:"primaryKey"`
+	Name        string `gorm:"uniqueIndex;not null;"`   // stable key, e.g. "tiktok"
+	App         string `gorm:"index;"`                  // display name, e.g. "TikTok"
+	Description string `gorm:"type:text;"`              // optional description
+	Enabled     bool   `gorm:"not null;default:false;"` // additive: off until enabled
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/internal/storage/repositories/category.go
+++ b/internal/storage/repositories/category.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package repositories
+
+import (
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// CategoryRepository persists the enable/disable state and metadata of catalog
+// categories. The feed definitions themselves live in the code catalog; this repo only
+// tracks which categories a user has turned on.
+type CategoryRepository interface {
+	List() ([]models.Category, error)
+	GetByName(name string) (*models.Category, error)
+	// EnsureExists inserts the category row if it is missing (seeding from the catalog),
+	// leaving an existing row's Enabled state untouched.
+	EnsureExists(cat *models.Category) error
+	SetEnabled(name string, enabled bool) error
+}
+
+type CategoryRepo struct {
+	db *gorm.DB
+}
+
+func NewCategoryRepo(db *gorm.DB) *CategoryRepo {
+	return &CategoryRepo{db: db}
+}
+
+func (r *CategoryRepo) List() ([]models.Category, error) {
+	var cats []models.Category
+	err := r.db.Order("name asc").Find(&cats).Error
+	return cats, err
+}
+
+func (r *CategoryRepo) GetByName(name string) (*models.Category, error) {
+	var cat models.Category
+	if err := r.db.First(&cat, "name = ?", name).Error; err != nil {
+		return nil, err
+	}
+	return &cat, nil
+}
+
+// EnsureExists seeds the row on first use. FirstOrCreate matches on Name and, when the
+// row already exists, loads it into cat without overwriting the persisted Enabled flag.
+func (r *CategoryRepo) EnsureExists(cat *models.Category) error {
+	return r.db.Where(models.Category{Name: cat.Name}).
+		Attrs(models.Category{Description: cat.Description, Type: cat.Type}).
+		FirstOrCreate(cat).Error
+}
+
+func (r *CategoryRepo) SetEnabled(name string, enabled bool) error {
+	result := r.db.Model(&models.Category{}).Where("name = ?", name).Update("enabled", enabled)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/internal/storage/repositories/collection.go
+++ b/internal/storage/repositories/collection.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package repositories
+
+import (
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// CollectionRepository persists the enable/disable state of app/service collections
+// (I-052). The curated domain bundles live in the code catalog; this repo only tracks
+// which collections a user has turned on.
+type CollectionRepository interface {
+	List() ([]models.Collection, error)
+	GetByName(name string) (*models.Collection, error)
+	EnsureExists(col *models.Collection) error
+	SetEnabled(name string, enabled bool) error
+}
+
+type CollectionRepo struct {
+	db *gorm.DB
+}
+
+func NewCollectionRepo(db *gorm.DB) *CollectionRepo {
+	return &CollectionRepo{db: db}
+}
+
+func (r *CollectionRepo) List() ([]models.Collection, error) {
+	var cols []models.Collection
+	err := r.db.Order("name asc").Find(&cols).Error
+	return cols, err
+}
+
+func (r *CollectionRepo) GetByName(name string) (*models.Collection, error) {
+	var col models.Collection
+	if err := r.db.First(&col, "name = ?", name).Error; err != nil {
+		return nil, err
+	}
+	return &col, nil
+}
+
+func (r *CollectionRepo) EnsureExists(col *models.Collection) error {
+	return r.db.Where(models.Collection{Name: col.Name}).
+		Attrs(models.Collection{App: col.App, Description: col.Description}).
+		FirstOrCreate(col).Error
+}
+
+func (r *CollectionRepo) SetEnabled(name string, enabled bool) error {
+	result := r.db.Model(&models.Collection{}).Where("name = ?", name).Update("enabled", enabled)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/internal/storage/repositories/store.go
+++ b/internal/storage/repositories/store.go
@@ -11,6 +11,8 @@ type Store struct {
 	Statistics  StatisticsRepository
 	SystemState SystemStateRepository
 	Policies    PolicyRepository
+	Categories  CategoryRepository
+	Collections CollectionRepository
 	Auth        AuthRepository
 	Resolvers   ResolverRepository
 
@@ -28,6 +30,8 @@ func NewStore(db *gorm.DB) *Store {
 		Statistics:  NewGormStatisticsRepo(db),
 		SystemState: NewSystemStateRepo(db),
 		Policies:    NewPolicyRepo(db),
+		Categories:  NewCategoryRepo(db),
+		Collections: NewCollectionRepo(db),
 		Auth:        NewAuthRepo(db),
 		Resolvers:   NewResolverRepo(db),
 		DB:          db,


### PR DESCRIPTION
## What

Adds a curated **filtering catalog** layered on top of the now-real blocklist handlers from #46: security/content **categories** and per-app **collections**, each a single enable/disable toggle.

- **Categories** (I-013/I-064/I-102/I-154): named toggles mapping curated community feeds (OISD, URLhaus, ThreatFox, Hagezi, abuse.ch) into groups — security (`malware`, `phishing`, `c2`, `cryptomining`) and content (`ads`, `trackers`, `adult`, `gambling`, `piracy`). The existing `Category` model is extended (`Type`, `Enabled`); nothing is fetched until enabled.
- **Collections** (I-052): per-app domain bundles (TikTok, Instagram, Facebook, YouTube, Snapchat) modeled the same way — a toggle backed by a small curated, deduped domain set.

## Why

Users want to turn on protection by intent ("block malware", "block TikTok") instead of hand-managing raw blocklist URLs. This builds directly on the real fetch/parse/store engine and CRUD wired in #46.

## How

- **Aggregation** reuses the existing blocklist fetch/parse/store engine. Enabling a category fetches all its feeds, **dedups domains across feeds**, and stores them under one namespaced aggregate source (`category:<name>`), so the dataplane's live blocklist view blocks them immediately. Disabling drops those entries. A single failing feed is tolerated (logged and skipped) rather than failing the whole category.
- Collections use the same aggregate path with an inline curated bundle (`collection:<name>`), no network fetch.
- New endpoints: `GET/PATCH/PUT /api/v1/categories[/:name]`, `GET/PATCH/PUT /api/v1/collections[/:name]`.
- Added a `domains` parser (plain domain-per-line) so feeds in that format flow through the same engine as `hosts` lists.
- Toggle state persisted via new `CategoryRepository` / `CollectionRepository`; catalog is a value field on `APIHandler` (defaults to the built-in catalog) so tests can inject feeds.
- Additive and default-off; existing blocklist behavior is unchanged.

## Tests

- `internal/blocklist`: dedup across feeds, failed-feed tolerance, collection bundle dedup/normalization.
- `cmd/controlplane/handlers`: categories default off, enable pulls feeds + dedups, toggle persists, disable clears entries + stops blocking, collection blocks its whole bundle (incl. subdomain match), unknown-name 404s. All httptest-based.
- `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green.

> **Stacks on #46 (`feat/wire-blocklists-handlers`) — merge after it.** This PR's base is that branch, so the diff shows only the catalog work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)