### PR TITLE
feat(policy): per-client policy scoping by IP/CIDR (I-014, first cut)

### DIFF
--- a/cmd/controlplane/handlers/policies.go
+++ b/cmd/controlplane/handlers/policies.go
@@ -21,6 +21,9 @@ type Policy struct {
 	RedirectIP  string   `json:"redirect_ip,omitempty"`
 	Domains     []string `json:"domains"`
 	Regexes     []string `json:"regexes"`
+	// ClientCIDRs scopes the policy to specific clients by IP/CIDR (I-014).
+	// Empty means the policy applies to all clients.
+	ClientCIDRs []string `json:"client_cidrs"`
 	Priority    int      `json:"priority"`
 	Enabled     bool     `json:"enabled"`
 
@@ -59,6 +62,8 @@ type CreatePolicyRequest struct {
 	RedirectIP  string   `json:"redirect_ip"`
 	Domains     []string `json:"domains" binding:"required"`
 	Regexes     []string `json:"regexes"`
+	// ClientCIDRs optionally scopes the policy to specific clients (I-014).
+	ClientCIDRs []string `json:"client_cidrs"`
 	Priority    int      `json:"priority"`
 
 	// Optional schedule (I-038). Omit for an always-on policy.
@@ -80,6 +85,9 @@ type UpdatePolicyRequest struct {
 	RedirectIP  *string   `json:"redirect_ip"`
 	Domains     *[]string `json:"domains"`
 	Regexes     *[]string `json:"regexes"`
+	// ClientCIDRs edits the client scope; nil leaves it unchanged, an empty
+	// slice clears it (policy becomes unscoped) (I-014).
+	ClientCIDRs *[]string `json:"client_cidrs"`
 	Priority    *int      `json:"priority"`
 	Enabled     *bool     `json:"enabled"`
 
@@ -92,7 +100,7 @@ type UpdatePolicyRequest struct {
 }
 
 func policyFromModel(m models.Policy) Policy {
-	var domains, regexes, scheduleDays []string
+	var domains, regexes, scheduleDays, clientCIDRs []string
 	if m.Domains != "" {
 		_ = json.Unmarshal([]byte(m.Domains), &domains)
 	}
@@ -101,6 +109,9 @@ func policyFromModel(m models.Policy) Policy {
 	}
 	if m.ScheduleDays != "" {
 		_ = json.Unmarshal([]byte(m.ScheduleDays), &scheduleDays)
+	}
+	if m.ClientCIDRs != "" {
+		_ = json.Unmarshal([]byte(m.ClientCIDRs), &clientCIDRs)
 	}
 	return Policy{
 		ID:           m.ID,
@@ -111,6 +122,7 @@ func policyFromModel(m models.Policy) Policy {
 		RedirectIP:   m.RedirectIP,
 		Domains:      domains,
 		Regexes:      regexes,
+		ClientCIDRs:  clientCIDRs,
 		Priority:     m.Priority,
 		Enabled:      m.Enabled,
 		ScheduleDays: scheduleDays,
@@ -205,6 +217,7 @@ func (h *APIHandler) CreatePolicy(c *gin.Context) {
 
 	domainsJSON, _ := json.Marshal(req.Domains)
 	regexesJSON, _ := json.Marshal(req.Regexes)
+	clientCIDRsJSON, _ := json.Marshal(req.ClientCIDRs)
 
 	m := &models.Policy{
 		ID:          req.ID,
@@ -215,6 +228,7 @@ func (h *APIHandler) CreatePolicy(c *gin.Context) {
 		RedirectIP:  req.RedirectIP,
 		Domains:     string(domainsJSON),
 		Regexes:     string(regexesJSON),
+		ClientCIDRs: string(clientCIDRsJSON),
 		Priority:    req.Priority,
 		Enabled:     true,
 
@@ -289,6 +303,10 @@ func (h *APIHandler) UpdatePolicy(c *gin.Context) {
 	if req.Regexes != nil {
 		regexesJSON, _ := json.Marshal(*req.Regexes)
 		m.Regexes = string(regexesJSON)
+	}
+	if req.ClientCIDRs != nil {
+		clientCIDRsJSON, _ := json.Marshal(*req.ClientCIDRs)
+		m.ClientCIDRs = string(clientCIDRsJSON)
 	}
 	if req.Priority != nil {
 		m.Priority = *req.Priority

--- a/cmd/controlplane/handlers/policies_test.go
+++ b/cmd/controlplane/handlers/policies_test.go
@@ -101,7 +101,7 @@ func TestPolicyCRUDLifecycle(t *testing.T) {
 	}
 
 	// Engine reflects the new BLOCK rule?
-	if d, _ := h.PolicyEngine.Evaluate("ads.example.com"); d.Action != policy.ActionDeny {
+	if d, _ := h.PolicyEngine.Evaluate("ads.example.com", ""); d.Action != policy.ActionDeny {
 		t.Fatalf("engine: expected Deny for ads.example.com, got %v", d.Action)
 	}
 
@@ -137,7 +137,7 @@ func TestPolicyCRUDLifecycle(t *testing.T) {
 		t.Fatalf("expected stored action ALLOW after update, got %s", stored.Action)
 	}
 	// Engine now allows the same domain.
-	if d, _ := h.PolicyEngine.Evaluate("ads.example.com"); d.Action != policy.ActionAllow {
+	if d, _ := h.PolicyEngine.Evaluate("ads.example.com", ""); d.Action != policy.ActionAllow {
 		t.Fatalf("engine: expected Allow after update, got %v", d.Action)
 	}
 
@@ -150,7 +150,7 @@ func TestPolicyCRUDLifecycle(t *testing.T) {
 		t.Fatal("expected policy gone after delete")
 	}
 	// Engine reflects removal (default Allow).
-	if d, _ := h.PolicyEngine.Evaluate("ads.example.com"); d.Action != policy.ActionAllow {
+	if d, _ := h.PolicyEngine.Evaluate("ads.example.com", ""); d.Action != policy.ActionAllow {
 		t.Fatalf("engine: expected Allow after delete, got %v", d.Action)
 	}
 }
@@ -183,7 +183,7 @@ func TestPolicyPatchPartialAndRegexes(t *testing.T) {
 	}
 
 	// Engine blocks/redirects the initial domain.
-	if d, _ := h.PolicyEngine.Evaluate("old.example.com"); d.Action != policy.ActionRedirect {
+	if d, _ := h.PolicyEngine.Evaluate("old.example.com", ""); d.Action != policy.ActionRedirect {
 		t.Fatalf("engine: expected Redirect for old.example.com, got %v", d.Action)
 	}
 
@@ -201,10 +201,10 @@ func TestPolicyPatchPartialAndRegexes(t *testing.T) {
 	}
 
 	// Engine now matches the new domain, not the old one.
-	if d, _ := h.PolicyEngine.Evaluate("new.example.com"); d.Action != policy.ActionRedirect {
+	if d, _ := h.PolicyEngine.Evaluate("new.example.com", ""); d.Action != policy.ActionRedirect {
 		t.Fatalf("engine: expected Redirect for new.example.com, got %v", d.Action)
 	}
-	if d, _ := h.PolicyEngine.Evaluate("old.example.com"); d.Action != policy.ActionAllow {
+	if d, _ := h.PolicyEngine.Evaluate("old.example.com", ""); d.Action != policy.ActionAllow {
 		t.Fatalf("engine: expected Allow for old.example.com after domain change, got %v", d.Action)
 	}
 }
@@ -367,7 +367,7 @@ func TestPolicyScheduleEngineActive(t *testing.T) {
 	if w := doReq(t, rIn, http.MethodPost, "/api/v1/policies", create); w.Code != http.StatusCreated {
 		t.Fatalf("create in-window: got %d body=%s", w.Code, w.Body.String())
 	}
-	if d, _ := hIn.PolicyEngine.Evaluate("social.example.com"); d.Action != policy.ActionDeny {
+	if d, _ := hIn.PolicyEngine.Evaluate("social.example.com", ""); d.Action != policy.ActionDeny {
 		t.Fatalf("engine: expected Deny inside window, got %v", d.Action)
 	}
 
@@ -376,7 +376,7 @@ func TestPolicyScheduleEngineActive(t *testing.T) {
 	if w := doReq(t, rOut, http.MethodPost, "/api/v1/policies", create); w.Code != http.StatusCreated {
 		t.Fatalf("create out-window: got %d body=%s", w.Code, w.Body.String())
 	}
-	if d, _ := hOut.PolicyEngine.Evaluate("social.example.com"); d.Action != policy.ActionAllow {
+	if d, _ := hOut.PolicyEngine.Evaluate("social.example.com", ""); d.Action != policy.ActionAllow {
 		t.Fatalf("engine: expected Allow outside window, got %v", d.Action)
 	}
 }
@@ -394,5 +394,95 @@ func TestPolicyCreateInvalidSchedule(t *testing.T) {
 	})
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid timezone, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestPolicyClientScopeCreateAndEngine verifies client_cidrs round-trips
+// through the API (create -> get) and that the running engine applies the
+// scoped policy per-client: an in-scope client is blocked, an out-of-scope
+// client is allowed (I-014).
+func TestPolicyClientScopeCreateAndEngine(t *testing.T) {
+	r, h := setupPolicyTest(t)
+
+	w := doReq(t, r, http.MethodPost, "/api/v1/policies", CreatePolicyRequest{
+		ID:          "kids-social",
+		Name:        "Block social for kids subnet",
+		Action:      "BLOCK",
+		Domains:     []string{"social.example.com"},
+		ClientCIDRs: []string{"192.168.10.0/24"},
+		Priority:    100,
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	// client_cidrs round-trips through create response.
+	var created ResponsePolicySingle
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if len(created.Data.ClientCIDRs) != 1 || created.Data.ClientCIDRs[0] != "192.168.10.0/24" {
+		t.Fatalf("client_cidrs not returned: %+v", created.Data.ClientCIDRs)
+	}
+
+	// ...and through GET (i.e. persisted).
+	w = doReq(t, r, http.MethodGet, "/api/v1/policies/kids-social", nil)
+	var got ResponsePolicySingle
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if len(got.Data.ClientCIDRs) != 1 || got.Data.ClientCIDRs[0] != "192.168.10.0/24" {
+		t.Fatalf("client_cidrs not persisted: %+v", got.Data.ClientCIDRs)
+	}
+
+	// Engine applies the scope per-client.
+	if d, _ := h.PolicyEngine.Evaluate("social.example.com", "192.168.10.5:53"); d.Action != policy.ActionDeny {
+		t.Fatalf("engine: expected Deny for in-scope client, got %v", d.Action)
+	}
+	if d, _ := h.PolicyEngine.Evaluate("social.example.com", "192.168.20.5:53"); d.Action != policy.ActionAllow {
+		t.Fatalf("engine: expected Allow for out-of-scope client, got %v", d.Action)
+	}
+}
+
+// TestPolicyClientScopeInvalid verifies an unparseable client scope is rejected
+// on create and never persisted.
+func TestPolicyClientScopeInvalid(t *testing.T) {
+	r, h := setupPolicyTest(t)
+	w := doReq(t, r, http.MethodPost, "/api/v1/policies", CreatePolicyRequest{
+		ID:          "bad-scope",
+		Name:        "Bad scope",
+		Action:      "BLOCK",
+		Domains:     []string{"x.com"},
+		ClientCIDRs: []string{"999.999.0.0/24"},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid client scope, got %d body=%s", w.Code, w.Body.String())
+	}
+	if _, err := h.Store.Policies.GetByID("bad-scope"); err == nil {
+		t.Fatal("expected policy with invalid scope not to be persisted")
+	}
+}
+
+// TestPolicyClientScopePatchClears verifies PATCHing client_cidrs to an empty
+// list clears the scope so the policy becomes unscoped (applies to all).
+func TestPolicyClientScopePatchClears(t *testing.T) {
+	r, h := setupPolicyTest(t)
+	doReq(t, r, http.MethodPost, "/api/v1/policies", CreatePolicyRequest{
+		ID: "scoped", Name: "Scoped", Action: "BLOCK",
+		Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}, Priority: 100,
+	})
+	// Out-of-scope client initially allowed.
+	if d, _ := h.PolicyEngine.Evaluate("ads.example.com", "10.0.0.1:53"); d.Action != policy.ActionAllow {
+		t.Fatalf("pre-clear: expected Allow for out-of-scope client, got %v", d.Action)
+	}
+
+	w := doReq(t, r, http.MethodPatch, "/api/v1/policies/scoped", map[string]interface{}{
+		"client_cidrs": []string{},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	// Now unscoped: the same client is blocked.
+	if d, _ := h.PolicyEngine.Evaluate("ads.example.com", "10.0.0.1:53"); d.Action != policy.ActionDeny {
+		t.Fatalf("post-clear: expected Deny for all clients, got %v", d.Action)
 	}
 }

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -621,7 +621,9 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	// --- Step 2: Evaluate policy ---
-	decision, err := e.policyEngine.Evaluate(domainName)
+	// Thread the client IP so per-client scoped policies (I-014) apply only
+	// to matching clients; unscoped policies still apply to everyone.
+	decision, err := e.policyEngine.Evaluate(domainName, clientIP)
 	if err != nil {
 		logger.Log.Error("Failed to evaluate policy: " + err.Error())
 		e.logQuery(domainName, clientIP, "error", "", threatResult)

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"net"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -37,60 +38,77 @@ func (e *Engine) LoadPolicies(policies []Policy) error {
 	return nil
 }
 
-// Evaluate returns the decision for given domain and context.
+// Evaluate returns the decision for a given domain and the querying client.
+//
+// clientIP is the source address of the query (may be "host:port" as handed
+// out by the dataplane, or a bare IP; empty when unknown). It is used to apply
+// per-client policy scoping (I-014): a policy with a non-empty client scope is
+// considered only for clients inside its ranges, while unscoped policies apply
+// to everyone.
+//
 // Evaluation order:
 //   - normalize domain
 //   - exact-match/Bloom fast path (walks up parent domains) => decision
 //   - scheduled policies only count while inside their active window (I-038)
+//   - policies are further filtered to those in scope for this client (I-014)
 //   - regex + wildcard slow path (only on exact miss) => decision
 //   - otherwise => ALLOW
 //
 // The exact-match fast path returns immediately when it hits, so an exact rule
 // always wins over regex/wildcard rules. Within the regex/wildcard slow path,
 // the usual priority ordering applies (higher priority wins; tie => lexicographic ID).
-func (e *Engine) Evaluate(domain string) (Decision, error) {
+func (e *Engine) Evaluate(domain string, clientIP string) (Decision, error) {
 	d := normalizeDomain(domain)
 	snap := e.snapshot.Load().(*PolicySnapshot)
-
+	client := parseClientIP(clientIP)
 	now := e.now()
 
 	// Check exact match first, then walk up parent domains for subdomain matching.
 	// e.g., www.godaddy.com → check www.godaddy.com, then godaddy.com.
-	// This is the hot path and is intentionally left untouched.
 	parts := strings.Split(d, ".")
 	for i := 0; i < len(parts)-1; i++ {
 		candidate := strings.Join(parts[i:], ".")
 		if snap.Bloom != nil && !snap.Bloom.TestString(candidate) {
 			continue
 		}
-		if pols, ok := snap.Exact[candidate]; ok && len(pols) > 0 {
-			// Drop scheduled policies that are outside their active window. A
-			// policy inactive right now is treated as if it did not match, so
-			// evaluation keeps walking up to any always-on parent-domain rule.
-			active := filterActive(pols, now)
-			if len(active) == 0 {
-				continue
-			}
-			best := pickHighestPriority(active)
+		pols, ok := snap.Exact[candidate]
+		if !ok || len(pols) == 0 {
+			continue
+		}
+		// Drop scheduled policies that are outside their active window (I-038).
+		// A policy inactive right now is treated as if it did not match, so
+		// evaluation keeps walking up to any always-on parent-domain rule.
+		active := filterActive(pols, now)
+		if len(active) == 0 {
+			continue
+		}
+		// Keep only policies whose client scope matches this client (I-014).
+		// Unscoped policies always match (fast path in matchesClient). If
+		// nothing is in scope at this level, keep walking up to parent domains
+		// rather than stopping — a scoped rule on a subdomain must not mask a
+		// broader rule on its parent for a different client.
+		best := pickHighestPriorityScoped(snap, active, client)
+		if best != nil {
 			return policyDecision(best), nil
 		}
 	}
 
 	// Slow path: no exact match. Evaluate wildcard and compiled-regex rules,
-	// respecting the same priority ordering as the exact path.
-	if best := matchDynamic(snap, d, now); best != nil {
+	// respecting the same priority ordering, schedule, and client-scope rules
+	// as the exact path.
+	if best := matchDynamic(snap, d, now, client); best != nil {
 		return policyDecision(best), nil
 	}
 
 	return Decision{Action: ActionAllow}, nil
 }
 
-// matchDynamic returns the highest-priority active policy whose wildcard or
-// compiled regex rule matches d, or nil when nothing matches. A wildcard
-// "*.example.com" matches the base domain ("example.com") and any subdomain
-// of it. Scheduled policies (I-038) are filtered the same as the exact-match
-// path above: a policy inactive right now is treated as if it did not match.
-func matchDynamic(snap *PolicySnapshot, d string, now time.Time) *Policy {
+// matchDynamic returns the highest-priority active, in-scope policy whose
+// wildcard or compiled regex rule matches d, or nil when nothing matches. A
+// wildcard "*.example.com" matches the base domain ("example.com") and any
+// subdomain of it. Scheduled policies (I-038) and client scoping (I-014) are
+// filtered the same as the exact-match path above.
+func matchDynamic(snap *PolicySnapshot, d string, now time.Time, client net.IP) *Policy {
 	var candidates []*Policy
 	for _, w := range snap.Wildcards {
 		if d == w.base || strings.HasSuffix(d, "."+w.base) {
@@ -105,7 +123,7 @@ func matchDynamic(snap *PolicySnapshot, d string, now time.Time) *Policy {
 	if len(candidates) == 0 {
 		return nil
 	}
-	return pickHighestPriority(filterActive(candidates, now))
+	return pickHighestPriorityScoped(snap, filterActive(candidates, now), client)
 }
 
 // filterActive returns the policies that are active at the given instant. When
@@ -132,17 +150,19 @@ func filterActive(pols []*Policy, now time.Time) []*Policy {
 	return out
 }
 
-// pickHighestPriority returns the matching policy with highest priority (deterministic).
-func pickHighestPriority(candidates []*Policy) *Policy {
+// pickHighestPriorityScoped selects the highest-priority policy from candidates
+// that also applies to the given client, or nil if none are in scope.
+func pickHighestPriorityScoped(snap *PolicySnapshot, candidates []*Policy, client net.IP) *Policy {
 	var best *Policy
 	for _, p := range candidates {
+		if !snap.matchesClient(p, client) {
+			continue
+		}
 		if best == nil || p.Priority > best.Priority {
 			best = p
-		} else if p.Priority == best.Priority {
+		} else if p.Priority == best.Priority && p.ID < best.ID {
 			// deterministic tie-breaker: lexicographic ID
-			if p.ID < best.ID {
-				best = p
-			}
+			best = p
 		}
 	}
 	return best

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -24,7 +24,7 @@ func TestNormalizeDomain(t *testing.T) {
 
 func TestEvaluate_AllowByDefault(t *testing.T) {
 	e := NewPolicyEngine()
-	d, err := e.Evaluate("unknown.com")
+	d, err := e.Evaluate("unknown.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestEvaluate_BlockExactDomain(t *testing.T) {
 		{ID: "block-ads", Action: "BLOCK", Priority: 100, Domains: []string{"ads.example.com"}},
 	})
 
-	d, err := e.Evaluate("ads.example.com")
+	d, err := e.Evaluate("ads.example.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestEvaluate_CaseInsensitive(t *testing.T) {
 		{ID: "p1", Action: "BLOCK", Priority: 100, Domains: []string{"ADS.Example.COM"}},
 	})
 
-	d, err := e.Evaluate("ads.example.com")
+	d, err := e.Evaluate("ads.example.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestEvaluate_TrailingDotNormalized(t *testing.T) {
 		{ID: "p1", Action: "BLOCK", Priority: 100, Domains: []string{"blocked.com"}},
 	})
 
-	d, err := e.Evaluate("blocked.com.")
+	d, err := e.Evaluate("blocked.com.", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestEvaluate_Redirect(t *testing.T) {
 		{ID: "redir", Action: "REDIRECT", Priority: 100, Redirect: "1.2.3.4", Domains: []string{"redirect.me"}},
 	})
 
-	d, err := e.Evaluate("redirect.me")
+	d, err := e.Evaluate("redirect.me", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestEvaluate_HighestPriorityWins(t *testing.T) {
 		{ID: "high", Action: "BLOCK", Priority: 200, Domains: []string{"test.com"}},
 	})
 
-	d, err := e.Evaluate("test.com")
+	d, err := e.Evaluate("test.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestEvaluate_TieBreakByID(t *testing.T) {
 		{ID: "aaa", Action: "BLOCK", Priority: 100, Domains: []string{"tie.com"}},
 	})
 
-	d, err := e.Evaluate("tie.com")
+	d, err := e.Evaluate("tie.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestEvaluate_BloomNegativeShortCircuit(t *testing.T) {
 	})
 
 	// Domain not in bloom filter should be allowed without hitting exact map
-	d, err := e.Evaluate("notblocked.com")
+	d, err := e.Evaluate("notblocked.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestEvaluate_MultipleDomainsSamePolicy(t *testing.T) {
 	})
 
 	for _, domain := range []string{"a.com", "b.com", "c.com"} {
-		d, err := e.Evaluate(domain)
+		d, err := e.Evaluate(domain, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -171,7 +171,7 @@ func TestEvaluate_EmptyPolicies(t *testing.T) {
 	e := NewPolicyEngine()
 	e.LoadPolicies([]Policy{})
 
-	d, err := e.Evaluate("anything.com")
+	d, err := e.Evaluate("anything.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestEvaluate_BlockByRegex(t *testing.T) {
 		{ID: "rx-block", Action: "BLOCK", Priority: 100, Regexes: []string{`.*\.doubleclick\.net$`}},
 	})
 
-	d, err := e.Evaluate("ads.doubleclick.net")
+	d, err := e.Evaluate("ads.doubleclick.net", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestEvaluate_BlockByRegex(t *testing.T) {
 	}
 
 	// Non-matching domain should fall through to ALLOW.
-	d, err = e.Evaluate("safe.example.org")
+	d, err = e.Evaluate("safe.example.org", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +228,7 @@ func TestEvaluate_RegexAllowOverridesByPriority(t *testing.T) {
 		{ID: "rx-allow", Action: "ALLOW", Priority: 100, Regexes: []string{`.*\.tracking\.com$`}},
 	})
 
-	d, err := e.Evaluate("beacon.tracking.com")
+	d, err := e.Evaluate("beacon.tracking.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +247,7 @@ func TestEvaluate_RegexTieBreakByID(t *testing.T) {
 		{ID: "aaa-rx", Action: "BLOCK", Priority: 50, Regexes: []string{`^tie\.rx$`}},
 	})
 
-	d, err := e.Evaluate("tie.rx")
+	d, err := e.Evaluate("tie.rx", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +267,7 @@ func TestEvaluate_WildcardMatchesSubdomains(t *testing.T) {
 
 	// Wildcard matches the base domain and any depth of subdomain.
 	for _, domain := range []string{"example.com", "sub.example.com", "a.b.example.com"} {
-		d, err := e.Evaluate(domain)
+		d, err := e.Evaluate(domain, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -281,7 +281,7 @@ func TestEvaluate_WildcardMatchesSubdomains(t *testing.T) {
 
 	// Unrelated domains must not match.
 	for _, domain := range []string{"notexample.com", "example.com.evil.net", "other.org"} {
-		d, err := e.Evaluate(domain)
+		d, err := e.Evaluate(domain, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -298,7 +298,7 @@ func TestEvaluate_WildcardPriority(t *testing.T) {
 		{ID: "wild-allow", Action: "ALLOW", Priority: 100, Domains: []string{"*.corp.com"}},
 	})
 
-	d, err := e.Evaluate("intra.corp.com")
+	d, err := e.Evaluate("intra.corp.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestEvaluate_ExactWinsOverRegex(t *testing.T) {
 		{ID: "rx-all", Action: "ALLOW", Priority: 999, Regexes: []string{`.*`}},
 	})
 
-	d, err := e.Evaluate("exact.com")
+	d, err := e.Evaluate("exact.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,7 +324,7 @@ func TestEvaluate_ExactWinsOverRegex(t *testing.T) {
 	}
 
 	// A domain with no exact match falls through to the regex slow path.
-	d, err = e.Evaluate("anything.else")
+	d, err = e.Evaluate("anything.else", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +343,7 @@ func TestEvaluate_InvalidRegexDoesNotCrash(t *testing.T) {
 	})
 
 	// The invalid regex is skipped; querying anything must not panic.
-	d, err := e.Evaluate("harmless.com")
+	d, err := e.Evaluate("harmless.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,7 +352,7 @@ func TestEvaluate_InvalidRegexDoesNotCrash(t *testing.T) {
 	}
 
 	// The valid regex alongside it still matches.
-	d, err = e.Evaluate("good.net")
+	d, err = e.Evaluate("good.net", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -369,7 +369,7 @@ func TestEvaluate_ExactStillWorksWithDynamicRulesPresent(t *testing.T) {
 		{ID: "rx", Action: "BLOCK", Priority: 100, Regexes: []string{`^evil\.io$`}},
 	})
 
-	d, err := e.Evaluate("ads.example.com")
+	d, err := e.Evaluate("ads.example.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/loader.go
+++ b/internal/policy/loader.go
@@ -75,5 +75,15 @@ func ValidatePolicy(p *Policy) error {
 	if _, err := compileSchedule(p); err != nil {
 		return fmt.Errorf("policy %s: %v", p.ID, err)
 	}
+	// client scope optional; when present every entry must be a valid IP or CIDR
+	// so we never persist a scope the engine would silently drop (I-014).
+	for _, c := range p.ClientCIDRs {
+		if strings.TrimSpace(c) == "" {
+			return fmt.Errorf("empty client scope in policy %s", p.ID)
+		}
+		if _, err := parseClientScope(c); err != nil {
+			return fmt.Errorf("policy %s: invalid client scope %q: %w", p.ID, c, err)
+		}
+	}
 	return nil
 }

--- a/internal/policy/schedule_test.go
+++ b/internal/policy/schedule_test.go
@@ -42,7 +42,7 @@ func TestEvaluate_UnscheduledAlwaysActive(t *testing.T) {
 		time.Date(2026, 12, 25, 23, 59, 0, 0, time.UTC),
 	} {
 		e := engineAt(t, now, p)
-		if d, _ := e.Evaluate("blocked.com"); d.Action != ActionDeny {
+		if d, _ := e.Evaluate("blocked.com", ""); d.Action != ActionDeny {
 			t.Fatalf("unscheduled policy should always block; got %v at %v", d.Action, now)
 		}
 	}
@@ -58,7 +58,7 @@ func TestEvaluate_ActiveInsideWindow(t *testing.T) {
 
 	// 12:00 IST is inside [09:00,17:00) -> active -> blocked.
 	e := engineAt(t, time.Date(2026, 7, 20, 12, 0, 0, 0, ist), p)
-	if d, _ := e.Evaluate("social.example.com"); d.Action != ActionDeny {
+	if d, _ := e.Evaluate("social.example.com", ""); d.Action != ActionDeny {
 		t.Fatalf("expected block inside window, got %v", d.Action)
 	}
 }
@@ -73,7 +73,7 @@ func TestEvaluate_InactiveOutsideWindow(t *testing.T) {
 
 	// 20:00 IST is outside the window -> inactive -> default allow.
 	e := engineAt(t, time.Date(2026, 7, 20, 20, 0, 0, 0, ist), p)
-	if d, _ := e.Evaluate("social.example.com"); d.Action != ActionAllow {
+	if d, _ := e.Evaluate("social.example.com", ""); d.Action != ActionAllow {
 		t.Fatalf("expected allow outside window, got %v", d.Action)
 	}
 }
@@ -85,11 +85,11 @@ func TestEvaluate_WindowBoundaries(t *testing.T) {
 		StartTime: "09:00", EndTime: "17:00", Timezone: "Asia/Kolkata",
 	}
 	// Start is inclusive.
-	if d, _ := engineAt(t, time.Date(2026, 7, 20, 9, 0, 0, 0, ist), p).Evaluate("x.com"); d.Action != ActionDeny {
+	if d, _ := engineAt(t, time.Date(2026, 7, 20, 9, 0, 0, 0, ist), p).Evaluate("x.com", ""); d.Action != ActionDeny {
 		t.Fatalf("expected block at inclusive start 09:00, got %v", d.Action)
 	}
 	// End is exclusive.
-	if d, _ := engineAt(t, time.Date(2026, 7, 20, 17, 0, 0, 0, ist), p).Evaluate("x.com"); d.Action != ActionAllow {
+	if d, _ := engineAt(t, time.Date(2026, 7, 20, 17, 0, 0, 0, ist), p).Evaluate("x.com", ""); d.Action != ActionAllow {
 		t.Fatalf("expected allow at exclusive end 17:00, got %v", d.Action)
 	}
 }
@@ -106,7 +106,7 @@ func TestEvaluate_TimezoneHandling(t *testing.T) {
 		ID: "utc", Action: "BLOCK", Priority: 100, Domains: []string{"x.com"},
 		StartTime: "09:00", EndTime: "17:00", Timezone: "UTC",
 	}
-	if d, _ := engineAt(t, nowUTC, pUTC).Evaluate("x.com"); d.Action != ActionDeny {
+	if d, _ := engineAt(t, nowUTC, pUTC).Evaluate("x.com", ""); d.Action != ActionDeny {
 		t.Fatalf("UTC: expected block at 12:00 UTC, got %v", d.Action)
 	}
 
@@ -115,7 +115,7 @@ func TestEvaluate_TimezoneHandling(t *testing.T) {
 		ID: "ist", Action: "BLOCK", Priority: 100, Domains: []string{"x.com"},
 		StartTime: "09:00", EndTime: "17:00", Timezone: "Asia/Kolkata",
 	}
-	if d, _ := engineAt(t, nowUTC, pIST).Evaluate("x.com"); d.Action != ActionAllow {
+	if d, _ := engineAt(t, nowUTC, pIST).Evaluate("x.com", ""); d.Action != ActionAllow {
 		t.Fatalf("IST: expected allow (17:30 IST past window), got %v", d.Action)
 	}
 }
@@ -132,7 +132,7 @@ func TestEvaluate_DayOfWeek(t *testing.T) {
 		ID: "today", Action: "BLOCK", Priority: 100, Domains: []string{"x.com"},
 		ScheduleDays: []string{today}, Timezone: "UTC",
 	}
-	if d, _ := engineAt(t, base, pToday).Evaluate("x.com"); d.Action != ActionDeny {
+	if d, _ := engineAt(t, base, pToday).Evaluate("x.com", ""); d.Action != ActionDeny {
 		t.Fatalf("expected block on scheduled day %q, got %v", today, d.Action)
 	}
 
@@ -141,7 +141,7 @@ func TestEvaluate_DayOfWeek(t *testing.T) {
 		ID: "tomorrow", Action: "BLOCK", Priority: 100, Domains: []string{"x.com"},
 		ScheduleDays: []string{tomorrow}, Timezone: "UTC",
 	}
-	if d, _ := engineAt(t, base, pTomorrow).Evaluate("x.com"); d.Action != ActionAllow {
+	if d, _ := engineAt(t, base, pTomorrow).Evaluate("x.com", ""); d.Action != ActionAllow {
 		t.Fatalf("expected allow off scheduled day (%q only), got %v", tomorrow, d.Action)
 	}
 }
@@ -157,12 +157,12 @@ func TestEvaluate_DayAndWindowCombined(t *testing.T) {
 		ScheduleDays: []string{today}, StartTime: "09:00", EndTime: "17:00", Timezone: "UTC",
 	}
 	// Right day, inside window -> block.
-	if d, _ := engineAt(t, base, p).Evaluate("x.com"); d.Action != ActionDeny {
+	if d, _ := engineAt(t, base, p).Evaluate("x.com", ""); d.Action != ActionDeny {
 		t.Fatalf("expected block on day+window, got %v", d.Action)
 	}
 	// Right day, outside window -> allow.
 	outside := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
-	if d, _ := engineAt(t, outside, p).Evaluate("x.com"); d.Action != ActionAllow {
+	if d, _ := engineAt(t, outside, p).Evaluate("x.com", ""); d.Action != ActionAllow {
 		t.Fatalf("expected allow on right day but outside window, got %v", d.Action)
 	}
 }
@@ -186,7 +186,7 @@ func TestEvaluate_OvernightWindow(t *testing.T) {
 	}
 	for _, tc := range cases {
 		now := time.Date(2026, 7, 20, tc.hour, 0, 0, 0, time.UTC)
-		if d, _ := engineAt(t, now, p).Evaluate("x.com"); d.Action != tc.want {
+		if d, _ := engineAt(t, now, p).Evaluate("x.com", ""); d.Action != tc.want {
 			t.Fatalf("overnight window at %02d:00: want %v, got %v", tc.hour, tc.want, d.Action)
 		}
 	}
@@ -205,13 +205,13 @@ func TestEvaluate_ScheduledFallsThroughToParent(t *testing.T) {
 
 	// 20:00 UTC: child inactive, so the always-on parent BLOCK applies.
 	e := engineAt(t, time.Date(2026, 7, 20, 20, 0, 0, 0, time.UTC), child, parent)
-	if d, _ := e.Evaluate("ads.example.com"); d.Action != ActionDeny || d.PolicyID != "parent" {
+	if d, _ := e.Evaluate("ads.example.com", ""); d.Action != ActionDeny || d.PolicyID != "parent" {
 		t.Fatalf("expected fall-through to parent BLOCK, got action=%v id=%q", d.Action, d.PolicyID)
 	}
 
 	// 12:00 UTC: child active (higher priority ALLOW) wins over parent.
 	e = engineAt(t, time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC), child, parent)
-	if d, _ := e.Evaluate("ads.example.com"); d.Action != ActionAllow || d.PolicyID != "child" {
+	if d, _ := e.Evaluate("ads.example.com", ""); d.Action != ActionAllow || d.PolicyID != "child" {
 		t.Fatalf("expected active child ALLOW to win, got action=%v id=%q", d.Action, d.PolicyID)
 	}
 }

--- a/internal/policy/scope.go
+++ b/internal/policy/scope.go
@@ -1,0 +1,73 @@
+package policy
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// parseClientScope parses a single client-scope entry into an *net.IPNet.
+// An entry may be a CIDR ("10.0.0.0/24") or a bare IP ("192.168.1.10"),
+// IPv4 or IPv6. A bare IP is treated as a host route (/32 or /128).
+func parseClientScope(entry string) (*net.IPNet, error) {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return nil, fmt.Errorf("empty client scope entry")
+	}
+	if strings.Contains(entry, "/") {
+		_, ipnet, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, err
+		}
+		return ipnet, nil
+	}
+	ip := net.ParseIP(entry)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP or CIDR %q", entry)
+	}
+	bits := 128
+	if ip.To4() != nil {
+		bits = 32
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}, nil
+}
+
+// parseClientIP extracts a net.IP from a raw client address. The dataplane
+// hands us the value of net.Addr.String(), which is "host:port" (e.g.
+// "192.168.1.10:5353" or "[::1]:53"); tests and some callers may pass a bare
+// IP. Returns nil when the address cannot be parsed.
+func parseClientIP(raw string) net.IP {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if host, _, err := net.SplitHostPort(raw); err == nil {
+		raw = host
+	}
+	return net.ParseIP(raw)
+}
+
+// matchesClient reports whether policy p applies to the given client IP.
+//
+// Fast path: an unscoped policy (no ClientCIDRs) applies to every client,
+// so it matches unconditionally and never touches the parsed-net map. A
+// scoped policy matches only when the client IP falls inside one of its
+// ranges; if the client IP is unknown (nil) or none of the ranges parsed,
+// a scoped policy does not match.
+func (s *PolicySnapshot) matchesClient(p *Policy, clientIP net.IP) bool {
+	if p == nil {
+		return false
+	}
+	if len(p.ClientCIDRs) == 0 {
+		return true // unscoped: applies to all clients
+	}
+	if clientIP == nil {
+		return false // scoped policy needs a known client IP
+	}
+	for _, n := range s.clientNets[p.ID] {
+		if n.Contains(clientIP) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/policy/scope_test.go
+++ b/internal/policy/scope_test.go
@@ -1,0 +1,196 @@
+package policy
+
+import "testing"
+
+// TestEvaluate_ScopedPolicyMatchingClient verifies a client-scoped policy
+// applies to a query from a client inside its range.
+func TestEvaluate_ScopedPolicyMatchingClient(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "scoped", Action: "BLOCK", Priority: 100,
+			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}},
+	})
+
+	d, err := e.Evaluate("ads.example.com", "192.168.1.50:5353")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny {
+		t.Errorf("expected ActionDeny for in-scope client, got %v", d.Action)
+	}
+	if d.PolicyID != "scoped" {
+		t.Errorf("expected policy ID scoped, got %q", d.PolicyID)
+	}
+}
+
+// TestEvaluate_ScopedPolicyNonMatchingClient verifies a client-scoped policy
+// does NOT apply to a query from a client outside its range (default Allow).
+func TestEvaluate_ScopedPolicyNonMatchingClient(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "scoped", Action: "BLOCK", Priority: 100,
+			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}},
+	})
+
+	d, err := e.Evaluate("ads.example.com", "10.0.0.5:1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow {
+		t.Errorf("expected ActionAllow for out-of-scope client, got %v", d.Action)
+	}
+}
+
+// TestEvaluate_UnscopedPolicyAppliesToAll verifies an unscoped policy applies
+// to every client, including one whose IP is unknown.
+func TestEvaluate_UnscopedPolicyAppliesToAll(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "all", Action: "BLOCK", Priority: 100, Domains: []string{"ads.example.com"}},
+	})
+
+	for _, client := range []string{"192.168.1.50:53", "10.0.0.5:53", "", "not-an-ip"} {
+		d, err := e.Evaluate("ads.example.com", client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Action != ActionDeny {
+			t.Errorf("expected ActionDeny for unscoped policy with client %q, got %v", client, d.Action)
+		}
+	}
+}
+
+// TestEvaluate_ScopedPolicyUnknownClientIP verifies a scoped policy never
+// matches when the client IP cannot be determined (fail-closed for scope).
+func TestEvaluate_ScopedPolicyUnknownClientIP(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "scoped", Action: "BLOCK", Priority: 100,
+			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}},
+	})
+
+	d, err := e.Evaluate("ads.example.com", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow {
+		t.Errorf("expected ActionAllow for scoped policy with unknown client, got %v", d.Action)
+	}
+}
+
+// TestEvaluate_ScopeSingleHostIP verifies a bare host IP scope (no CIDR)
+// matches only that exact client.
+func TestEvaluate_ScopeSingleHostIP(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "host", Action: "BLOCK", Priority: 100,
+			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.10"}},
+	})
+
+	if d, _ := e.Evaluate("ads.example.com", "192.168.1.10:5000"); d.Action != ActionDeny {
+		t.Errorf("expected ActionDeny for exact host, got %v", d.Action)
+	}
+	if d, _ := e.Evaluate("ads.example.com", "192.168.1.11:5000"); d.Action != ActionAllow {
+		t.Errorf("expected ActionAllow for different host, got %v", d.Action)
+	}
+}
+
+// TestEvaluate_MultipleClientsIndependent verifies two clients see independent
+// decisions: a scoped block hits only one subnet, the other stays allowed,
+// while an unscoped policy on a different domain hits both.
+func TestEvaluate_MultipleClientsIndependent(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "kids-block", Action: "BLOCK", Priority: 100,
+			Domains: []string{"social.example.com"}, ClientCIDRs: []string{"192.168.10.0/24"}},
+		{ID: "global-block", Action: "BLOCK", Priority: 100,
+			Domains: []string{"malware.example.com"}},
+	})
+
+	const kid = "192.168.10.5:53"
+	const staff = "192.168.20.9:53"
+
+	// Scoped rule: only the kids subnet is blocked on social.
+	if d, _ := e.Evaluate("social.example.com", kid); d.Action != ActionDeny {
+		t.Errorf("kid: expected social blocked, got %v", d.Action)
+	}
+	if d, _ := e.Evaluate("social.example.com", staff); d.Action != ActionAllow {
+		t.Errorf("staff: expected social allowed, got %v", d.Action)
+	}
+
+	// Unscoped rule: both clients are blocked on malware.
+	if d, _ := e.Evaluate("malware.example.com", kid); d.Action != ActionDeny {
+		t.Errorf("kid: expected malware blocked, got %v", d.Action)
+	}
+	if d, _ := e.Evaluate("malware.example.com", staff); d.Action != ActionDeny {
+		t.Errorf("staff: expected malware blocked, got %v", d.Action)
+	}
+}
+
+// TestEvaluate_ScopeWalksToParentPolicy verifies that when a scoped policy on a
+// subdomain does not apply to the client, evaluation still finds a broader
+// unscoped policy on the parent domain rather than stopping early.
+func TestEvaluate_ScopeWalksToParentPolicy(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "sub-scoped", Action: "REDIRECT", Priority: 100, Redirect: "1.2.3.4",
+			Domains: []string{"api.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}},
+		{ID: "parent-all", Action: "BLOCK", Priority: 100,
+			Domains: []string{"example.com"}},
+	})
+
+	// Out-of-scope client: subdomain rule is skipped, parent BLOCK applies.
+	d, err := e.Evaluate("api.example.com", "10.0.0.1:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny || d.PolicyID != "parent-all" {
+		t.Errorf("expected parent BLOCK for out-of-scope client, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+
+	// In-scope client: subdomain REDIRECT wins (most specific match).
+	d, err = e.Evaluate("api.example.com", "192.168.1.7:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionRedirect || d.PolicyID != "sub-scoped" {
+		t.Errorf("expected subdomain REDIRECT for in-scope client, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
+// TestEvaluate_ScopeIPv6 verifies IPv6 CIDR scoping works, including the
+// bracketed host:port form handed out by the dataplane.
+func TestEvaluate_ScopeIPv6(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "v6", Action: "BLOCK", Priority: 100,
+			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"2001:db8::/32"}},
+	})
+
+	if d, _ := e.Evaluate("ads.example.com", "[2001:db8::1]:53"); d.Action != ActionDeny {
+		t.Errorf("expected ActionDeny for in-scope IPv6 client, got %v", d.Action)
+	}
+	if d, _ := e.Evaluate("ads.example.com", "[2001:dead::1]:53"); d.Action != ActionAllow {
+		t.Errorf("expected ActionAllow for out-of-scope IPv6 client, got %v", d.Action)
+	}
+}
+
+// TestValidatePolicy_ClientScope verifies scope validation accepts valid
+// IP/CIDR entries and rejects malformed ones.
+func TestValidatePolicy_ClientScope(t *testing.T) {
+	valid := &Policy{ID: "p", Action: "BLOCK",
+		ClientCIDRs: []string{"192.168.1.0/24", "10.0.0.5", "2001:db8::/32"}}
+	if err := ValidatePolicy(valid); err != nil {
+		t.Errorf("expected valid client scope to pass, got %v", err)
+	}
+
+	bad := &Policy{ID: "p", Action: "BLOCK", ClientCIDRs: []string{"not-a-cidr"}}
+	if err := ValidatePolicy(bad); err == nil {
+		t.Error("expected invalid client scope to fail validation")
+	}
+
+	empty := &Policy{ID: "p", Action: "BLOCK", ClientCIDRs: []string{"  "}}
+	if err := ValidatePolicy(empty); err == nil {
+		t.Error("expected empty client scope entry to fail validation")
+	}
+}

--- a/internal/policy/snapshot.go
+++ b/internal/policy/snapshot.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"net"
 	"regexp"
 	"strings"
 
@@ -29,12 +30,19 @@ type PolicySnapshot struct {
 	// once at snapshot-build time and cached here.
 	Regexes   []compiledRegexRule
 	Wildcards []wildcardRule
+
+	// clientNets holds the parsed client-scope ranges for each scoped policy,
+	// keyed by policy ID. It is precomputed once at snapshot-build time so
+	// per-query client matching never re-parses CIDR strings. Unscoped
+	// policies are absent from this map (see matchesClient). (I-014)
+	clientNets map[string][]*net.IPNet
 }
 
 func buildSnapshot(policies []Policy) *PolicySnapshot {
 	exact := make(map[string][]*Policy)
 	var wildcards []wildcardRule
 	var regexes []compiledRegexRule
+	clientNets := make(map[string][]*net.IPNet)
 	totalDomains := 0
 
 	// Precompute each policy's schedule once (I-038). A nil result means the
@@ -75,6 +83,16 @@ func buildSnapshot(policies []Policy) *PolicySnapshot {
 			}
 			regexes = append(regexes, compiledRegexRule{re: re, policy: p})
 		}
+		// Precompute parsed client-scope ranges for scoped policies so
+		// per-query matching is allocation- and parse-free. Invalid entries
+		// are skipped here; the loader/control-plane validate on ingest, so a
+		// bad range means "no valid ranges" and the scoped policy simply never
+		// matches (fail-closed for scope, not for the whole policy set).
+		for _, c := range policies[i].ClientCIDRs {
+			if n, err := parseClientScope(c); err == nil {
+				clientNets[policies[i].ID] = append(clientNets[policies[i].ID], n)
+			}
+		}
 	}
 
 	// build the bloom filter
@@ -99,10 +117,11 @@ func buildSnapshot(policies []Policy) *PolicySnapshot {
 	}
 
 	return &PolicySnapshot{
-		Exact:     exact,
-		Bloom:     bf,
-		Regexes:   regexes,
-		Wildcards: wildcards,
+		Exact:      exact,
+		Bloom:      bf,
+		Regexes:    regexes,
+		Wildcards:  wildcards,
+		clientNets: clientNets,
 	}
 }
 

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -51,6 +51,13 @@ type Policy struct {
 	// nil means always active. Unexported so gorm and encoding/json ignore it.
 	sched *compiledSchedule
 
+	// ClientCIDRs optionally scopes a policy to specific clients by IP/CIDR.
+	// Empty means the policy is unscoped and applies to all clients (I-014).
+	// Entries may be single IPs ("192.168.1.10") or CIDRs ("10.0.0.0/24"),
+	// IPv4 or IPv6. MAC-based scoping is intentionally left out of this first
+	// cut (it needs a client inventory).
+	ClientCIDRs []string `gorm:"-" json:"client_cidrs"`
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/internal/storage/models/policy.model.go
+++ b/internal/storage/models/policy.model.go
@@ -12,6 +12,11 @@ type Policy struct {
 	RedirectIP  string
 	Domains     string `gorm:"type:text"` // JSON array stored as text
 	Regexes     string `gorm:"type:text"` // JSON array stored as text
+	// ClientCIDRs scopes the policy to specific clients by IP/CIDR, stored as a
+	// JSON array of strings. Empty (the migration default) means the policy is
+	// unscoped and applies to all clients, so AutoMigrate adds the column
+	// safely to existing rows without changing their behavior (I-014).
+	ClientCIDRs string `gorm:"type:text"`
 	Priority    int    `gorm:"default:0"`
 	Enabled     bool   `gorm:"default:true"`
 

--- a/internal/storage/repositories/policy.go
+++ b/internal/storage/repositories/policy.go
@@ -15,7 +15,7 @@ import (
 // dataplane (poll-based reload) and the control plane (immediate reload),
 // so the two never drift.
 func ToEnginePolicy(m models.Policy) policy.Policy {
-	var domains, regexes, scheduleDays []string
+	var domains, regexes, scheduleDays, clientCIDRs []string
 	if m.Domains != "" {
 		_ = json.Unmarshal([]byte(m.Domains), &domains)
 	}
@@ -24,6 +24,9 @@ func ToEnginePolicy(m models.Policy) policy.Policy {
 	}
 	if m.ScheduleDays != "" {
 		_ = json.Unmarshal([]byte(m.ScheduleDays), &scheduleDays)
+	}
+	if m.ClientCIDRs != "" {
+		_ = json.Unmarshal([]byte(m.ClientCIDRs), &clientCIDRs)
 	}
 	return policy.Policy{
 		ID:           m.ID,
@@ -40,6 +43,7 @@ func ToEnginePolicy(m models.Policy) policy.Policy {
 		StartTime:    m.ScheduleStart,
 		EndTime:      m.ScheduleEnd,
 		Timezone:     m.Timezone,
+		ClientCIDRs:  clientCIDRs,
 	}
 }
 


### PR DESCRIPTION
> **Stacks on #44** (`feat/wire-policies-handlers`); base = that branch. Also conceptually overlaps the time-policies PR — **merge order matters**.

## What
Adds an optional **client scope** to policies. A policy may carry a list of client IP ranges / CIDRs; a scoped policy applies **only** to queries from a matching client IP. Unscoped policies (empty scope) apply to all clients, exactly as before.

## Why
First cut of **I-014**: per-client policy differentiation (e.g. block social media for the students subnet but not staff, without duplicating the whole policy set). Storage-level scoping keeps the fast unscoped path untouched for the common case.

## How
- **Model** — add `ClientCIDRs []string` to `policy.Policy` and a JSON-text `ClientCIDRs` column on `models.Policy`. `AutoMigrate` adds the column with an empty default, so every existing policy stays unscoped (applies to all) — safe migration, no behavior change.
- **Engine** — `Engine.Evaluate` now takes the client IP and only considers a policy whose scope matches (or is empty). Parsed CIDRs are precomputed once per snapshot (`buildSnapshot`), so per-query matching never re-parses strings and unscoped policies keep the allocation-free fast path. Exact / subdomain-walk matching is preserved; when a scoped subdomain rule doesn't apply to a client, evaluation walks up to parent-domain rules instead of stopping early. A scoped policy with an unknown client IP fails closed (does not match).
- **Dataplane** — `ProcessDNSQuery` threads its existing `clientIP` into `Evaluate` (host:port and IPv6 bracket forms are handled).
- **Control-plane** — `POST`/`PUT`/`PATCH` accept `client_cidrs`; a `nil` field leaves scope unchanged, an empty list clears it. Validation rejects malformed IP/CIDR so a bad scope is never persisted.

## Tests (deterministic)
Engine: scoped applies only to the matching client; unscoped applies to all; CIDR, single-host, and IPv6 matching; multiple clients independent; parent-domain walk fallback; unknown-client fails closed; scope validation. Control-plane: `client_cidrs` round-trips through create/get, engine enforces it per-client, invalid scope is rejected (400, not persisted), and PATCH-to-empty clears the scope. `gofmt` / `go build` / `go vet` / `go test ./...` all green.

## Scope note
This first cut is **IP/CIDR only**. **MAC-based scoping is intentionally deferred** — it needs a client inventory to map MACs to identities, which doesn't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)