### PR TITLE
feat: plain-language reporting engine (I-019, first cut)

### DIFF
--- a/cmd/controlplane/handlers/reports.go
+++ b/cmd/controlplane/handlers/reports.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/lopster568/phantomDNS/internal/report"
+)
+
+// parseReportTime accepts either an RFC3339 timestamp or a plain YYYY-MM-DD
+// date. Dates are interpreted in UTC.
+func parseReportTime(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// GetReport handles GET /api/v1/reports?from=&to=&format=text|html
+//
+// It generates a plain-language period report from the DNS query log. When
+// from/to are omitted it defaults to the last 7 days. format defaults to text;
+// pass format=html for the HTML rendering.
+func (h *APIHandler) GetReport(c *gin.Context) {
+	now := time.Now().UTC()
+	to := now
+	from := now.AddDate(0, 0, -7)
+
+	if v, ok := parseReportTime(c.Query("from")); ok {
+		from = v
+	}
+	if v, ok := parseReportTime(c.Query("to")); ok {
+		to = v
+	}
+	if to.Before(from) {
+		errMsg := "invalid range: 'to' is before 'from'"
+		c.JSON(http.StatusBadRequest, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+
+	rep, err := report.Generate(h.Store.QueryLogs, from, to)
+	if err != nil {
+		errMsg := "failed to generate report"
+		c.JSON(http.StatusInternalServerError, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+
+	switch c.Query("format") {
+	case "html":
+		c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(report.RenderHTML(rep)))
+	case "json":
+		c.JSON(http.StatusOK, ResponseGeneric{Status: "success", Data: rep})
+	default:
+		c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(report.RenderText(rep)))
+	}
+}

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -97,5 +97,8 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 			cfg.GET("/export", apiHandler.ExportConfig)
 			cfg.POST("/import", apiHandler.ImportConfig)
 		}
+
+		// Reporting endpoint — plain-language period report (text/html/json)
+		api.GET("/reports", apiHandler.GetReport)
 	}
 }

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lopster568/phantomDNS/internal/metrics"
 	"github.com/lopster568/phantomDNS/internal/nrd"
 	"github.com/lopster568/phantomDNS/internal/policy"
+	"github.com/lopster568/phantomDNS/internal/report"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 	"github.com/lopster568/phantomDNS/internal/threat"
@@ -90,6 +91,10 @@ func (m *mockQueryLog) GatherWindowStats(w repositories.AnalyticsWindow) (reposi
 
 func (m *mockQueryLog) AnomalyDigestBetween(current, prior repositories.AnalyticsWindow, cfg repositories.AnomalyThresholds) (repositories.AnomalyDigest, error) {
 	return repositories.AnomalyDigest{}, nil
+}
+
+func (m *mockQueryLog) Aggregate(from, to time.Time, topN int) (report.Aggregates, error) {
+	return report.Aggregates{}, nil
 }
 
 // waitSaved blocks until logQuery's goroutine persists a row (or times out).

--- a/internal/report/errors.go
+++ b/internal/report/errors.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package report
+
+import "errors"
+
+// errNilRepo is returned by Generate when no Aggregator is supplied.
+var errNilRepo = errors.New("report: nil aggregator")

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package report
+
+import (
+	"fmt"
+	"html/template"
+	"strconv"
+	"strings"
+)
+
+// RenderText renders a Report as a friendly, non-technical plain-text summary
+// suitable for an email body or a printed page.
+func RenderText(r Report) string {
+	var b strings.Builder
+
+	b.WriteString("HydraDNS Security Report\n")
+	b.WriteString(r.PeriodLabel)
+	b.WriteString(" (")
+	b.WriteString(formatRange(r))
+	b.WriteString(")\n\n")
+
+	if r.TotalQueries == 0 {
+		fmt.Fprintf(&b, "%s HydraDNS saw no DNS activity for this period, so there is nothing to report yet.\n",
+			capitalize(r.PeriodLabel))
+		fmt.Fprintf(&b, "\nGenerated %s.\n", r.GeneratedAt.Format("Jan 2, 2006 at 15:04 MST"))
+		return b.String()
+	}
+
+	// Headline sentence, in plain language.
+	fmt.Fprintf(&b, "%s HydraDNS answered %s DNS requests and blocked %s of them (%s%% of all traffic).\n",
+		capitalize(r.PeriodLabel),
+		humanizeInt(r.TotalQueries),
+		humanizeInt(r.BlockedQueries),
+		formatPercent(r.BlockRatePercent),
+	)
+	fmt.Fprintf(&b, "That includes %s ads and trackers and %s malware and phishing attempts stopped before they reached your network.\n",
+		humanizeInt(r.AdsAndTrackers),
+		humanizeInt(r.ThreatsBlocked),
+	)
+
+	if len(r.TopBlockedDomains) > 0 {
+		b.WriteString("\nTop blocked domains:\n")
+		for i, d := range r.TopBlockedDomains {
+			fmt.Fprintf(&b, "  %d. %s — %s times\n", i+1, d.Domain, humanizeInt(d.Count))
+		}
+	}
+
+	if len(r.TopBlockedCategories) > 0 {
+		b.WriteString("\nTop blocked categories:\n")
+		for i, c := range r.TopBlockedCategories {
+			fmt.Fprintf(&b, "  %d. %s — %s\n", i+1, c.Category, humanizeInt(c.Count))
+		}
+	}
+
+	if len(r.NotableEvents) > 0 {
+		b.WriteString("\nNotable events:\n")
+		for _, e := range r.NotableEvents {
+			verb := "flagged"
+			if e.Blocked {
+				verb = "blocked"
+			}
+			reason := e.Reason
+			if reason == "" {
+				reason = "suspicious lookup"
+			}
+			fmt.Fprintf(&b, "  • %s — %s %s (threat score %.2f): %s\n",
+				e.Timestamp.Format("Jan 2 15:04"), e.Domain, verb, e.ThreatScore, reason)
+		}
+	}
+
+	fmt.Fprintf(&b, "\nGenerated %s.\n", r.GeneratedAt.Format("Jan 2, 2006 at 15:04 MST"))
+	return b.String()
+}
+
+// reportHTMLTemplate is a minimal, self-contained HTML rendering. html/template
+// escapes all interpolated values automatically.
+var reportHTMLTemplate = template.Must(template.New("report").Funcs(template.FuncMap{
+	"humanize": humanizeInt,
+	"percent":  formatPercent,
+	"cap":      capitalize,
+	"rangeOf":  formatRange,
+	"score":    func(f float64) string { return fmt.Sprintf("%.2f", f) },
+	"stamp":    func(r Report) string { return r.GeneratedAt.Format("Jan 2, 2006 at 15:04 MST") },
+	"evtime":   func(e Event) string { return e.Timestamp.Format("Jan 2 15:04") },
+}).Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>HydraDNS Security Report</title>
+</head>
+<body style="font-family: -apple-system, Arial, sans-serif; max-width: 640px; margin: 0 auto; color: #1a1a1a;">
+<h1>HydraDNS Security Report</h1>
+<p><strong>{{ cap .PeriodLabel }}</strong> ({{ rangeOf . }})</p>
+{{- if eq .TotalQueries 0 }}
+<p>{{ cap .PeriodLabel }} HydraDNS saw no DNS activity for this period, so there is nothing to report yet.</p>
+{{- else }}
+<p>{{ cap .PeriodLabel }} HydraDNS answered <strong>{{ humanize .TotalQueries }}</strong> DNS requests and blocked
+<strong>{{ humanize .BlockedQueries }}</strong> of them ({{ percent .BlockRatePercent }}% of all traffic).</p>
+<p>That includes <strong>{{ humanize .AdsAndTrackers }}</strong> ads and trackers and
+<strong>{{ humanize .ThreatsBlocked }}</strong> malware and phishing attempts stopped before they reached your network.</p>
+{{- if .TopBlockedDomains }}
+<h2>Top blocked domains</h2>
+<ol>
+{{- range .TopBlockedDomains }}
+<li>{{ .Domain }} — {{ humanize .Count }} times</li>
+{{- end }}
+</ol>
+{{- end }}
+{{- if .TopBlockedCategories }}
+<h2>Top blocked categories</h2>
+<ol>
+{{- range .TopBlockedCategories }}
+<li>{{ .Category }} — {{ humanize .Count }}</li>
+{{- end }}
+</ol>
+{{- end }}
+{{- if .NotableEvents }}
+<h2>Notable events</h2>
+<ul>
+{{- range .NotableEvents }}
+<li>{{ evtime . }} — {{ .Domain }} {{ if .Blocked }}blocked{{ else }}flagged{{ end }}
+(threat score {{ score .ThreatScore }}){{ if .Reason }}: {{ .Reason }}{{ end }}</li>
+{{- end }}
+</ul>
+{{- end }}
+{{- end }}
+<hr>
+<p style="color: #888; font-size: 0.85em;">Generated {{ stamp . }}.</p>
+</body>
+</html>
+`))
+
+// RenderHTML renders a Report as a minimal, self-contained HTML page. All
+// values are HTML-escaped by html/template.
+func RenderHTML(r Report) string {
+	var b strings.Builder
+	// The template is static and the data is trusted-shaped; an error here
+	// would indicate a programming bug, so fall back to the text rendering.
+	if err := reportHTMLTemplate.Execute(&b, r); err != nil {
+		return "<pre>" + template.HTMLEscapeString(RenderText(r)) + "</pre>"
+	}
+	return b.String()
+}
+
+// --- small formatting helpers (no external deps) ---
+
+// humanizeInt formats n with thousands separators, e.g. 41300 -> "41,300".
+func humanizeInt(n int64) string {
+	neg := n < 0
+	s := strconv.FormatInt(n, 10)
+	if neg {
+		s = s[1:]
+	}
+	if len(s) <= 3 {
+		if neg {
+			return "-" + s
+		}
+		return s
+	}
+	var out strings.Builder
+	pre := len(s) % 3
+	if pre > 0 {
+		out.WriteString(s[:pre])
+		if len(s) > pre {
+			out.WriteByte(',')
+		}
+	}
+	for i := pre; i < len(s); i += 3 {
+		out.WriteString(s[i : i+3])
+		if i+3 < len(s) {
+			out.WriteByte(',')
+		}
+	}
+	if neg {
+		return "-" + out.String()
+	}
+	return out.String()
+}
+
+// formatPercent renders a percentage with one decimal place, e.g. "27.3".
+func formatPercent(f float64) string {
+	return strconv.FormatFloat(f, 'f', 1, 64)
+}
+
+// capitalize upper-cases the first rune of s.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// formatRange renders the report window as "Jan 2 – Jan 9, 2006".
+func formatRange(r Report) string {
+	if r.From.Year() == r.To.Year() {
+		return fmt.Sprintf("%s – %s", r.From.Format("Jan 2"), r.To.Format("Jan 2, 2006"))
+	}
+	return fmt.Sprintf("%s – %s", r.From.Format("Jan 2, 2006"), r.To.Format("Jan 2, 2006"))
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package report builds plain-language period reports (weekly, trial, annual)
+// from the DNS query log and statistics stored by HydraDNS. It turns raw
+// aggregates into a friendly, non-technical summary that a school admin or SMB
+// owner can read at a glance ("This week we blocked 41,300 ads and 218 malware
+// attempts").
+//
+// The aggregation is done by an Aggregator (implemented by the query-log
+// repository); this package only shapes and renders the result, so it depends
+// on nothing but the standard library.
+package report
+
+import (
+	"sort"
+	"time"
+)
+
+// Period classifies the length of a report window.
+type Period string
+
+const (
+	PeriodWeekly Period = "weekly"
+	PeriodTrial  Period = "trial"
+	PeriodAnnual Period = "annual"
+)
+
+// defaultTopN is how many domains, categories and notable events a report
+// surfaces. Kept small so the summary stays readable.
+const defaultTopN = 5
+
+// DomainCount is a blocked domain and how often it was blocked in the window.
+type DomainCount struct {
+	Domain string `json:"domain"`
+	Count  int64  `json:"count"`
+}
+
+// CategoryCount is a blocked category and its total block count in the window.
+type CategoryCount struct {
+	Category string `json:"category"`
+	Count    int64  `json:"count"`
+}
+
+// Event is a notable (suspicious) lookup worth calling out in the report.
+type Event struct {
+	Timestamp   time.Time `json:"timestamp"`
+	Domain      string    `json:"domain"`
+	ClientIP    string    `json:"client_ip"`
+	Reason      string    `json:"reason"`
+	ThreatScore float64   `json:"threat_score"`
+	Blocked     bool      `json:"blocked"`
+}
+
+// Aggregates is the raw, pre-rendered result the Aggregator produces for a
+// window. Generate turns it into a Report.
+type Aggregates struct {
+	TotalQueries         int64
+	BlockedQueries       int64
+	AllowedQueries       int64
+	ThreatsBlocked       int64
+	TopBlockedDomains    []DomainCount
+	TopBlockedCategories []CategoryCount
+	NotableEvents        []Event
+}
+
+// Aggregator produces the aggregates for a time window. topN bounds how many
+// top domains / categories / events to return. The query-log repository
+// implements this interface.
+type Aggregator interface {
+	Aggregate(from, to time.Time, topN int) (Aggregates, error)
+}
+
+// Report is the fully-shaped, render-ready period report.
+type Report struct {
+	Period      Period    `json:"period"`
+	PeriodLabel string    `json:"period_label"` // friendly phrase, e.g. "this week"
+	From        time.Time `json:"from"`
+	To          time.Time `json:"to"`
+	GeneratedAt time.Time `json:"generated_at"`
+
+	TotalQueries     int64   `json:"total_queries"`
+	BlockedQueries   int64   `json:"blocked_queries"`
+	AllowedQueries   int64   `json:"allowed_queries"`
+	ThreatsBlocked   int64   `json:"threats_blocked"`
+	AdsAndTrackers   int64   `json:"ads_and_trackers"` // blocked that were not threats
+	BlockRatePercent float64 `json:"block_rate_percent"`
+
+	TopBlockedDomains    []DomainCount   `json:"top_blocked_domains"`
+	TopBlockedCategories []CategoryCount `json:"top_blocked_categories"`
+	NotableEvents        []Event         `json:"notable_events"`
+}
+
+// Generate builds a Report for the window [from, to] using the aggregates from
+// repo. An empty window (no queries) yields a valid, zeroed Report rather than
+// an error.
+func Generate(repo Aggregator, from, to time.Time) (Report, error) {
+	if repo == nil {
+		return Report{}, errNilRepo
+	}
+
+	agg, err := repo.Aggregate(from, to, defaultTopN)
+	if err != nil {
+		return Report{}, err
+	}
+
+	period, label := classifyPeriod(from, to)
+
+	var blockRate float64
+	if agg.TotalQueries > 0 {
+		blockRate = float64(agg.BlockedQueries) / float64(agg.TotalQueries) * 100
+	}
+
+	ads := agg.BlockedQueries - agg.ThreatsBlocked
+	if ads < 0 {
+		ads = 0
+	}
+
+	// Defensive: keep the surfaced lists sorted and bounded even if the
+	// Aggregator returned them unsorted.
+	domains := append([]DomainCount(nil), agg.TopBlockedDomains...)
+	sort.SliceStable(domains, func(i, j int) bool {
+		if domains[i].Count != domains[j].Count {
+			return domains[i].Count > domains[j].Count
+		}
+		return domains[i].Domain < domains[j].Domain
+	})
+	if len(domains) > defaultTopN {
+		domains = domains[:defaultTopN]
+	}
+
+	categories := append([]CategoryCount(nil), agg.TopBlockedCategories...)
+	sort.SliceStable(categories, func(i, j int) bool {
+		if categories[i].Count != categories[j].Count {
+			return categories[i].Count > categories[j].Count
+		}
+		return categories[i].Category < categories[j].Category
+	})
+	if len(categories) > defaultTopN {
+		categories = categories[:defaultTopN]
+	}
+
+	return Report{
+		Period:               period,
+		PeriodLabel:          label,
+		From:                 from,
+		To:                   to,
+		GeneratedAt:          time.Now().UTC(),
+		TotalQueries:         agg.TotalQueries,
+		BlockedQueries:       agg.BlockedQueries,
+		AllowedQueries:       agg.AllowedQueries,
+		ThreatsBlocked:       agg.ThreatsBlocked,
+		AdsAndTrackers:       ads,
+		BlockRatePercent:     blockRate,
+		TopBlockedDomains:    domains,
+		TopBlockedCategories: categories,
+		NotableEvents:        agg.NotableEvents,
+	}, nil
+}
+
+// classifyPeriod maps a window duration to a Period and a friendly phrase.
+// The thresholds are deliberately loose: a report window is rarely exact.
+func classifyPeriod(from, to time.Time) (Period, string) {
+	d := to.Sub(from)
+	switch {
+	case d <= 8*24*time.Hour:
+		return PeriodWeekly, "this week"
+	case d <= 45*24*time.Hour:
+		return PeriodTrial, "your trial period"
+	default:
+		return PeriodAnnual, "this year"
+	}
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package report_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	glogger "gorm.io/gorm/logger"
+
+	"github.com/lopster568/phantomDNS/internal/report"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: glogger.Default.LogMode(glogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.DNSQuery{}, &models.BlocklistEntry{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+// seedWindow inserts a deterministic set of query-log rows: 7 blocks
+// (2 of them suspicious threats) and 5 allows inside the window, plus one
+// block dated before the window that must be excluded from every aggregate.
+func seedWindow(t *testing.T, db *gorm.DB) (from, to time.Time) {
+	t.Helper()
+	base := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+
+	rows := []models.DNSQuery{
+		{Domain: "ads.example.com", ClientIP: "10.0.0.1", Action: "block", Timestamp: base.Add(1 * time.Minute)},
+		{Domain: "ads.example.com", ClientIP: "10.0.0.2", Action: "block", Timestamp: base.Add(2 * time.Minute)},
+		{Domain: "ads.example.com", ClientIP: "10.0.0.3", Action: "block", Timestamp: base.Add(3 * time.Minute)},
+		{Domain: "tracker.example.net", ClientIP: "10.0.0.1", Action: "block", Timestamp: base.Add(4 * time.Minute)},
+		{Domain: "tracker.example.net", ClientIP: "10.0.0.2", Action: "block", Timestamp: base.Add(5 * time.Minute)},
+		{Domain: "malware.bad.com", ClientIP: "10.0.0.9", Action: "block", Timestamp: base.Add(6 * time.Minute),
+			IsSuspicious: true, ThreatScore: 0.95, ThreatReason: "known malware C2"},
+		{Domain: "malware.bad.com", ClientIP: "10.0.0.8", Action: "block", Timestamp: base.Add(7 * time.Minute),
+			IsSuspicious: true, ThreatScore: 0.90, DetectionMethod: "heuristic"},
+		{Domain: "good.com", ClientIP: "10.0.0.1", Action: "allow", Timestamp: base.Add(8 * time.Minute)},
+		{Domain: "good.com", ClientIP: "10.0.0.2", Action: "allow", Timestamp: base.Add(9 * time.Minute)},
+		{Domain: "good.com", ClientIP: "10.0.0.3", Action: "allow", Timestamp: base.Add(10 * time.Minute)},
+		{Domain: "good.com", ClientIP: "10.0.0.4", Action: "allow", Timestamp: base.Add(11 * time.Minute)},
+		{Domain: "safe.org", ClientIP: "10.0.0.5", Action: "allow", Timestamp: base.Add(12 * time.Minute)},
+		// Outside the window — must be excluded.
+		{Domain: "old.example.com", ClientIP: "10.0.0.1", Action: "block", Timestamp: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	for i := range rows {
+		if err := db.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("seed dns query: %v", err)
+		}
+	}
+
+	entries := []models.BlocklistEntry{
+		{Domain: "ads.example.com", SourceID: "s", Category: "advertising"},
+		{Domain: "tracker.example.net", SourceID: "s", Category: "tracking"},
+		{Domain: "malware.bad.com", SourceID: "s", Category: "malware"},
+	}
+	for i := range entries {
+		if err := db.Create(&entries[i]).Error; err != nil {
+			t.Fatalf("seed blocklist entry: %v", err)
+		}
+	}
+
+	from = time.Date(2026, 7, 13, 0, 0, 0, 0, time.UTC)
+	to = time.Date(2026, 7, 20, 23, 59, 59, 0, time.UTC)
+	return from, to
+}
+
+func TestGenerate_Aggregates(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repositories.NewGormQueryLogRepo(db)
+	from, to := seedWindow(t, db)
+
+	rep, err := report.Generate(repo, from, to)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if rep.TotalQueries != 12 {
+		t.Errorf("TotalQueries = %d, want 12 (out-of-window row must be excluded)", rep.TotalQueries)
+	}
+	if rep.BlockedQueries != 7 {
+		t.Errorf("BlockedQueries = %d, want 7", rep.BlockedQueries)
+	}
+	if rep.AllowedQueries != 5 {
+		t.Errorf("AllowedQueries = %d, want 5", rep.AllowedQueries)
+	}
+	if rep.ThreatsBlocked != 2 {
+		t.Errorf("ThreatsBlocked = %d, want 2", rep.ThreatsBlocked)
+	}
+	if rep.AdsAndTrackers != 5 {
+		t.Errorf("AdsAndTrackers = %d, want 5", rep.AdsAndTrackers)
+	}
+	// 7/12 * 100 = 58.33...
+	if got := rep.BlockRatePercent; got < 58.3 || got > 58.4 {
+		t.Errorf("BlockRatePercent = %.4f, want ~58.33", got)
+	}
+	if rep.Period != report.PeriodWeekly {
+		t.Errorf("Period = %q, want weekly", rep.Period)
+	}
+
+	// Top blocked domains: ads(3), then the 2-count tie broken by domain name.
+	wantDomains := []report.DomainCount{
+		{Domain: "ads.example.com", Count: 3},
+		{Domain: "malware.bad.com", Count: 2},
+		{Domain: "tracker.example.net", Count: 2},
+	}
+	if len(rep.TopBlockedDomains) != len(wantDomains) {
+		t.Fatalf("TopBlockedDomains = %+v, want %+v", rep.TopBlockedDomains, wantDomains)
+	}
+	for i, w := range wantDomains {
+		if rep.TopBlockedDomains[i] != w {
+			t.Errorf("TopBlockedDomains[%d] = %+v, want %+v", i, rep.TopBlockedDomains[i], w)
+		}
+	}
+
+	// Top blocked categories, derived from the blocklist join.
+	wantCats := []report.CategoryCount{
+		{Category: "advertising", Count: 3},
+		{Category: "malware", Count: 2},
+		{Category: "tracking", Count: 2},
+	}
+	if len(rep.TopBlockedCategories) != len(wantCats) {
+		t.Fatalf("TopBlockedCategories = %+v, want %+v", rep.TopBlockedCategories, wantCats)
+	}
+	for i, w := range wantCats {
+		if rep.TopBlockedCategories[i] != w {
+			t.Errorf("TopBlockedCategories[%d] = %+v, want %+v", i, rep.TopBlockedCategories[i], w)
+		}
+	}
+
+	// Notable events: both suspicious lookups, highest score first.
+	if len(rep.NotableEvents) != 2 {
+		t.Fatalf("NotableEvents count = %d, want 2", len(rep.NotableEvents))
+	}
+	if rep.NotableEvents[0].Domain != "malware.bad.com" || rep.NotableEvents[0].ThreatScore != 0.95 {
+		t.Errorf("NotableEvents[0] = %+v, want malware.bad.com @0.95", rep.NotableEvents[0])
+	}
+	if rep.NotableEvents[0].Reason != "known malware C2" {
+		t.Errorf("NotableEvents[0].Reason = %q, want 'known malware C2'", rep.NotableEvents[0].Reason)
+	}
+	if !rep.NotableEvents[0].Blocked {
+		t.Error("NotableEvents[0].Blocked = false, want true")
+	}
+	// Falls back to DetectionMethod when ThreatReason is empty.
+	if rep.NotableEvents[1].Reason != "heuristic" {
+		t.Errorf("NotableEvents[1].Reason = %q, want 'heuristic'", rep.NotableEvents[1].Reason)
+	}
+}
+
+func TestRenderText_ContainsKeyNumbers(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repositories.NewGormQueryLogRepo(db)
+	from, to := seedWindow(t, db)
+
+	rep, err := report.Generate(repo, from, to)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	text := report.RenderText(rep)
+	for _, want := range []string{
+		"This week",          // period label, capitalized
+		"12 DNS requests",    // total
+		"blocked 7",          // blocked count
+		"58.3",               // block rate
+		"5 ads and trackers", // ads = blocked - threats
+		"2 malware",          // threats
+		"ads.example.com",    // top domain
+		"advertising",        // top category
+		"malware.bad.com",    // notable event
+		"known malware C2",   // notable event reason
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("RenderText missing %q\n---\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderHTML_ContainsKeyNumbers(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repositories.NewGormQueryLogRepo(db)
+	from, to := seedWindow(t, db)
+
+	rep, err := report.Generate(repo, from, to)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	html := report.RenderHTML(rep)
+	for _, want := range []string{
+		"<!DOCTYPE html>",
+		"HydraDNS Security Report",
+		"<strong>12</strong>",
+		"<strong>7</strong>",
+		"advertising",
+		"malware.bad.com",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("RenderHTML missing %q\n---\n%s", want, html)
+		}
+	}
+}
+
+func TestGenerate_EmptyRange(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repositories.NewGormQueryLogRepo(db)
+	seedWindow(t, db) // data exists, but the query window below has none
+
+	from := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2020, 1, 8, 0, 0, 0, 0, time.UTC)
+
+	rep, err := report.Generate(repo, from, to)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if rep.TotalQueries != 0 || rep.BlockedQueries != 0 {
+		t.Errorf("empty range should be zeroed, got total=%d blocked=%d", rep.TotalQueries, rep.BlockedQueries)
+	}
+	if rep.BlockRatePercent != 0 {
+		t.Errorf("empty range block rate = %v, want 0 (no divide-by-zero)", rep.BlockRatePercent)
+	}
+	if len(rep.TopBlockedDomains) != 0 || len(rep.TopBlockedCategories) != 0 || len(rep.NotableEvents) != 0 {
+		t.Error("empty range should have no domains/categories/events")
+	}
+
+	text := report.RenderText(rep)
+	if !strings.Contains(text, "no DNS activity") {
+		t.Errorf("empty RenderText should mention no activity, got:\n%s", text)
+	}
+	html := report.RenderHTML(rep)
+	if !strings.Contains(html, "no DNS activity") {
+		t.Errorf("empty RenderHTML should mention no activity, got:\n%s", html)
+	}
+}
+
+func TestGenerate_NilRepo(t *testing.T) {
+	if _, err := report.Generate(nil, time.Now(), time.Now()); err == nil {
+		t.Error("Generate(nil, ...) should return an error")
+	}
+}

--- a/internal/storage/repositories/query_log.go
+++ b/internal/storage/repositories/query_log.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
+	"github.com/lopster568/phantomDNS/internal/report"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"gorm.io/gorm"
 )
@@ -66,6 +67,10 @@ type QueryLogRepository interface {
 	// window; delivery of the resulting digest is handled elsewhere.
 	GatherWindowStats(w AnalyticsWindow) (WindowStats, error)
 	AnomalyDigestBetween(current, prior AnalyticsWindow, cfg AnomalyThresholds) (AnomalyDigest, error)
+
+	// Aggregate computes period aggregates for the reporting engine. It
+	// satisfies report.Aggregator.
+	Aggregate(from, to time.Time, topN int) (report.Aggregates, error)
 }
 
 // Implementation

--- a/internal/storage/repositories/report_repo.go
+++ b/internal/storage/repositories/report_repo.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package repositories
+
+import (
+	"sort"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/report"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+)
+
+// Aggregate computes the period aggregates the reporting engine needs from the
+// DNS query log for the window [from, to] (inclusive). Blocked-category counts
+// are derived by matching blocked domains against the blocklist entries that
+// carry a category, so the query log itself does not need a category column.
+//
+// It satisfies report.Aggregator.
+func (r *GormQueryLogRepo) Aggregate(from, to time.Time, topN int) (report.Aggregates, error) {
+	if topN <= 0 {
+		topN = 5
+	}
+	var agg report.Aggregates
+
+	// Totals.
+	if err := r.db.Model(&models.DNSQuery{}).
+		Where("timestamp >= ? AND timestamp <= ?", from, to).
+		Count(&agg.TotalQueries).Error; err != nil {
+		return report.Aggregates{}, err
+	}
+	if err := r.db.Model(&models.DNSQuery{}).
+		Where("action = ? AND timestamp >= ? AND timestamp <= ?", "block", from, to).
+		Count(&agg.BlockedQueries).Error; err != nil {
+		return report.Aggregates{}, err
+	}
+	if err := r.db.Model(&models.DNSQuery{}).
+		Where("action = ? AND timestamp >= ? AND timestamp <= ?", "allow", from, to).
+		Count(&agg.AllowedQueries).Error; err != nil {
+		return report.Aggregates{}, err
+	}
+	// Threats blocked: blocked lookups flagged as suspicious.
+	if err := r.db.Model(&models.DNSQuery{}).
+		Where("action = ? AND is_suspicious = ? AND timestamp >= ? AND timestamp <= ?", "block", true, from, to).
+		Count(&agg.ThreatsBlocked).Error; err != nil {
+		return report.Aggregates{}, err
+	}
+
+	// Blocked domains with counts (all of them; we roll up categories in Go
+	// and slice the top-N for domains).
+	type domainRow struct {
+		Domain string
+		Count  int64
+	}
+	var blockedRows []domainRow
+	if err := r.db.Model(&models.DNSQuery{}).
+		Select("domain, count(*) as count").
+		Where("action = ? AND timestamp >= ? AND timestamp <= ?", "block", from, to).
+		Group("domain").
+		Find(&blockedRows).Error; err != nil {
+		return report.Aggregates{}, err
+	}
+
+	sort.SliceStable(blockedRows, func(i, j int) bool {
+		if blockedRows[i].Count != blockedRows[j].Count {
+			return blockedRows[i].Count > blockedRows[j].Count
+		}
+		return blockedRows[i].Domain < blockedRows[j].Domain
+	})
+	for i, row := range blockedRows {
+		if i >= topN {
+			break
+		}
+		agg.TopBlockedDomains = append(agg.TopBlockedDomains, report.DomainCount{
+			Domain: row.Domain,
+			Count:  row.Count,
+		})
+	}
+
+	// Categories: map each blocked domain to a blocklist category (if any),
+	// then sum block counts per category.
+	if len(blockedRows) > 0 {
+		domains := make([]string, 0, len(blockedRows))
+		for _, row := range blockedRows {
+			domains = append(domains, row.Domain)
+		}
+		var entries []models.BlocklistEntry
+		if err := r.db.
+			Where("domain IN ? AND category <> ''", domains).
+			Find(&entries).Error; err != nil {
+			return report.Aggregates{}, err
+		}
+		catByDomain := make(map[string]string, len(entries))
+		for _, e := range entries {
+			if _, ok := catByDomain[e.Domain]; !ok {
+				catByDomain[e.Domain] = e.Category
+			}
+		}
+		catCounts := make(map[string]int64)
+		for _, row := range blockedRows {
+			if cat, ok := catByDomain[row.Domain]; ok {
+				catCounts[cat] += row.Count
+			}
+		}
+		cats := make([]report.CategoryCount, 0, len(catCounts))
+		for cat, cnt := range catCounts {
+			cats = append(cats, report.CategoryCount{Category: cat, Count: cnt})
+		}
+		sort.SliceStable(cats, func(i, j int) bool {
+			if cats[i].Count != cats[j].Count {
+				return cats[i].Count > cats[j].Count
+			}
+			return cats[i].Category < cats[j].Category
+		})
+		if len(cats) > topN {
+			cats = cats[:topN]
+		}
+		agg.TopBlockedCategories = cats
+	}
+
+	// Notable events: the highest-scoring suspicious lookups in the window.
+	var events []models.DNSQuery
+	if err := r.db.
+		Where("is_suspicious = ? AND timestamp >= ? AND timestamp <= ?", true, from, to).
+		Order("threat_score desc, timestamp desc").
+		Limit(topN).
+		Find(&events).Error; err != nil {
+		return report.Aggregates{}, err
+	}
+	for _, e := range events {
+		reason := e.ThreatReason
+		if reason == "" {
+			reason = e.DetectionMethod
+		}
+		agg.NotableEvents = append(agg.NotableEvents, report.Event{
+			Timestamp:   e.Timestamp,
+			Domain:      e.Domain,
+			ClientIP:    e.ClientIP,
+			Reason:      reason,
+			ThreatScore: e.ThreatScore,
+			Blocked:     e.Action == "block",
+		})
+	}
+
+	return agg, nil
+}


### PR DESCRIPTION
## 📝 Description

First cut of a **plain-language reporting engine** (I-019). It turns the DNS query log into a friendly period report a non-technical operator can read at a glance — e.g. *"This week HydraDNS answered 12 DNS requests and blocked 7 of them (58.3%). That includes 5 ads and trackers and 2 malware and phishing attempts stopped before they reached your network."*

## 🧪 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test coverage improvement

## 🔍 Changes Made

**What / Why:** SMB/school operators want a readable summary, not a metrics dashboard. This produces one from data we already collect.

**How:**
- New package `internal/report`:
  - `Generate(repo, from, to) (Report, error)` — builds aggregates: totals, blocked count + block rate, top blocked domains, top blocked categories, threats blocked, and notable (suspicious) events. Classifies the window as weekly / trial / annual. Empty ranges return a valid zeroed report (no divide-by-zero).
  - `RenderText(Report)` and `RenderHTML(Report)` — friendly, non-technical summaries. HTML is minimal and self-contained; `html/template` escapes all values. No external deps (pure stdlib).
- Query-log repository gains an `Aggregate(from, to, topN)` method (satisfies `report.Aggregator`). Blocked-category counts are derived by matching blocked domains against blocklist entries that carry a category, so the query log needs no new column.
- Optional control-plane endpoint `GET /api/v1/reports?from=&to=&format=text|html` (also `json`); defaults to the last 7 days.

## 🧪 Testing

### Test Environment
- Go Version: 1.24.6
- Deployment Method: local

### Tests Performed
- [x] Unit tests pass (`go test ./...`)
- [x] `go build ./...`, `go vet ./...`, `gofmt` all clean

### Test Cases
1. `Generate` over seeded query-log rows produces the expected aggregates (totals, block rate, top domains/categories via blocklist join, threats, notable events), and excludes out-of-window rows.
2. `RenderText` / `RenderHTML` contain the key numbers (total, blocked, rate, ads, malware) and top-domain/category/event details.
3. Empty range is handled — zeroed report + a "no DNS activity" summary in both renderings.

Tests use a temp in-memory sqlite with fixed timestamps, so they are deterministic.

## 📚 Additional Notes

**PDF export is a documented follow-up.** Deliberately not added here to avoid pulling in a heavy PDF dependency; the structured `Report` + HTML rendering give a clean base for a print-to-PDF step later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
