### PR TITLE
feat: WhatsApp Business API notification sink (I-011, scaffold)

### DIFF
--- a/internal/notify/whatsapp/client.go
+++ b/internal/notify/whatsapp/client.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package whatsapp implements a notification sink backed by the Meta WhatsApp
+// Business Cloud API. It lets alert and report paths deliver messages over
+// WhatsApp by POSTing to https://graph.facebook.com/v.../{phone_number_id}/messages
+// with a bearer token.
+//
+// SCAFFOLDING: this integration is disabled by default and completely inert
+// until credentials are supplied. Actually delivering messages requires an
+// approved WhatsApp Business Account (WABA) and, for template messages, a
+// pre-approved message template. Until that approval is in place the notifier
+// is a no-op. The package is therefore fully unit-tested against a local
+// httptest server rather than the live Meta API.
+//
+// Configuration comes from three environment variables; if any is empty the
+// notifier is disabled and Notify does nothing:
+//
+//	WHATSAPP_TOKEN     bearer token for the WhatsApp Cloud API
+//	WHATSAPP_PHONE_ID  sender phone number ID
+//	WHATSAPP_TO        recipient phone number in E.164 form
+package whatsapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultAPIVersion is the Graph API version segment used when none is set.
+	defaultAPIVersion = "v20.0"
+	// defaultBaseURL is the Meta Graph API host. Overridable for testing.
+	defaultBaseURL = "https://graph.facebook.com"
+	// defaultTimeout bounds a single delivery attempt.
+	defaultTimeout = 10 * time.Second
+	// maxErrBody caps how much of an error response body we read back.
+	maxErrBody = 4096
+)
+
+// Notifier is the minimal contract alert and report paths use to send an
+// outbound message. Implementations must be safe for concurrent use and must
+// treat a disabled/unconfigured sink as a successful no-op.
+type Notifier interface {
+	// Notify sends a plain-text message. When the sink is disabled it returns
+	// nil without performing any I/O.
+	Notify(ctx context.Context, message string) error
+	// Enabled reports whether the notifier will actually deliver messages.
+	Enabled() bool
+}
+
+// Config holds the credentials and target for the WhatsApp Cloud API. All of
+// Token, PhoneID and To must be set for the notifier to be enabled; if any is
+// empty the notifier is a no-op.
+type Config struct {
+	Token   string // WHATSAPP_TOKEN
+	PhoneID string // WHATSAPP_PHONE_ID
+	To      string // WHATSAPP_TO
+
+	// APIVersion is the Graph API version segment, e.g. "v20.0". Defaults to
+	// defaultAPIVersion when empty.
+	APIVersion string
+	// BaseURL is the API host. Defaults to defaultBaseURL when empty. This is
+	// primarily an injection point for tests.
+	BaseURL string
+}
+
+// ConfigFromEnv builds a Config from WHATSAPP_TOKEN, WHATSAPP_PHONE_ID and
+// WHATSAPP_TO. When any of them is absent the resulting notifier is disabled.
+func ConfigFromEnv() Config {
+	return Config{
+		Token:   os.Getenv("WHATSAPP_TOKEN"),
+		PhoneID: os.Getenv("WHATSAPP_PHONE_ID"),
+		To:      os.Getenv("WHATSAPP_TO"),
+	}
+}
+
+// Enabled reports whether all required credentials are present.
+func (c Config) Enabled() bool {
+	return c.Token != "" && c.PhoneID != "" && c.To != ""
+}
+
+// Client is a WhatsApp Cloud API Notifier. Construct one with New or
+// NewFromEnv; the zero value is not usable.
+type Client struct {
+	cfg  Config
+	http *http.Client
+}
+
+// Compile-time assurance that *Client satisfies Notifier.
+var _ Notifier = (*Client)(nil)
+
+// New constructs a Client from cfg. When cfg is missing credentials the
+// returned Client is a valid no-op: Enabled reports false and Notify does
+// nothing. httpClient may be nil, in which case a client with a sane timeout
+// is used.
+func New(cfg Config, httpClient *http.Client) *Client {
+	if cfg.APIVersion == "" {
+		cfg.APIVersion = defaultAPIVersion
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = defaultBaseURL
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultTimeout}
+	}
+	return &Client{cfg: cfg, http: httpClient}
+}
+
+// NewFromEnv constructs a Client from environment variables. It never returns
+// an error: with no credentials configured the returned Client is a no-op,
+// which is the default (disabled) state pending WABA approval.
+func NewFromEnv() *Client {
+	return New(ConfigFromEnv(), nil)
+}
+
+// Enabled reports whether the client will actually deliver messages.
+func (c *Client) Enabled() bool {
+	return c.cfg.Enabled()
+}
+
+// endpoint returns the fully-qualified messages endpoint for the configured
+// phone number ID.
+func (c *Client) endpoint() string {
+	return fmt.Sprintf("%s/%s/%s/messages",
+		strings.TrimRight(c.cfg.BaseURL, "/"),
+		c.cfg.APIVersion,
+		c.cfg.PhoneID,
+	)
+}
+
+// --- request payload types -------------------------------------------------
+
+type textBody struct {
+	PreviewURL bool   `json:"preview_url"`
+	Body       string `json:"body"`
+}
+
+type templateLanguage struct {
+	Code string `json:"code"`
+}
+
+type templateParameter struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type templateComponent struct {
+	Type       string              `json:"type"`
+	Parameters []templateParameter `json:"parameters,omitempty"`
+}
+
+type templatePayload struct {
+	Name       string              `json:"name"`
+	Language   templateLanguage    `json:"language"`
+	Components []templateComponent `json:"components,omitempty"`
+}
+
+// message is the Cloud API /messages request body.
+type message struct {
+	MessagingProduct string           `json:"messaging_product"`
+	RecipientType    string           `json:"recipient_type,omitempty"`
+	To               string           `json:"to"`
+	Type             string           `json:"type"`
+	Text             *textBody        `json:"text,omitempty"`
+	Template         *templatePayload `json:"template,omitempty"`
+}
+
+// buildTextMessage assembles the request body for a plain-text message to the
+// configured recipient.
+func (c *Client) buildTextMessage(body string) message {
+	return message{
+		MessagingProduct: "whatsapp",
+		RecipientType:    "individual",
+		To:               c.cfg.To,
+		Type:             "text",
+		Text:             &textBody{PreviewURL: false, Body: body},
+	}
+}
+
+// buildTemplateMessage assembles the request body for a pre-approved template
+// message. langCode defaults to "en_US" when empty; bodyParams, when present,
+// are attached as text parameters of the template body component.
+func (c *Client) buildTemplateMessage(name, langCode string, bodyParams []string) message {
+	if langCode == "" {
+		langCode = "en_US"
+	}
+	tpl := &templatePayload{
+		Name:     name,
+		Language: templateLanguage{Code: langCode},
+	}
+	if len(bodyParams) > 0 {
+		params := make([]templateParameter, 0, len(bodyParams))
+		for _, p := range bodyParams {
+			params = append(params, templateParameter{Type: "text", Text: p})
+		}
+		tpl.Components = []templateComponent{{Type: "body", Parameters: params}}
+	}
+	return message{
+		MessagingProduct: "whatsapp",
+		To:               c.cfg.To,
+		Type:             "template",
+		Template:         tpl,
+	}
+}
+
+// --- delivery --------------------------------------------------------------
+
+// Notify sends msg as a WhatsApp text message. If the client is disabled
+// (missing credentials) it is a no-op and returns nil.
+func (c *Client) Notify(ctx context.Context, msg string) error {
+	if !c.Enabled() {
+		return nil
+	}
+	if strings.TrimSpace(msg) == "" {
+		return fmt.Errorf("whatsapp: empty message")
+	}
+	return c.post(ctx, c.buildTextMessage(msg))
+}
+
+// NotifyTemplate sends a pre-approved template message. If the client is
+// disabled it is a no-op and returns nil. This is the delivery path a real
+// WABA integration uses once a template has been approved by Meta.
+func (c *Client) NotifyTemplate(ctx context.Context, name, langCode string, bodyParams ...string) error {
+	if !c.Enabled() {
+		return nil
+	}
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("whatsapp: empty template name")
+	}
+	return c.post(ctx, c.buildTemplateMessage(name, langCode, bodyParams))
+}
+
+// post marshals m and POSTs it to the messages endpoint with the bearer token.
+func (c *Client) post(ctx context.Context, m message) error {
+	payload, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("whatsapp: marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint(), bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("whatsapp: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("whatsapp: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
+		return fmt.Errorf("whatsapp: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	// Drain the body so the underlying connection can be reused.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxErrBody))
+	return nil
+}

--- a/internal/notify/whatsapp/client_test.go
+++ b/internal/notify/whatsapp/client_test.go
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package whatsapp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func enabledConfig() Config {
+	return Config{
+		Token:   "test-token",
+		PhoneID: "1234567890",
+		To:      "919999999999",
+	}
+}
+
+func TestConfigEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"all set", Config{Token: "t", PhoneID: "p", To: "r"}, true},
+		{"empty", Config{}, false},
+		{"missing token", Config{PhoneID: "p", To: "r"}, false},
+		{"missing phone", Config{Token: "t", To: "r"}, false},
+		{"missing to", Config{Token: "t", PhoneID: "p"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.Enabled(); got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigFromEnv(t *testing.T) {
+	t.Setenv("WHATSAPP_TOKEN", "env-token")
+	t.Setenv("WHATSAPP_PHONE_ID", "env-phone")
+	t.Setenv("WHATSAPP_TO", "env-to")
+
+	cfg := ConfigFromEnv()
+	if cfg.Token != "env-token" || cfg.PhoneID != "env-phone" || cfg.To != "env-to" {
+		t.Fatalf("ConfigFromEnv() = %+v, want values from env", cfg)
+	}
+	if !cfg.Enabled() {
+		t.Errorf("Enabled() = false, want true")
+	}
+}
+
+func TestNewFromEnv_DisabledWithoutCreds(t *testing.T) {
+	t.Setenv("WHATSAPP_TOKEN", "")
+	t.Setenv("WHATSAPP_PHONE_ID", "")
+	t.Setenv("WHATSAPP_TO", "")
+
+	c := NewFromEnv()
+	if c.Enabled() {
+		t.Errorf("Enabled() = true, want false when no creds set")
+	}
+}
+
+func TestEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "defaults version",
+			cfg:  Config{PhoneID: "111", BaseURL: "https://graph.facebook.com"},
+			want: "https://graph.facebook.com/" + defaultAPIVersion + "/111/messages",
+		},
+		{
+			name: "explicit version",
+			cfg:  Config{PhoneID: "222", APIVersion: "v21.0", BaseURL: "https://example.test"},
+			want: "https://example.test/v21.0/222/messages",
+		},
+		{
+			name: "trims trailing slash on base url",
+			cfg:  Config{PhoneID: "333", APIVersion: "v20.0", BaseURL: "https://example.test/"},
+			want: "https://example.test/v20.0/333/messages",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New(tt.cfg, nil)
+			if got := c.endpoint(); got != tt.want {
+				t.Errorf("endpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildTextMessage(t *testing.T) {
+	c := New(enabledConfig(), nil)
+	m := c.buildTextMessage("hello world")
+
+	if m.MessagingProduct != "whatsapp" {
+		t.Errorf("MessagingProduct = %q, want whatsapp", m.MessagingProduct)
+	}
+	if m.RecipientType != "individual" {
+		t.Errorf("RecipientType = %q, want individual", m.RecipientType)
+	}
+	if m.To != "919999999999" {
+		t.Errorf("To = %q, want 919999999999", m.To)
+	}
+	if m.Type != "text" {
+		t.Errorf("Type = %q, want text", m.Type)
+	}
+	if m.Text == nil || m.Text.Body != "hello world" {
+		t.Errorf("Text = %+v, want body 'hello world'", m.Text)
+	}
+	if m.Template != nil {
+		t.Errorf("Template = %+v, want nil for a text message", m.Template)
+	}
+}
+
+func TestBuildTemplateMessage(t *testing.T) {
+	c := New(enabledConfig(), nil)
+
+	// No language -> default en_US, no params -> no components.
+	m := c.buildTemplateMessage("alert_tpl", "", nil)
+	if m.Type != "template" {
+		t.Fatalf("Type = %q, want template", m.Type)
+	}
+	if m.Template == nil {
+		t.Fatalf("Template = nil, want non-nil")
+	}
+	if m.Template.Name != "alert_tpl" {
+		t.Errorf("Template.Name = %q, want alert_tpl", m.Template.Name)
+	}
+	if m.Template.Language.Code != "en_US" {
+		t.Errorf("Language.Code = %q, want en_US (default)", m.Template.Language.Code)
+	}
+	if len(m.Template.Components) != 0 {
+		t.Errorf("Components = %+v, want empty", m.Template.Components)
+	}
+
+	// Explicit language + body params -> body component with text params.
+	m2 := c.buildTemplateMessage("report_tpl", "en", []string{"one", "two"})
+	if m2.Template.Language.Code != "en" {
+		t.Errorf("Language.Code = %q, want en", m2.Template.Language.Code)
+	}
+	if len(m2.Template.Components) != 1 {
+		t.Fatalf("Components len = %d, want 1", len(m2.Template.Components))
+	}
+	comp := m2.Template.Components[0]
+	if comp.Type != "body" {
+		t.Errorf("Component.Type = %q, want body", comp.Type)
+	}
+	if len(comp.Parameters) != 2 {
+		t.Fatalf("Parameters len = %d, want 2", len(comp.Parameters))
+	}
+	if comp.Parameters[0].Type != "text" || comp.Parameters[0].Text != "one" {
+		t.Errorf("Parameters[0] = %+v, want {text, one}", comp.Parameters[0])
+	}
+}
+
+func TestNotify_PostsWithAuthHeader(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotAuth   string
+		gotCT     string
+		gotBody   message
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotCT = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"messages":[{"id":"wamid.TEST"}]}`))
+	}))
+	defer srv.Close()
+
+	cfg := enabledConfig()
+	cfg.BaseURL = srv.URL
+	cfg.APIVersion = "v20.0"
+	c := New(cfg, srv.Client())
+
+	if err := c.Notify(context.Background(), "queries blocked spike detected"); err != nil {
+		t.Fatalf("Notify() error = %v, want nil", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if want := "/v20.0/1234567890/messages"; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+	if want := "Bearer test-token"; gotAuth != want {
+		t.Errorf("Authorization = %q, want %q", gotAuth, want)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+	if gotBody.To != "919999999999" || gotBody.Type != "text" {
+		t.Errorf("body = %+v, want To=919999999999 Type=text", gotBody)
+	}
+	if gotBody.Text == nil || gotBody.Text.Body != "queries blocked spike detected" {
+		t.Errorf("body.Text = %+v, want the sent message", gotBody.Text)
+	}
+}
+
+func TestNotifyTemplate_PostsTemplatePayload(t *testing.T) {
+	var gotBody message
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := enabledConfig()
+	cfg.BaseURL = srv.URL
+	c := New(cfg, srv.Client())
+
+	if err := c.NotifyTemplate(context.Background(), "daily_report", "en_US", "42"); err != nil {
+		t.Fatalf("NotifyTemplate() error = %v, want nil", err)
+	}
+	if gotBody.Type != "template" || gotBody.Template == nil {
+		t.Fatalf("body = %+v, want a template message", gotBody)
+	}
+	if gotBody.Template.Name != "daily_report" {
+		t.Errorf("Template.Name = %q, want daily_report", gotBody.Template.Name)
+	}
+	if len(gotBody.Template.Components) != 1 || len(gotBody.Template.Components[0].Parameters) != 1 {
+		t.Fatalf("Components = %+v, want one body param", gotBody.Template.Components)
+	}
+}
+
+func TestNotify_Disabled_NoOp(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// No credentials => disabled. Point BaseURL at the server to prove it is
+	// never contacted.
+	cfg := Config{BaseURL: srv.URL}
+	c := New(cfg, srv.Client())
+
+	if c.Enabled() {
+		t.Fatalf("Enabled() = true, want false")
+	}
+	if err := c.Notify(context.Background(), "should not send"); err != nil {
+		t.Errorf("Notify() error = %v, want nil (no-op)", err)
+	}
+	if err := c.NotifyTemplate(context.Background(), "tpl", "en_US"); err != nil {
+		t.Errorf("NotifyTemplate() error = %v, want nil (no-op)", err)
+	}
+	if called {
+		t.Errorf("server was contacted, want no I/O when disabled")
+	}
+}
+
+func TestNotify_EmptyMessage(t *testing.T) {
+	c := New(enabledConfig(), nil)
+	err := c.Notify(context.Background(), "   ")
+	if err == nil || !strings.Contains(err.Error(), "empty message") {
+		t.Errorf("Notify(empty) error = %v, want empty message error", err)
+	}
+}
+
+func TestNotifyTemplate_EmptyName(t *testing.T) {
+	c := New(enabledConfig(), nil)
+	err := c.NotifyTemplate(context.Background(), "  ", "en_US")
+	if err == nil || !strings.Contains(err.Error(), "empty template name") {
+		t.Errorf("NotifyTemplate(empty) error = %v, want empty template name error", err)
+	}
+}
+
+func TestNotify_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid token"}}`))
+	}))
+	defer srv.Close()
+
+	cfg := enabledConfig()
+	cfg.BaseURL = srv.URL
+	c := New(cfg, srv.Client())
+
+	err := c.Notify(context.Background(), "hello")
+	if err == nil {
+		t.Fatalf("Notify() error = nil, want non-nil on 401")
+	}
+	if !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "invalid token") {
+		t.Errorf("error = %v, want it to mention status 401 and body", err)
+	}
+}
+
+func TestNotify_TransportError(t *testing.T) {
+	// Server is closed immediately so the request fails at the transport layer.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	client := srv.Client()
+	srv.Close()
+
+	cfg := enabledConfig()
+	cfg.BaseURL = srv.URL
+	c := New(cfg, client)
+
+	err := c.Notify(context.Background(), "hello")
+	if err == nil || !strings.Contains(err.Error(), "send request") {
+		t.Errorf("Notify() error = %v, want a send request error", err)
+	}
+}


### PR DESCRIPTION
## What
Adds `internal/notify/whatsapp`: a notification sink backed by the Meta WhatsApp Business (Cloud) API, so alert and report paths can deliver messages over WhatsApp.

- `Notifier` interface (`Notify(ctx, message)` + `Enabled()`) for callers to depend on.
- `Client` that POSTs to `https://graph.facebook.com/v.../{phone_number_id}/messages` with a bearer token.
- Text messages (`Notify`) and pre-approved template messages (`NotifyTemplate`).
- Config from `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_ID`, `WHATSAPP_TO` via `ConfigFromEnv` / `NewFromEnv`.

## Why
Indian SMBs, schools and hospitals live on WhatsApp; delivering security alerts and daily reports there is far more actionable than email. This lands the integration wiring now so it can be switched on with credentials once approved.

## How
- `Config.Enabled()` requires all three of token, phone ID and recipient; if any is empty the sink is a no-op.
- Graph API version (default `v20.0`) and base URL are overridable, the latter purely as a test injection point.
- `post()` marshals the payload, sets `Authorization: Bearer <token>` and `Content-Type: application/json`, and treats non-2xx as an error (surfacing status + body).
- No existing code paths are modified; the Notifier is exposed for later wiring to keep scope tight.

## Tests
Hermetic, no real Meta API — an `httptest` server stands in:
- Text payload shape (`messaging_product`, `recipient_type`, `to`, `type`, `text.body`).
- Template payload shape (name, language default `en_US`, body component parameters).
- POST hits the right path with the correct bearer + content-type headers.
- Disabled (no creds) = no-op, server never contacted.
- Error handling: empty message, empty template name, non-2xx response, transport failure.
- `Enabled()` matrix and `ConfigFromEnv` env parsing.

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green.

## Note
**Scaffolding.** This is disabled by default and completely inert without credentials. Actually delivering messages requires an approved WhatsApp Business Account (WABA) and, for templates, a pre-approved message template from Meta. The sink stays a no-op until that approval is in place and credentials are configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)