### PR TITLE
feat(controlplane): read-only MSP fleet status aggregator (I-055, first cut)

### DIFF
--- a/cmd/controlplane/handlers/blocklists_test.go
+++ b/cmd/controlplane/handlers/blocklists_test.go
@@ -47,7 +47,7 @@ func newTestHandler(t *testing.T) *APIHandler {
 	); err != nil {
 		t.Fatalf("migrate failed: %v", err)
 	}
-	return NewAPIHandler(*repositories.NewStore(db), nil, nil, nil)
+	return NewAPIHandler(*repositories.NewStore(db), nil, nil, nil, nil, "")
 }
 
 func newTestRouter(h *APIHandler) *gin.Engine {

--- a/cmd/controlplane/handlers/categories_test.go
+++ b/cmd/controlplane/handlers/categories_test.go
@@ -38,7 +38,7 @@ func newCatalogTestHandler(t *testing.T) *APIHandler {
 	); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	return NewAPIHandler(*repositories.NewStore(db), nil, nil, nil)
+	return NewAPIHandler(*repositories.NewStore(db), nil, nil, nil, nil, "")
 }
 
 func newCatalogRouter(h *APIHandler) *gin.Engine {

--- a/cmd/controlplane/handlers/config_test.go
+++ b/cmd/controlplane/handlers/config_test.go
@@ -53,7 +53,7 @@ func newConfigTestServer(t *testing.T) (*gin.Engine, *repositories.Store) {
 	store := repositories.NewStore(db)
 	// DataPlaneClient and Inventory are nil: import persists and skips the
 	// best-effort reload; handlers must treat a nil Inventory as empty.
-	h := NewAPIHandler(*store, nil, nil, nil)
+	h := NewAPIHandler(*store, nil, nil, nil, nil, "")
 
 	r := gin.New()
 	api := r.Group("/api/v1")

--- a/cmd/controlplane/handlers/dns_test.go
+++ b/cmd/controlplane/handlers/dns_test.go
@@ -39,7 +39,7 @@ func newTestResolverHandler(t *testing.T) (*gin.Engine, *APIHandler) {
 
 	// DataPlaneClient is nil: handlers persist-only, apply is a no-op (documented).
 	store := repositories.Store{Resolvers: repositories.NewResolverRepo(db)}
-	h := NewAPIHandler(store, nil, nil, nil)
+	h := NewAPIHandler(store, nil, nil, nil, nil, "")
 
 	r := gin.New()
 	dns := r.Group("/api/v1/dns")

--- a/cmd/controlplane/handlers/fleet.go
+++ b/cmd/controlplane/handlers/fleet.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lopster568/phantomDNS/internal/fleet"
+)
+
+// ResponseFleet is the consolidated fleet view response.
+type ResponseFleet struct {
+	Status string          `json:"status"`
+	Data   fleet.FleetView `json:"data"`
+	Error  *string         `json:"error"`
+}
+
+// PostFleetHeartbeat handles POST /fleet/heartbeat.
+//
+// A reporting box submits aggregate metadata (no query contents). The route is
+// authenticated with the dedicated fleet heartbeat token, not the admin key.
+func (h *APIHandler) PostFleetHeartbeat(c *gin.Context) {
+	if h.Fleet == nil {
+		errMsg := "fleet aggregator disabled"
+		c.JSON(http.StatusServiceUnavailable, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+
+	var hb fleet.Heartbeat
+	if err := c.ShouldBindJSON(&hb); err != nil {
+		errMsg := "invalid heartbeat payload — site_id is required"
+		c.JSON(http.StatusBadRequest, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+
+	h.Fleet.Record(hb)
+	c.JSON(http.StatusOK, ResponseGeneric{
+		Status: "success",
+		Data:   gin.H{"site_id": hb.SiteID, "accepted": true},
+	})
+}
+
+// GetFleet handles GET /fleet — the consolidated, read-only fleet view. This
+// route is admin-only (gated by the global auth middleware).
+func (h *APIHandler) GetFleet(c *gin.Context) {
+	if h.Fleet == nil {
+		errMsg := "fleet aggregator disabled"
+		c.JSON(http.StatusServiceUnavailable, ResponseGeneric{Status: "error", Error: &errMsg})
+		return
+	}
+
+	c.JSON(http.StatusOK, ResponseFleet{
+		Status: "success",
+		Data:   h.Fleet.Snapshot(),
+	})
+}

--- a/cmd/controlplane/handlers/fleet_test.go
+++ b/cmd/controlplane/handlers/fleet_test.go
@@ -1,0 +1,155 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/lopster568/phantomDNS/cmd/controlplane/handlers"
+	"github.com/lopster568/phantomDNS/cmd/controlplane/middlewares"
+	"github.com/lopster568/phantomDNS/cmd/controlplane/routes"
+	"github.com/lopster568/phantomDNS/internal/fleet"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+const (
+	testAdminToken = "admin-token-123"
+	testBoxToken   = "box-token-abc"
+)
+
+// newFleetTestServer wires the real router and global auth middleware over an
+// in-memory DB, exactly as main.go does, so the tests exercise real auth flow.
+func newFleetTestServer(t *testing.T) (*gin.Engine, *fleet.Store) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.AdminCredential{}, &models.Statistics{}, &models.DNSQuery{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	repos := repositories.NewStore(db)
+	// Complete setup so the global auth middleware is active (not in setup mode).
+	if err := repos.Auth.CreateAdmin("hash", testAdminToken); err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+
+	store := fleet.NewStore(90*time.Second, nil)
+	h := handlers.NewAPIHandler(*repos, nil, nil, nil, store, testBoxToken)
+
+	r := gin.New()
+	r.Use(middlewares.Auth(repos.Auth))
+	routes.RegisterRoutes(r, h)
+	return r, store
+}
+
+func do(r *gin.Engine, method, path, token string, body []byte) *httptest.ResponseRecorder {
+	var rdr *bytes.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	} else {
+		rdr = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestFleetHeartbeat_IngestsAndConsolidates(t *testing.T) {
+	r, _ := newFleetTestServer(t)
+
+	// Box posts a heartbeat using the dedicated box token.
+	body, _ := json.Marshal(fleet.Heartbeat{SiteID: "box-1", Name: "Clinic A", QPS: 15, BlockedPercent: 9})
+	w := do(r, http.MethodPost, "/api/v1/fleet/heartbeat", testBoxToken, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("heartbeat: status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	// Admin pulls the consolidated view.
+	w = do(r, http.MethodGet, "/api/v1/fleet", testAdminToken, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get fleet: status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp handlers.ResponseFleet
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Data.Total != 1 || len(resp.Data.Sites) != 1 {
+		t.Fatalf("expected 1 site, got %+v", resp.Data)
+	}
+	site := resp.Data.Sites[0]
+	if site.SiteID != "box-1" || site.Name != "Clinic A" || site.Status != fleet.StatusUp {
+		t.Errorf("unexpected consolidated site: %+v", site)
+	}
+	if site.QPS != 15 || site.BlockedPercent != 9 {
+		t.Errorf("metadata mismatch: %+v", site)
+	}
+}
+
+func TestFleetHeartbeat_AuthRequired(t *testing.T) {
+	r, store := newFleetTestServer(t)
+
+	// Missing box token -> rejected, nothing ingested.
+	body, _ := json.Marshal(fleet.Heartbeat{SiteID: "box-1"})
+	w := do(r, http.MethodPost, "/api/v1/fleet/heartbeat", "", body)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no token: status = %d, want 401", w.Code)
+	}
+
+	// Wrong box token -> rejected.
+	w = do(r, http.MethodPost, "/api/v1/fleet/heartbeat", "wrong", body)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("wrong token: status = %d, want 401", w.Code)
+	}
+
+	// The admin key must NOT work as a box token on the heartbeat endpoint.
+	w = do(r, http.MethodPost, "/api/v1/fleet/heartbeat", testAdminToken, body)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("admin token on heartbeat: status = %d, want 401", w.Code)
+	}
+
+	if got := store.Snapshot().Total; got != 0 {
+		t.Errorf("expected no sites ingested on failed auth, got %d", got)
+	}
+}
+
+func TestFleet_GetRequiresAdmin(t *testing.T) {
+	r, _ := newFleetTestServer(t)
+
+	// No token -> global admin auth rejects.
+	w := do(r, http.MethodGet, "/api/v1/fleet", "", nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no token: status = %d, want 401", w.Code)
+	}
+
+	// Box token is not the admin key -> rejected.
+	w = do(r, http.MethodGet, "/api/v1/fleet", testBoxToken, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("box token on admin view: status = %d, want 401", w.Code)
+	}
+
+	// Admin token -> allowed.
+	w = do(r, http.MethodGet, "/api/v1/fleet", testAdminToken, nil)
+	if w.Code != http.StatusOK {
+		t.Errorf("admin token: status = %d, want 200", w.Code)
+	}
+}

--- a/cmd/controlplane/handlers/handlers.go
+++ b/cmd/controlplane/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/lopster568/phantomDNS/internal/blocklist"
+	"github.com/lopster568/phantomDNS/internal/fleet"
 	client "github.com/lopster568/phantomDNS/internal/grpc/controlplane"
 	"github.com/lopster568/phantomDNS/internal/inventory"
 	"github.com/lopster568/phantomDNS/internal/policy"
@@ -25,6 +26,11 @@ type APIHandler struct {
 	// endpoints. It defaults to blocklist.DefaultCatalog() and is a field so tests can
 	// substitute feeds pointing at local servers.
 	Catalog *blocklist.Catalog
+
+	// Fleet is the optional MSP fleet-status aggregator. It is nil unless the
+	// feature is opted in; routes check for nil before registering.
+	Fleet               *fleet.Store
+	FleetHeartbeatToken string
 }
 
 func NewAPIHandler(
@@ -32,13 +38,17 @@ func NewAPIHandler(
 	dataPlaneClient *client.Client,
 	deviceInventory *inventory.Inventory,
 	policyEngine *policy.Engine,
+	fleetStore *fleet.Store,
+	fleetHeartbeatToken string,
 ) *APIHandler {
 	return &APIHandler{
-		Store:           store,
-		DataPlaneClient: dataPlaneClient,
-		Inventory:       deviceInventory,
-		PolicyEngine:    policyEngine,
-		Catalog:         blocklist.DefaultCatalog(),
+		Store:               store,
+		DataPlaneClient:     dataPlaneClient,
+		Inventory:           deviceInventory,
+		PolicyEngine:        policyEngine,
+		Catalog:             blocklist.DefaultCatalog(),
+		Fleet:               fleetStore,
+		FleetHeartbeatToken: fleetHeartbeatToken,
 	}
 }
 

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lopster568/phantomDNS/cmd/controlplane/middlewares"
 	"github.com/lopster568/phantomDNS/cmd/controlplane/routes"
 	"github.com/lopster568/phantomDNS/internal/config"
+	"github.com/lopster568/phantomDNS/internal/fleet"
 	client "github.com/lopster568/phantomDNS/internal/grpc/controlplane"
 	"github.com/lopster568/phantomDNS/internal/inventory"
 	"github.com/lopster568/phantomDNS/internal/license"
@@ -94,8 +95,23 @@ func main() {
 		_ = policyEngine.LoadPolicies(engPolicies)
 	}
 
+	// Optional MSP fleet aggregator (opt-in, OFF by default). Only wired up
+	// when explicitly enabled with a heartbeat token; otherwise the routes are
+	// never registered.
+	var fleetStore *fleet.Store
+	fleetCfg := fleet.LoadConfig()
+	if fleetCfg.Enabled {
+		if fleetCfg.HeartbeatToken == "" {
+			log.Println("fleet aggregator enabled but FLEET_HEARTBEAT_TOKEN is empty — feature disabled")
+			fleetCfg.Enabled = false
+		} else {
+			fleetStore = fleet.NewStore(fleetCfg.StaleAfter, nil)
+			log.Printf("fleet aggregator enabled (stale after %s)", fleetCfg.StaleAfter)
+		}
+	}
+
 	// Initialize Gin router
-	apiHandler := handlers.NewAPIHandler(*repos, c, deviceInventory, policyEngine)
+	apiHandler := handlers.NewAPIHandler(*repos, c, deviceInventory, policyEngine, fleetStore, fleetCfg.HeartbeatToken)
 	r := gin.Default()
 	r.Use(middlewares.Logger())
 

--- a/cmd/controlplane/middlewares/auth.go
+++ b/cmd/controlplane/middlewares/auth.go
@@ -8,13 +8,17 @@ import (
 )
 
 func Auth(authRepo repositories.AuthRepository) gin.HandlerFunc {
-	// Paths that don't require authentication
+	// Paths that don't require admin authentication. The fleet heartbeat is
+	// exempt because it is authenticated separately with a dedicated box token
+	// (see internal/fleet.RequireHeartbeatToken) and never accepts the admin
+	// API key. It is only reachable when the opt-in fleet feature registers it.
 	exemptPaths := map[string]bool{
-		"/health":             true,
-		"/":                   true,
-		"/api/v1/auth/status": true,
-		"/api/v1/auth/login":  true,
-		"/api/v1/auth/setup":  true,
+		"/health":                 true,
+		"/":                       true,
+		"/api/v1/auth/status":     true,
+		"/api/v1/auth/login":      true,
+		"/api/v1/auth/setup":      true,
+		"/api/v1/fleet/heartbeat": true,
 	}
 
 	return func(c *gin.Context) {

--- a/cmd/controlplane/routes/router.go
+++ b/cmd/controlplane/routes/router.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/lopster568/phantomDNS/cmd/controlplane/handlers"
+	"github.com/lopster568/phantomDNS/internal/fleet"
 )
 
 func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
@@ -100,5 +101,19 @@ func RegisterRoutes(r *gin.Engine, apiHandler *handlers.APIHandler) {
 
 		// Reporting endpoint — plain-language period report (text/html/json)
 		api.GET("/reports", apiHandler.GetReport)
+
+		// Fleet endpoints (opt-in — only registered when the aggregator is on).
+		// POST /fleet/heartbeat authenticates with the dedicated fleet token
+		// (exempt from the global admin auth); GET /fleet is admin-only and
+		// stays gated by the global auth middleware.
+		if apiHandler.Fleet != nil {
+			fleetGroup := api.Group("/fleet")
+			{
+				fleetGroup.POST("/heartbeat",
+					fleet.RequireHeartbeatToken(apiHandler.FleetHeartbeatToken),
+					apiHandler.PostFleetHeartbeat)
+				fleetGroup.GET("", apiHandler.GetFleet)
+			}
+		}
 	}
 }

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package fleet
+
+import (
+	"os"
+	"time"
+)
+
+// Config controls the opt-in MSP fleet aggregator. The feature is OFF by
+// default: it only activates when explicitly enabled and given a heartbeat
+// token that reporting boxes must present.
+type Config struct {
+	Enabled        bool
+	HeartbeatToken string
+	StaleAfter     time.Duration
+}
+
+// LoadConfig reads fleet configuration from the environment:
+//
+//	FLEET_ENABLED          "true" to opt in (default off)
+//	FLEET_HEARTBEAT_TOKEN  shared token boxes present on /fleet/heartbeat
+//	FLEET_STALE_AFTER      Go duration, e.g. "90s" (default 90s)
+func LoadConfig() Config {
+	c := Config{StaleAfter: DefaultStaleAfter}
+
+	if os.Getenv("FLEET_ENABLED") == "true" {
+		c.Enabled = true
+	}
+	c.HeartbeatToken = os.Getenv("FLEET_HEARTBEAT_TOKEN")
+	if v := os.Getenv("FLEET_STALE_AFTER"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			c.StaleAfter = d
+		}
+	}
+	return c
+}

--- a/internal/fleet/middleware.go
+++ b/internal/fleet/middleware.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package fleet
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const bearerPrefix = "Bearer "
+
+// RequireHeartbeatToken guards the heartbeat endpoint. Boxes authenticate with
+// a dedicated fleet token (Authorization: Bearer <token>) rather than the admin
+// API key, so appliance credentials stay separate from operator credentials.
+//
+// An empty token means the feature is not usable, so requests are refused.
+func RequireHeartbeatToken(token string) gin.HandlerFunc {
+	want := []byte(token)
+	return func(c *gin.Context) {
+		if len(want) == 0 {
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{
+				"status": "error",
+				"error":  "fleet heartbeat disabled — no token configured",
+			})
+			return
+		}
+
+		auth := c.GetHeader("Authorization")
+		if !strings.HasPrefix(auth, bearerPrefix) ||
+			subtle.ConstantTimeCompare([]byte(strings.TrimPrefix(auth, bearerPrefix)), want) != 1 {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"status": "error",
+				"error":  "unauthorized — provide Authorization: Bearer <heartbeat-token>",
+			})
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/fleet/middleware_test.go
+++ b/internal/fleet/middleware_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package fleet
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+func newAuthEngine(token string) *gin.Engine {
+	r := gin.New()
+	r.POST("/hb", RequireHeartbeatToken(token), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "success"})
+	})
+	return r
+}
+
+func TestRequireHeartbeatToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		authHeader string
+		wantStatus int
+	}{
+		{"valid token", "s3cret", "Bearer s3cret", http.StatusOK},
+		{"missing header", "s3cret", "", http.StatusUnauthorized},
+		{"wrong token", "s3cret", "Bearer nope", http.StatusUnauthorized},
+		{"no bearer prefix", "s3cret", "s3cret", http.StatusUnauthorized},
+		{"disabled (empty token)", "", "Bearer anything", http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newAuthEngine(tt.token)
+			req := httptest.NewRequest(http.MethodPost, "/hb", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/fleet/store.go
+++ b/internal/fleet/store.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package fleet implements a minimal, read-only MSP fleet-status aggregator.
+//
+// Boxes (deployed appliances) periodically POST aggregate heartbeat metadata —
+// last-seen, QPS, blocked percentage, blocklist freshness and active alerts —
+// and an operator can pull a consolidated per-site view. Only aggregate
+// metadata is stored; query contents (domains, client IPs) are never accepted,
+// keeping the feature custody-safe.
+//
+// The store is in-memory and keyed by site id. It is safe for concurrent use
+// and takes an injectable clock so stale detection is deterministic in tests.
+package fleet
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Site status values.
+const (
+	StatusUp   = "up"
+	StatusDown = "down"
+)
+
+// Heartbeat is the aggregate metadata a box reports on each check-in. It
+// deliberately carries no query contents — only counters and freshness markers.
+type Heartbeat struct {
+	SiteID             string     `json:"site_id" binding:"required"`
+	Name               string     `json:"name,omitempty"`
+	Version            string     `json:"version,omitempty"`
+	QPS                float64    `json:"qps"`
+	BlockedPercent     float64    `json:"blocked_percent"`
+	BlocklistUpdatedAt *time.Time `json:"blocklist_updated_at,omitempty"`
+	Alerts             []string   `json:"alerts,omitempty"`
+}
+
+// Site is the consolidated per-site view returned to operators.
+type Site struct {
+	SiteID              string     `json:"site_id"`
+	Name                string     `json:"name,omitempty"`
+	Version             string     `json:"version,omitempty"`
+	Status              string     `json:"status"` // "up" or "down"
+	LastSeen            time.Time  `json:"last_seen"`
+	LastSeenAgeSeconds  int64      `json:"last_seen_age_seconds"`
+	QPS                 float64    `json:"qps"`
+	BlockedPercent      float64    `json:"blocked_percent"`
+	BlocklistUpdatedAt  *time.Time `json:"blocklist_updated_at,omitempty"`
+	BlocklistAgeSeconds *int64     `json:"blocklist_age_seconds,omitempty"`
+	Alerts              []string   `json:"alerts,omitempty"`
+}
+
+// FleetView is the consolidated fleet snapshot.
+type FleetView struct {
+	GeneratedAt       time.Time `json:"generated_at"`
+	StaleAfterSeconds int64     `json:"stale_after_seconds"`
+	Total             int       `json:"total"`
+	Up                int       `json:"up"`
+	Down              int       `json:"down"`
+	Sites             []Site    `json:"sites"`
+}
+
+type record struct {
+	hb       Heartbeat
+	lastSeen time.Time
+}
+
+// Store is an in-memory, concurrency-safe registry of site statuses keyed by
+// site id.
+type Store struct {
+	mu         sync.RWMutex
+	sites      map[string]record
+	staleAfter time.Duration
+	now        func() time.Time
+}
+
+// DefaultStaleAfter is the default no-heartbeat window before a site is
+// considered down (3x a 30s heartbeat interval).
+const DefaultStaleAfter = 90 * time.Second
+
+// NewStore creates a Store. A site with no heartbeat within staleAfter is
+// reported down. now supplies the clock and may be nil (defaults to time.Now);
+// injecting it makes stale detection deterministic in tests.
+func NewStore(staleAfter time.Duration, now func() time.Time) *Store {
+	if staleAfter <= 0 {
+		staleAfter = DefaultStaleAfter
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &Store{
+		sites:      make(map[string]record),
+		staleAfter: staleAfter,
+		now:        now,
+	}
+}
+
+// Record ingests a heartbeat, creating or updating the site keyed by SiteID.
+// The last-seen time is stamped from the store clock, not the payload, so a box
+// cannot backdate or forward-date itself.
+func (s *Store) Record(hb Heartbeat) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sites[hb.SiteID] = record{hb: hb, lastSeen: s.now()}
+}
+
+// Snapshot returns the consolidated fleet view. Sites are ordered by id for
+// deterministic output; each is flagged up or down based on the store clock.
+func (s *Store) Snapshot() FleetView {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := s.now()
+	sites := make([]Site, 0, len(s.sites))
+	up, down := 0, 0
+
+	for _, r := range s.sites {
+		age := now.Sub(r.lastSeen)
+		status := StatusUp
+		if age > s.staleAfter {
+			status = StatusDown
+			down++
+		} else {
+			up++
+		}
+
+		sv := Site{
+			SiteID:             r.hb.SiteID,
+			Name:               r.hb.Name,
+			Version:            r.hb.Version,
+			Status:             status,
+			LastSeen:           r.lastSeen,
+			LastSeenAgeSeconds: int64(age.Seconds()),
+			QPS:                r.hb.QPS,
+			BlockedPercent:     r.hb.BlockedPercent,
+			Alerts:             r.hb.Alerts,
+		}
+		if r.hb.BlocklistUpdatedAt != nil {
+			t := *r.hb.BlocklistUpdatedAt
+			sv.BlocklistUpdatedAt = &t
+			secs := int64(now.Sub(t).Seconds())
+			sv.BlocklistAgeSeconds = &secs
+		}
+		sites = append(sites, sv)
+	}
+
+	sort.Slice(sites, func(i, j int) bool { return sites[i].SiteID < sites[j].SiteID })
+
+	return FleetView{
+		GeneratedAt:       now,
+		StaleAfterSeconds: int64(s.staleAfter.Seconds()),
+		Total:             len(sites),
+		Up:                up,
+		Down:              down,
+		Sites:             sites,
+	}
+}

--- a/internal/fleet/store_test.go
+++ b/internal/fleet/store_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package fleet
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeClock is a deterministic, mutable clock for tests.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.t }
+func (c *fakeClock) Advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newTestStore(stale time.Duration) (*Store, *fakeClock) {
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	return NewStore(stale, clk.Now), clk
+}
+
+func TestStore_RecordUpdatesSite(t *testing.T) {
+	s, _ := newTestStore(90 * time.Second)
+
+	s.Record(Heartbeat{SiteID: "box-1", Name: "Clinic A", QPS: 12.5, BlockedPercent: 8.0})
+
+	view := s.Snapshot()
+	if view.Total != 1 {
+		t.Fatalf("expected 1 site, got %d", view.Total)
+	}
+	site := view.Sites[0]
+	if site.SiteID != "box-1" || site.Name != "Clinic A" {
+		t.Fatalf("unexpected site identity: %+v", site)
+	}
+	if site.QPS != 12.5 || site.BlockedPercent != 8.0 {
+		t.Errorf("metadata not stored: qps=%v blocked=%v", site.QPS, site.BlockedPercent)
+	}
+	if site.Status != StatusUp {
+		t.Errorf("expected fresh site to be up, got %q", site.Status)
+	}
+
+	// A second heartbeat for the same id updates in place (no duplicate).
+	s.Record(Heartbeat{SiteID: "box-1", QPS: 20})
+	view = s.Snapshot()
+	if view.Total != 1 {
+		t.Fatalf("expected same site updated, got %d sites", view.Total)
+	}
+	if view.Sites[0].QPS != 20 {
+		t.Errorf("expected updated qps 20, got %v", view.Sites[0].QPS)
+	}
+}
+
+func TestStore_SnapshotConsolidatedView(t *testing.T) {
+	s, _ := newTestStore(90 * time.Second)
+
+	s.Record(Heartbeat{SiteID: "box-b"})
+	s.Record(Heartbeat{SiteID: "box-a"})
+	s.Record(Heartbeat{SiteID: "box-c"})
+
+	view := s.Snapshot()
+	if view.Total != 3 || view.Up != 3 || view.Down != 0 {
+		t.Fatalf("unexpected counts: total=%d up=%d down=%d", view.Total, view.Up, view.Down)
+	}
+	// Deterministic ordering by site id.
+	want := []string{"box-a", "box-b", "box-c"}
+	for i, id := range want {
+		if view.Sites[i].SiteID != id {
+			t.Errorf("site %d: expected %q, got %q", i, id, view.Sites[i].SiteID)
+		}
+	}
+	if view.StaleAfterSeconds != 90 {
+		t.Errorf("expected stale_after 90s, got %d", view.StaleAfterSeconds)
+	}
+}
+
+func TestStore_StaleDetectionFlipsToDown(t *testing.T) {
+	s, clk := newTestStore(90 * time.Second)
+
+	s.Record(Heartbeat{SiteID: "box-1"})
+
+	// Still within the window: up.
+	clk.Advance(60 * time.Second)
+	if got := s.Snapshot().Sites[0].Status; got != StatusUp {
+		t.Fatalf("expected up within window, got %q", got)
+	}
+
+	// Past the stale threshold: flips to down.
+	clk.Advance(60 * time.Second) // total 120s > 90s
+	view := s.Snapshot()
+	if got := view.Sites[0].Status; got != StatusDown {
+		t.Fatalf("expected down after stale window, got %q", got)
+	}
+	if view.Up != 0 || view.Down != 1 {
+		t.Errorf("expected up=0 down=1, got up=%d down=%d", view.Up, view.Down)
+	}
+
+	// A fresh heartbeat revives it.
+	s.Record(Heartbeat{SiteID: "box-1"})
+	if got := s.Snapshot().Sites[0].Status; got != StatusUp {
+		t.Errorf("expected up after fresh heartbeat, got %q", got)
+	}
+}
+
+func TestStore_BlocklistFreshness(t *testing.T) {
+	s, clk := newTestStore(90 * time.Second)
+
+	updated := clk.Now().Add(-30 * time.Minute)
+	s.Record(Heartbeat{SiteID: "box-1", BlocklistUpdatedAt: &updated})
+
+	site := s.Snapshot().Sites[0]
+	if site.BlocklistAgeSeconds == nil {
+		t.Fatal("expected blocklist age to be computed")
+	}
+	if *site.BlocklistAgeSeconds != 1800 {
+		t.Errorf("expected blocklist age 1800s, got %d", *site.BlocklistAgeSeconds)
+	}
+}


### PR DESCRIPTION
## What

Adds an **opt-in, read-only MSP fleet-status aggregator** (I-055, scoped first cut). Deployed boxes periodically report aggregate heartbeat metadata; an operator pulls a single consolidated view of fleet health.

## Why

Running boxes across many SMB/school/hospital sites, an operator needs one screen answering "is every box up, resolving, and blocking, with fresh blocklists?" — without a full multi-tenant control plane. This is the minimal read-only slice that delivers that.

## How

New package `internal/fleet`:
- In-memory store keyed by site id, safe for concurrent use, with an **injectable clock** so stale detection is deterministic in tests.
- A site with no heartbeat within the threshold (default 90s) flips to **down**.
- `Heartbeat` carries **metadata only** — site id, name, version, QPS, blocked %, blocklist freshness, active alerts. Never query contents (no domains, no client IPs), keeping the feature **custody-safe**.
- `RequireHeartbeatToken` middleware: boxes authenticate with a **dedicated fleet token** (constant-time compare), never the admin API key.

Endpoints (only registered when the feature is enabled):
- `POST /api/v1/fleet/heartbeat` — a box reports in; fleet-token authed (exempt from global admin auth so appliance creds stay separate from operator creds).
- `GET /api/v1/fleet` — consolidated per-site view; admin-only via the existing global auth middleware.

**Default OFF / opt-in:** activates only with `FLEET_ENABLED=true` **and** a non-empty `FLEET_HEARTBEAT_TOKEN` (optional `FLEET_STALE_AFTER`). When disabled, no routes are registered.

## Scope

Deliberately a **read-only fleet view**, not a full multi-tenant control plane (no per-tenant RBAC, no remote config push, no persistence across restarts). Store is in-memory by design for this first cut.

## Tests

- Heartbeat ingestion creates/updates a site (no duplicates on re-report).
- `GET` returns the consolidated view with correct counts and deterministic ordering.
- Injected-clock **stale detection** flips a site up -> down past the threshold, and a fresh heartbeat revives it.
- **Auth required**: heartbeat rejects missing/wrong token and refuses the admin key; `GET /fleet` rejects missing token and the box token, accepts the admin key.
- Blocklist-freshness age computed correctly.

All deterministic, temp in-memory store; `go build`, `go vet`, `go test ./...` (incl. `-race`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)