### PR TITLE
chore: gofmt the files failing Code Linting on main

### DIFF
--- a/cmd/controlplane/handlers/dashboard.go
+++ b/cmd/controlplane/handlers/dashboard.go
@@ -7,10 +7,10 @@ import (
 )
 
 type DashboardSummaryData struct {
-	TotalQueries      uint64 `json:"total_queries"`
-	BlockedQueries    uint64 `json:"blocked_queries"`
-	AllowedQueries    uint64 `json:"allowed_queries"`
-	RedirectedQueries uint64 `json:"redirected_queries"`
+	TotalQueries      uint64  `json:"total_queries"`
+	BlockedQueries    uint64  `json:"blocked_queries"`
+	AllowedQueries    uint64  `json:"allowed_queries"`
+	RedirectedQueries uint64  `json:"redirected_queries"`
 	BlockRatePercent  float64 `json:"block_rate_percent"`
 }
 

--- a/cmd/controlplane/middlewares/auth.go
+++ b/cmd/controlplane/middlewares/auth.go
@@ -10,11 +10,11 @@ import (
 func Auth(authRepo repositories.AuthRepository) gin.HandlerFunc {
 	// Paths that don't require authentication
 	exemptPaths := map[string]bool{
-		"/health":               true,
-		"/":                     true,
-		"/api/v1/auth/status":   true,
-		"/api/v1/auth/login":    true,
-		"/api/v1/auth/setup":    true,
+		"/health":             true,
+		"/":                   true,
+		"/api/v1/auth/status": true,
+		"/api/v1/auth/login":  true,
+		"/api/v1/auth/setup":  true,
 	}
 
 	return func(c *gin.Context) {

--- a/cmd/controlplane/middlewares/logger.go
+++ b/cmd/controlplane/middlewares/logger.go
@@ -1,24 +1,24 @@
 package middlewares
 
 import (
-    "log"
-    "time"
-    "github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin"
+	"log"
+	"time"
 )
 
-func Logger() gin.HandlerFunc  {
-	return func(c *gin.Context){
+func Logger() gin.HandlerFunc {
+	return func(c *gin.Context) {
 		start := time.Now()
 		c.Next()
 		duration := time.Since(start)
 
 		log.Printf("[%s] %s %s %d %s",
-            c.Request.Method,
-            c.Request.URL.Path,
-            c.ClientIP(),
-            c.Writer.Status(),
-            duration,
-        )
+			c.Request.Method,
+			c.Request.URL.Path,
+			c.ClientIP(),
+			c.Writer.Status(),
+			duration,
+		)
 	}
 
 }

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -34,7 +34,7 @@ func (w *mockResponseWriter) Write([]byte) (int, error) { return 0, nil }
 func (w *mockResponseWriter) Close() error              { return nil }
 func (w *mockResponseWriter) TsigStatus() error         { return nil }
 func (w *mockResponseWriter) TsigTimersOnly(bool)       {}
-func (w *mockResponseWriter) Hijack()                    {}
+func (w *mockResponseWriter) Hijack()                   {}
 
 func newTestQuery(domain string) *dns.Msg {
 	m := new(dns.Msg)

--- a/internal/threat/detector.go
+++ b/internal/threat/detector.go
@@ -16,7 +16,7 @@ import (
 type Result struct {
 	IsSuspicious    bool    `json:"is_suspicious"`
 	ThreatScore     float64 `json:"threat_score"`     // 0.0 to 1.0
-	DetectionMethod string  `json:"detection_method"`  // e.g. "entropy", "dga_pattern", "length"
+	DetectionMethod string  `json:"detection_method"` // e.g. "entropy", "dga_pattern", "length"
 	Reason          string  `json:"reason"`
 }
 
@@ -108,13 +108,13 @@ var (
 
 // Known infrastructure TLDs that produce hex-like labels
 var infraDomains = map[string]bool{
-	"cloudfront.net":  true,
-	"amazonaws.com":   true,
-	"akamaihd.net":    true,
-	"akamaized.net":   true,
-	"sentry.io":       true,
-	"fastly.net":      true,
-	"cloudflare.com":  true,
+	"cloudfront.net":    true,
+	"amazonaws.com":     true,
+	"akamaihd.net":      true,
+	"akamaized.net":     true,
+	"sentry.io":         true,
+	"fastly.net":        true,
+	"cloudflare.com":    true,
 	"azurewebsites.net": true,
 }
 


### PR DESCRIPTION
Five files on main are gofmt-dirty and cause the Code Linting CI job to fail on every PR. This commit formats them to pass the linter. No semantic changes, formatting only.