### PR TITLE
fix: .gitignore bare patterns were ignoring cmd/ source trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Binaries
 /bin/
-controlplane
-dataplane
+# Anchored to repo root: unanchored patterns also matched the
+# cmd/controlplane and cmd/dataplane source directories.
+/controlplane
+/dataplane
 
 # Data
 /data/


### PR DESCRIPTION
Bare `controlplane` and `dataplane` patterns in `.gitignore` match at any depth, so they were also matching the `cmd/controlplane` and `cmd/dataplane` source directories and silently untracking new files added there. This anchors both patterns to the repo root (`/controlplane`, `/dataplane`) so they only match the compiled binaries, not the source trees. This extracts just the `.gitignore` fix from #48 so it can merge on its own ahead of the rest of that PR.
