### PR TITLE
Chunk 1: default-off dataplane features (8 PRs)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -19,6 +19,9 @@ dataplane:
   # Optional per-client DNS query rate limit (queries/sec per client IP).
   # 0 disables it (default). Env override: CLIENT_RATE_LIMIT_PER_SEC.
   client_rate_limit_per_sec: 0
+  # Rewrite well-known search/video hosts to their enforced-safe targets
+  # (Google/Bing/DuckDuckGo SafeSearch, YouTube Restricted Mode). Env: SAFE_SEARCH.
+  safe_search: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -13,6 +13,9 @@ dataplane:
   # Env overrides: THREAT_BLOCK_THRESHOLD, THREAT_BLOCK_DRYRUN.
   threat_block_threshold: 0
   threat_block_dryrun: false
+  # Reject upstream answers that map a public name to a private/loopback/
+  # link-local IP (DNS rebinding defense). Env override: REBIND_PROTECTION.
+  rebind_protection: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -16,6 +16,9 @@ dataplane:
   # Reject upstream answers that map a public name to a private/loopback/
   # link-local IP (DNS rebinding defense). Env override: REBIND_PROTECTION.
   rebind_protection: false
+  # Optional per-client DNS query rate limit (queries/sec per client IP).
+  # 0 disables it (default). Env override: CLIENT_RATE_LIMIT_PER_SEC.
+  client_rate_limit_per_sec: 0
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,6 +6,13 @@ dataplane:
   anonymization:
     secret: "${PHANTOM_ANON_SECRET:-change-me-in-production}"
   blocklist_update_interval: "6h"
+  # Threat-score enforcement for the heuristic detector (DGA / entropy / tunneling).
+  # 0 disables enforcement — the detector still scores and logs (historical default).
+  # Set a value in (0, 1], e.g. 0.8, to block queries scored at or above it.
+  # threat_block_dryrun logs would-be blocks without blocking (safe rollout).
+  # Env overrides: THREAT_BLOCK_THRESHOLD, THREAT_BLOCK_DRYRUN.
+  threat_block_threshold: 0
+  threat_block_dryrun: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -22,6 +22,9 @@ dataplane:
   # Rewrite well-known search/video hosts to their enforced-safe targets
   # (Google/Bing/DuckDuckGo SafeSearch, YouTube Restricted Mode). Env: SAFE_SEARCH.
   safe_search: false
+  # Enable DNS 0x20 case-randomization on outbound upstream queries
+  # (anti-spoofing hardening). Default false. Env override: DNS_0X20.
+  dns_0x20: false
   grpc_server:
     port: 50051
     listen_addr: "localhost:50051"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,11 @@ type DataPlaneConfig struct {
 	// ClientRateLimitPerSec caps DNS queries accepted per client IP each second.
 	// 0 (the default) disables rate limiting entirely.
 	ClientRateLimitPerSec int `yaml:"client_rate_limit_per_sec"`
+
+	// SafeSearch, when true, rewrites well-known search/video hosts to their
+	// enforced-safe CNAME targets (Google/Bing/DuckDuckGo SafeSearch and
+	// YouTube Restricted Mode). Default false = no rewrite.
+	SafeSearch bool `yaml:"safe_search"`
 }
 
 type ControlPlaneConfig struct {
@@ -121,6 +126,11 @@ var DefaultConfig = func() *Config {
 			cfg.DataPlane.ClientRateLimitPerSec = n
 		} else {
 			logger.Log.Warnf("Invalid CLIENT_RATE_LIMIT_PER_SEC=%q, ignoring: %v", v, err)
+		}
+	}
+	if v := os.Getenv("SAFE_SEARCH"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.SafeSearch = b
 		}
 	}
 	return cfg

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,10 @@ type DataPlaneConfig struct {
 	// AbusedTLDs is the set of high-abuse TLDs (e.g. "zip", "mov", "top") to
 	// block on the default allow path. Empty (the default) disables the feature.
 	AbusedTLDs []string `yaml:"abused_tlds"`
+
+	// RebindProtection rejects upstream answers that map a public name to a
+	// private/loopback/link-local IP (DNS rebinding defense). Default false.
+	RebindProtection bool `yaml:"rebind_protection"`
 }
 
 type ControlPlaneConfig struct {
@@ -100,6 +104,13 @@ var DefaultConfig = func() *Config {
 	}
 	if v := os.Getenv("ABUSED_TLDS"); v != "" {
 		cfg.DataPlane.AbusedTLDs = parseAbusedTLDs(v)
+	}
+	if v := os.Getenv("REBIND_PROTECTION"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.RebindProtection = b
+		} else {
+			logger.Log.Warnf("Invalid REBIND_PROTECTION value %q: %v", v, err)
+		}
 	}
 	return cfg
 }()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,10 @@ type DataPlaneConfig struct {
 	// enforced-safe CNAME targets (Google/Bing/DuckDuckGo SafeSearch and
 	// YouTube Restricted Mode). Default false = no rewrite.
 	SafeSearch bool `yaml:"safe_search"`
+
+	// DNS0x20 enables DNS 0x20 case-randomization on outbound upstream queries
+	// (anti-spoofing hardening). Default false = behaviour unchanged.
+	DNS0x20 bool `yaml:"dns_0x20"`
 }
 
 type ControlPlaneConfig struct {
@@ -131,6 +135,13 @@ var DefaultConfig = func() *Config {
 	if v := os.Getenv("SAFE_SEARCH"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
 			cfg.DataPlane.SafeSearch = b
+		}
+	}
+	if v := os.Getenv("DNS_0X20"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.DNS0x20 = b
+		} else {
+			logger.Log.Warnf("Invalid DNS_0X20 value %q, ignoring", v)
 		}
 	}
 	return cfg

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,10 @@ type DataPlaneConfig struct {
 	// RebindProtection rejects upstream answers that map a public name to a
 	// private/loopback/link-local IP (DNS rebinding defense). Default false.
 	RebindProtection bool `yaml:"rebind_protection"`
+
+	// ClientRateLimitPerSec caps DNS queries accepted per client IP each second.
+	// 0 (the default) disables rate limiting entirely.
+	ClientRateLimitPerSec int `yaml:"client_rate_limit_per_sec"`
 }
 
 type ControlPlaneConfig struct {
@@ -110,6 +114,13 @@ var DefaultConfig = func() *Config {
 			cfg.DataPlane.RebindProtection = b
 		} else {
 			logger.Log.Warnf("Invalid REBIND_PROTECTION value %q: %v", v, err)
+		}
+	}
+	if v := os.Getenv("CLIENT_RATE_LIMIT_PER_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.DataPlane.ClientRateLimitPerSec = n
+		} else {
+			logger.Log.Warnf("Invalid CLIENT_RATE_LIMIT_PER_SEC=%q, ignoring: %v", v, err)
 		}
 	}
 	return cfg

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"gopkg.in/yaml.v3"
@@ -32,6 +33,10 @@ type DataPlaneConfig struct {
 	ThreatBlockThreshold float64 `yaml:"threat_block_threshold"`
 	// ThreatBlockDryRun logs would-be threat blocks without actually blocking.
 	ThreatBlockDryRun bool `yaml:"threat_block_dryrun"`
+
+	// AbusedTLDs is the set of high-abuse TLDs (e.g. "zip", "mov", "top") to
+	// block on the default allow path. Empty (the default) disables the feature.
+	AbusedTLDs []string `yaml:"abused_tlds"`
 }
 
 type ControlPlaneConfig struct {
@@ -93,8 +98,25 @@ var DefaultConfig = func() *Config {
 			logger.Log.Warnf("Invalid THREAT_BLOCK_DRYRUN %q, ignoring: %v", v, err)
 		}
 	}
+	if v := os.Getenv("ABUSED_TLDS"); v != "" {
+		cfg.DataPlane.AbusedTLDs = parseAbusedTLDs(v)
+	}
 	return cfg
 }()
+
+// parseAbusedTLDs splits a comma-separated env value into a normalized list of
+// TLDs: split on ",", trim surrounding spaces, lowercase, and drop empties.
+func parseAbusedTLDs(v string) []string {
+	parts := strings.Split(v, ",")
+	tlds := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" {
+			tlds = append(tlds, p)
+		}
+	}
+	return tlds
+}
 
 func configPath() string {
 	if p := os.Getenv("PHANTOM_CONFIG"); p != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 // SPDX-License-Identifier: GPL-3.0-or-later
 import (
 	"os"
+	"strconv"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,14 @@ type DataPlaneConfig struct {
 	UpstreamResolvers       []string         `yaml:"upstream_resolvers"`
 	GRPCServer              GRPCServerConfig `yaml:"grpc_server"`
 	BlocklistUpdateInterval string           `yaml:"blocklist_update_interval"`
+
+	// ThreatBlockThreshold enables enforcement of the heuristic threat detector.
+	// When > 0, a query scored suspicious with ThreatScore >= threshold is blocked
+	// (or logged as a would-be block when ThreatBlockDryRun is set). 0 disables
+	// enforcement, preserving the historical log-only behaviour.
+	ThreatBlockThreshold float64 `yaml:"threat_block_threshold"`
+	// ThreatBlockDryRun logs would-be threat blocks without actually blocking.
+	ThreatBlockDryRun bool `yaml:"threat_block_dryrun"`
 }
 
 type ControlPlaneConfig struct {
@@ -69,6 +78,20 @@ var DefaultConfig = func() *Config {
 	}
 	if interval := os.Getenv("BLOCKLIST_UPDATE_INTERVAL"); interval != "" {
 		cfg.DataPlane.BlocklistUpdateInterval = interval
+	}
+	if v := os.Getenv("THREAT_BLOCK_THRESHOLD"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			cfg.DataPlane.ThreatBlockThreshold = f
+		} else {
+			logger.Log.Warnf("Invalid THREAT_BLOCK_THRESHOLD %q, ignoring: %v", v, err)
+		}
+	}
+	if v := os.Getenv("THREAT_BLOCK_DRYRUN"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DataPlane.ThreatBlockDryRun = b
+		} else {
+			logger.Log.Warnf("Invalid THREAT_BLOCK_DRYRUN %q, ignoring: %v", v, err)
+		}
 	}
 	return cfg
 }()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAbusedTLDs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"simple", "zip,mov,top", []string{"zip", "mov", "top"}},
+		{"trims spaces", " zip , mov ,top ", []string{"zip", "mov", "top"}},
+		{"lowercases", "ZIP,Mov,TOP", []string{"zip", "mov", "top"}},
+		{"drops empties", "zip,,mov,", []string{"zip", "mov"}},
+		{"single", "xyz", []string{"xyz"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAbusedTLDs(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAbusedTLDs(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/dnsengine/case_randomize.go
+++ b/internal/dnsengine/case_randomize.go
@@ -1,0 +1,97 @@
+// DNS 0x20 encoding (case-randomization) for outbound upstream queries.
+// See draft-vixie-dnsext-dns0x20-00: randomly flipping the case of the ASCII
+// letters in the QNAME adds entropy that an off-path spoofer must also guess,
+// while remaining transparent because DNS name matching is case-insensitive.
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"math/rand"
+	"strings"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+	"github.com/miekg/dns"
+)
+
+// randomizeCase applies DNS 0x20 encoding to name: it randomly flips the case
+// of each ASCII letter, leaving digits, dots, hyphens and every other byte
+// untouched. It is a pure function of (name, r), so seeding r makes the result
+// deterministic for tests. The returned string always lower-cases to the same
+// value as name (only case changes).
+func randomizeCase(name string, r *rand.Rand) string {
+	b := []byte(name)
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			if r.Intn(2) == 1 {
+				b[i] = c - 0x20 // to upper
+			}
+		case c >= 'A' && c <= 'Z':
+			if r.Intn(2) == 1 {
+				b[i] = c + 0x20 // to lower
+			}
+		}
+	}
+	return string(b)
+}
+
+// equalNameFold reports whether two DNS names are equal ignoring ASCII case.
+// It is the case-insensitive match used to validate that an upstream echoed the
+// question name we sent (it always should, even after 0x20 randomization).
+func equalNameFold(a, b string) bool {
+	return strings.EqualFold(a, b)
+}
+
+// encodeCase0x20 returns a copy of q whose question names have been case-
+// randomized, together with the original (client-requested) names indexed by
+// question so the response can be restored later. The input q is not modified.
+func encodeCase0x20(q *dns.Msg, r *rand.Rand) (*dns.Msg, []string) {
+	out := q.Copy()
+	originals := make([]string, len(out.Question))
+	for i := range out.Question {
+		originals[i] = out.Question[i].Name
+		out.Question[i].Name = randomizeCase(out.Question[i].Name, r)
+	}
+	return out, originals
+}
+
+// restoreCase0x20 rewrites resp in place so the client sees the exact case it
+// requested. For each question it verifies the upstream echoed the name case-
+// insensitively (the anti-spoofing check); on a match it restores the original
+// name in the question and in any RR owner names equal to the question name.
+// A mismatch is logged and left untouched.
+func restoreCase0x20(resp *dns.Msg, originals []string) {
+	if resp == nil {
+		return
+	}
+	for i := range resp.Question {
+		if i >= len(originals) {
+			break
+		}
+		echoed := resp.Question[i].Name
+		if !equalNameFold(echoed, originals[i]) {
+			logger.Log.Warnf("0x20: upstream echoed mismatched question name: got %q, want (case-insensitive) %q", echoed, originals[i])
+			continue
+		}
+		resp.Question[i].Name = originals[i]
+		restoreOwnerNames(resp.Answer, originals[i])
+		restoreOwnerNames(resp.Ns, originals[i])
+		restoreOwnerNames(resp.Extra, originals[i])
+	}
+}
+
+// restoreOwnerNames restores the original case of any RR whose owner name
+// matches original case-insensitively (i.e. the query name echoed back).
+// Other names in the record set (e.g. CNAME targets) are left untouched.
+func restoreOwnerNames(rrs []dns.RR, original string) {
+	for _, rr := range rrs {
+		if rr == nil {
+			continue
+		}
+		h := rr.Header()
+		if equalNameFold(h.Name, original) {
+			h.Name = original
+		}
+	}
+}

--- a/internal/dnsengine/case_randomize_test.go
+++ b/internal/dnsengine/case_randomize_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"math/rand"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// randomizeCase must only change the case of ASCII letters: the result is
+// case-insensitively equal to the input and every non-letter byte (digits,
+// dots, hyphens, ...) is preserved in place.
+func TestRandomizeCase_PreservesNonLetters(t *testing.T) {
+	names := []string{
+		"foo-bar123.example-9.com.",
+		"a1b2c3.test-domain.io.",
+		"192-0-2-1.in-addr.arpa.",
+		"",
+	}
+	for _, name := range names {
+		for seed := int64(0); seed < 20; seed++ {
+			r := rand.New(rand.NewSource(seed))
+			got := randomizeCase(name, r)
+
+			if len(got) != len(name) {
+				t.Fatalf("randomizeCase(%q) changed length: %q", name, got)
+			}
+			if !strings.EqualFold(got, name) {
+				t.Fatalf("randomizeCase(%q)=%q is not case-insensitively equal", name, got)
+			}
+			for i := 0; i < len(name); i++ {
+				oc := name[i]
+				isLetter := (oc >= 'a' && oc <= 'z') || (oc >= 'A' && oc <= 'Z')
+				if !isLetter && got[i] != oc {
+					t.Errorf("randomizeCase(%q) changed non-letter at %d: %q -> %q", name, i, string(oc), string(got[i]))
+				}
+			}
+		}
+	}
+}
+
+// The same seed must yield the same output (needed for deterministic behaviour).
+func TestRandomizeCase_DeterministicSeed(t *testing.T) {
+	a := randomizeCase("secure.example.com.", rand.New(rand.NewSource(42)))
+	b := randomizeCase("secure.example.com.", rand.New(rand.NewSource(42)))
+	if a != b {
+		t.Fatalf("same seed produced different output: %q vs %q", a, b)
+	}
+}
+
+// Over enough seeds, a many-letter name must actually get some letters flipped,
+// otherwise the encoding would add no entropy.
+func TestRandomizeCase_FlipsSomeLetters(t *testing.T) {
+	const name = "abcdefghijklmnop.example.com."
+	changed := false
+	for seed := int64(0); seed < 50 && !changed; seed++ {
+		if randomizeCase(name, rand.New(rand.NewSource(seed))) != name {
+			changed = true
+		}
+	}
+	if !changed {
+		t.Fatal("randomizeCase never changed a many-letter name across 50 seeds")
+	}
+}
+
+func TestEqualNameFold(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"example.com.", "ExAmPlE.CoM.", true},
+		{"example.com.", "example.com.", true},
+		{"EXAMPLE.COM.", "example.com.", true},
+		{"example.com.", "example.net.", false},
+		{"a.com.", "b.com.", false},
+	}
+	for _, c := range cases {
+		if got := equalNameFold(c.a, c.b); got != c.want {
+			t.Errorf("equalNameFold(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// With 0x20 disabled the outbound path must be unchanged: the exact same
+// message pointer is returned and no originals are captured (no network here).
+func TestPrepareOutbound_DisabledUnchanged(t *testing.T) {
+	m := &UpstreamManager{dns0x20: false}
+	q := new(dns.Msg)
+	q.SetQuestion("ExAmPlE.CoM.", dns.TypeA)
+
+	out, originals := m.prepareOutbound(q, nil)
+	if out != q {
+		t.Error("disabled 0x20 must return the original message unchanged (same pointer)")
+	}
+	if originals != nil {
+		t.Errorf("disabled 0x20 must return nil originals, got %v", originals)
+	}
+	if q.Question[0].Name != "ExAmPlE.CoM." {
+		t.Errorf("query must not be mutated while disabled, got %q", q.Question[0].Name)
+	}
+}
+
+// With 0x20 enabled a randomized copy is sent, the original name is captured,
+// and the caller's message is left untouched.
+func TestPrepareOutbound_EnabledRandomizes(t *testing.T) {
+	m := &UpstreamManager{dns0x20: true}
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	r := rand.New(rand.NewSource(1))
+
+	out, originals := m.prepareOutbound(q, r)
+	if out == q {
+		t.Fatal("enabled 0x20 must send a copy, not the original message")
+	}
+	if len(originals) != 1 || originals[0] != "example.com." {
+		t.Fatalf("originals not captured correctly: %v", originals)
+	}
+	if !equalNameFold(out.Question[0].Name, "example.com.") {
+		t.Errorf("outbound qname %q not case-insensitively equal to original", out.Question[0].Name)
+	}
+	if q.Question[0].Name != "example.com." {
+		t.Errorf("original query must not be mutated, got %q", q.Question[0].Name)
+	}
+}
+
+// restoreCase0x20 restores the client's requested case in the question and in
+// RR owner names that match the question name, while leaving unrelated names
+// (a CNAME target, an A record for a different owner) untouched.
+func TestRestoreCase0x20_RestoresOriginalCase(t *testing.T) {
+	resp := new(dns.Msg)
+	resp.Question = []dns.Question{{Name: "eXAmPLe.CoM.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+	resp.Answer = []dns.RR{
+		&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "eXAmPLe.CoM.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 60},
+			Target: "cdn.example.net.",
+		},
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "cdn.example.net.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.ParseIP("1.2.3.4"),
+		},
+	}
+
+	restoreCase0x20(resp, []string{"example.com."})
+
+	if resp.Question[0].Name != "example.com." {
+		t.Errorf("question name not restored: %q", resp.Question[0].Name)
+	}
+	if got := resp.Answer[0].Header().Name; got != "example.com." {
+		t.Errorf("matching owner name not restored: %q", got)
+	}
+	if tgt := resp.Answer[0].(*dns.CNAME).Target; tgt != "cdn.example.net." {
+		t.Errorf("CNAME target should be untouched, got %q", tgt)
+	}
+	if got := resp.Answer[1].Header().Name; got != "cdn.example.net." {
+		t.Errorf("non-matching owner name should be untouched, got %q", got)
+	}
+}
+
+// A question that does not fold to the sent name (a spoof-like mismatch) must
+// not be rewritten.
+func TestRestoreCase0x20_MismatchLeftUntouched(t *testing.T) {
+	resp := new(dns.Msg)
+	resp.Question = []dns.Question{{Name: "attacker.evil.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+
+	restoreCase0x20(resp, []string{"example.com."})
+
+	if resp.Question[0].Name != "attacker.evil.com." {
+		t.Errorf("mismatched question name should be left untouched, got %q", resp.Question[0].Name)
+	}
+}
+
+func TestRestoreCase0x20_NilSafe(t *testing.T) {
+	restoreCase0x20(nil, []string{"example.com."}) // must not panic
+}

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -2,6 +2,7 @@
 package dnsengine
 
 import (
+	"net"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -45,6 +46,10 @@ type Engine struct {
 	// abusedTLDs is the set of high-abuse TLDs to block on the default allow
 	// path (lowercased, no leading dot). Empty/nil disables the feature.
 	abusedTLDs map[string]bool
+
+	// rebindProtection, when true, strips A/AAAA answers that resolve a public
+	// name to a private/loopback/link-local IP. Default false (unchanged behaviour).
+	rebindProtection bool
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -85,6 +90,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		threatBlockThreshold: cfg.ThreatBlockThreshold,
 		threatBlockDryRun:    cfg.ThreatBlockDryRun,
 		abusedTLDs:           abusedTLDs,
+		rebindProtection:     cfg.RebindProtection,
 	}, nil
 }
 
@@ -153,6 +159,33 @@ func (e *Engine) respondRedirect(w dns.ResponseWriter, r *dns.Msg, domain, ip st
 	}
 }
 
+// filterRebind removes A/AAAA answer records whose IP is private, loopback,
+// link-local, or unspecified. This defends against DNS rebinding, where a
+// public name is resolved to an internal address to reach services behind the
+// resolver. Non-A/AAAA records are always kept. It is a pure function: it
+// returns the surviving records and the number that were dropped.
+func filterRebind(answers []dns.RR) (kept []dns.RR, dropped int) {
+	for _, rr := range answers {
+		var ip net.IP
+		switch v := rr.(type) {
+		case *dns.A:
+			ip = v.A
+		case *dns.AAAA:
+			ip = v.AAAA
+		default:
+			kept = append(kept, rr)
+			continue
+		}
+		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			dropped++
+			continue
+		}
+		kept = append(kept, rr)
+	}
+	return kept, dropped
+}
+
 func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string) {
 	resp, err := e.upstreamManager.Exchange(r, 5, 2)
 	if err != nil {
@@ -169,6 +202,23 @@ func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string
 		_ = w.WriteMsg(m)
 		return
 	}
+
+	// DNS rebinding protection: strip answers that map a public name to an
+	// internal IP. If dropping them leaves an A/AAAA query with no answers at
+	// all, block the response outright instead of returning an empty reply.
+	if e.rebindProtection {
+		kept, dropped := filterRebind(resp.Answer)
+		if dropped > 0 {
+			logger.Log.Warnf("Rebind protection dropped %d record(s) for %s", dropped, domain)
+			resp.Answer = kept
+			qtype := r.Question[0].Qtype
+			if len(kept) == 0 && (qtype == dns.TypeA || qtype == dns.TypeAAAA) {
+				e.respondBlocked(w, r, domain, "rebind")
+				return
+			}
+		}
+	}
+
 	if err := w.WriteMsg(resp); err != nil {
 		logger.Log.Error("Failed to write DNS response: " + err.Error())
 	}

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -357,7 +357,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			logger.Log.Error("Blocklist check failed: " + err.Error())
 		} else if blocked {
 			logger.Log.Infof("Blocked by blocklist: %s", domainName)
-			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.logQuery(domainName, clientIP, "block", "blocklist", threatResult)
 			e.respondBlocked(w, r, domainName, "blocklist")
 			success = true
 			return
@@ -368,7 +368,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	decision, err := e.policyEngine.Evaluate(domainName)
 	if err != nil {
 		logger.Log.Error("Failed to evaluate policy: " + err.Error())
-		e.logQuery(domainName, clientIP, "error", threatResult)
+		e.logQuery(domainName, clientIP, "error", "", threatResult)
 		m := new(dns.Msg)
 		m.SetRcode(r, dns.RcodeServerFailure)
 		_ = w.WriteMsg(m)
@@ -378,12 +378,12 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	switch decision.Action {
 	case policy.ActionDeny:
 		logger.Log.Infof("Blocking via policy %s", decision.PolicyID)
-		e.logQuery(domainName, clientIP, "block", threatResult)
+		e.logQuery(domainName, clientIP, "block", decision.PolicyID, threatResult)
 		e.respondBlocked(w, r, domainName, decision.PolicyID)
 		success = true
 
 	case policy.ActionRedirect:
-		e.logQuery(domainName, clientIP, "redirect", threatResult)
+		e.logQuery(domainName, clientIP, "redirect", "redirect:"+decision.PolicyID, threatResult)
 		e.respondRedirect(w, r, domainName, decision.RedirectIP)
 		success = true
 
@@ -395,7 +395,7 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		case threatBlock:
 			logger.Log.Warnf("Blocking suspicious domain %s (score=%.2f >= %.2f, method=%s)",
 				domainName, threatResult.ThreatScore, e.threatBlockThreshold, threatResult.DetectionMethod)
-			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.logQuery(domainName, clientIP, "block", "threat:"+threatResult.DetectionMethod, threatResult)
 			e.respondBlocked(w, r, domainName, "threat:"+threatResult.DetectionMethod)
 			success = true
 			return
@@ -409,23 +409,25 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// still wins and is forwarded normally.
 		if decision.PolicyID == "" && e.isAbusedTLD(domainName) {
 			logger.Log.Infof("Blocking via abused TLD: %s", domainName)
-			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.logQuery(domainName, clientIP, "block", "abused-tld", threatResult)
 			e.respondBlocked(w, r, domainName, "abused-tld")
 			success = true
 			return
 		}
 		action := "allow"
+		reason := ""
 		if threatResult.IsSuspicious {
 			action = "flagged"
+			reason = threatResult.DetectionMethod
 			logger.Log.Warnf("Suspicious domain allowed: %s (score=%.2f, method=%s)", domainName, threatResult.ThreatScore, threatResult.DetectionMethod)
 		}
-		e.logQuery(domainName, clientIP, action, threatResult)
+		e.logQuery(domainName, clientIP, action, reason, threatResult)
 		e.forwardUpstream(w, r, domainName)
 		success = true
 	}
 }
 
-func (e *Engine) logQuery(domain, clientIP, action string, tr threat.Result) {
+func (e *Engine) logQuery(domain, clientIP, action, reason string, tr threat.Result) {
 	if e.queryLog == nil {
 		return
 	}
@@ -433,6 +435,7 @@ func (e *Engine) logQuery(domain, clientIP, action string, tr threat.Result) {
 		Domain:          domain,
 		ClientIP:        clientIP,
 		Action:          action,
+		BlockReason:     reason,
 		IsSuspicious:    tr.IsSuspicious,
 		ThreatScore:     tr.ThreatScore,
 		DetectionMethod: tr.DetectionMethod,

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -83,7 +83,7 @@ func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
 }
 
 func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *policy.Engine) (*Engine, error) {
-	mgr, err := NewUpstreamManager(cfg.UpstreamResolvers, 4)
+	mgr, err := NewUpstreamManager(cfg.UpstreamResolvers, 4, WithDNS0x20(cfg.DNS0x20))
 	state := &RuntimeState{}
 	state.acceptQueries.Store(false)
 	qm := metrics.NewQueryMetrics()

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -52,6 +52,30 @@ type Engine struct {
 	rebindProtection bool
 
 	rateLimiter *rateLimiter
+
+	safeSearch bool
+}
+
+// safeSearchTargets maps well-known search/video hostnames to their
+// enforced-safe CNAME target. When SafeSearch is enabled, a query for any
+// mapped host on the allow path is answered with a CNAME to its target so the
+// client re-resolves the safe endpoint. These are the vendor-documented
+// SafeSearch / YouTube Restricted Mode hostnames.
+var safeSearchTargets = map[string]string{
+	// Google SafeSearch
+	"google.com":     "forcesafesearch.google.com",
+	"www.google.com": "forcesafesearch.google.com",
+	// Bing strict SafeSearch
+	"bing.com":     "strict.bing.com",
+	"www.bing.com": "strict.bing.com",
+	// DuckDuckGo safe search
+	"duckduckgo.com": "safe.duckduckgo.com",
+	// YouTube Restricted Mode (moderate)
+	"youtube.com":             "restrictmoderate.youtube.com",
+	"www.youtube.com":         "restrictmoderate.youtube.com",
+	"m.youtube.com":           "restrictmoderate.youtube.com",
+	"youtubei.googleapis.com": "restrictmoderate.youtube.com",
+	"youtube.googleapis.com":  "restrictmoderate.youtube.com",
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -94,6 +118,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		abusedTLDs:           abusedTLDs,
 		rebindProtection:     cfg.RebindProtection,
 		rateLimiter:          newRateLimiter(cfg.ClientRateLimitPerSec),
+		safeSearch:           cfg.SafeSearch,
 	}, nil
 }
 
@@ -187,6 +212,26 @@ func filterRebind(answers []dns.RR) (kept []dns.RR, dropped int) {
 		kept = append(kept, rr)
 	}
 	return kept, dropped
+}
+
+// respondSafeSearch answers the query with a CNAME pointing the queried name
+// at its enforced-safe target (e.g. www.google.com -> forcesafesearch.google.com).
+// The client then re-resolves the target through normal resolution.
+func (e *Engine) respondSafeSearch(w dns.ResponseWriter, r *dns.Msg, target string) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	name := r.Question[0].Name
+	rr, err := dns.NewRR(name + " 60 IN CNAME " + dns.Fqdn(target))
+	if err != nil {
+		logger.Log.Error("Failed to create SafeSearch CNAME RR: " + err.Error())
+		m.SetRcode(r, dns.RcodeServerFailure)
+		_ = w.WriteMsg(m)
+		return
+	}
+	m.Answer = append(m.Answer, rr)
+	if err := w.WriteMsg(m); err != nil {
+		logger.Log.Error("Failed to write SafeSearch response: " + err.Error())
+	}
 }
 
 func (e *Engine) forwardUpstream(w dns.ResponseWriter, r *dns.Msg, domain string) {
@@ -414,6 +459,20 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 			success = true
 			return
 		}
+
+		// SafeSearch enforcement: on the allow path, rewrite well-known search/
+		// video hosts to their enforced-safe target via a CNAME so the client
+		// re-resolves the safe endpoint. Never overrides a block/redirect above.
+		if e.safeSearch {
+			if target, ok := safeSearchTargets[domainName]; ok {
+				logger.Log.Infof("SafeSearch rewrite: %s -> %s", domainName, target)
+				e.logQuery(domainName, clientIP, "allow", "", threatResult)
+				e.respondSafeSearch(w, r, target)
+				success = true
+				return
+			}
+		}
+
 		action := "allow"
 		reason := ""
 		if threatResult.IsSuspicious {

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -35,6 +35,12 @@ type Engine struct {
 	queryLog        repositories.QueryLogRepository
 	statistics      repositories.StatisticsRepository
 	threatDetector  *threat.Detector
+
+	// threatBlockThreshold, when > 0, turns the heuristic threat detector from
+	// log-only into enforcement: a suspicious query with ThreatScore >= threshold
+	// is blocked. threatBlockDryRun logs a would-be block instead of blocking.
+	threatBlockThreshold float64
+	threatBlockDryRun    bool
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -51,13 +57,15 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		return nil, err
 	}
 	return &Engine{
-		upstreamManager: mgr,
-		policyEngine:    pE,
-		state:           state,
-		metrics:         qm,
-		queryLog:        repos.QueryLogs,
-		statistics:      repos.Statistics,
-		threatDetector:  threat.NewDetector(),
+		upstreamManager:      mgr,
+		policyEngine:         pE,
+		state:                state,
+		metrics:              qm,
+		queryLog:             repos.QueryLogs,
+		statistics:           repos.Statistics,
+		threatDetector:       threat.NewDetector(),
+		threatBlockThreshold: cfg.ThreatBlockThreshold,
+		threatBlockDryRun:    cfg.ThreatBlockDryRun,
 	}, nil
 }
 
@@ -172,6 +180,33 @@ func stripSearchDomain(domain string) string {
 	return domain
 }
 
+// threatAction is the enforcement decision for a scored query.
+type threatAction int
+
+const (
+	threatNone   threatAction = iota // do not enforce; forward as usual
+	threatBlock                      // block the query
+	threatDryRun                     // log a would-be block, but still allow
+)
+
+// shouldEnforceThreat reports whether a scored threat result crosses the
+// configured block threshold. A threshold of 0 disables enforcement, preserving
+// the historical log-only behaviour.
+func shouldEnforceThreat(tr threat.Result, threshold float64) bool {
+	return threshold > 0 && tr.IsSuspicious && tr.ThreatScore >= threshold
+}
+
+// threatDecision maps a scored result to an enforcement action for this engine.
+func (e *Engine) threatDecision(tr threat.Result) threatAction {
+	if !shouldEnforceThreat(tr, e.threatBlockThreshold) {
+		return threatNone
+	}
+	if e.threatBlockDryRun {
+		return threatDryRun
+	}
+	return threatBlock
+}
+
 // ProcessDNSQuery processes the DNS query and returns a response
 func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	if r == nil || len(r.Question) == 0 {
@@ -243,6 +278,22 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 		success = true
 
 	default: // policy.ActionAllow
+		// The query is not on any blocklist or block policy. If threat enforcement
+		// is enabled, a sufficiently suspicious domain is blocked here (dry-run only
+		// logs). Threshold 0 keeps the historical log-only behaviour.
+		switch e.threatDecision(threatResult) {
+		case threatBlock:
+			logger.Log.Warnf("Blocking suspicious domain %s (score=%.2f >= %.2f, method=%s)",
+				domainName, threatResult.ThreatScore, e.threatBlockThreshold, threatResult.DetectionMethod)
+			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.respondBlocked(w, r, domainName, "threat:"+threatResult.DetectionMethod)
+			success = true
+			return
+		case threatDryRun:
+			logger.Log.Warnf("[threat dry-run] would block %s (score=%.2f >= %.2f, method=%s)",
+				domainName, threatResult.ThreatScore, e.threatBlockThreshold, threatResult.DetectionMethod)
+		}
+
 		action := "allow"
 		if threatResult.IsSuspicious {
 			action = "flagged"

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -50,6 +50,8 @@ type Engine struct {
 	// rebindProtection, when true, strips A/AAAA answers that resolve a public
 	// name to a private/loopback/link-local IP. Default false (unchanged behaviour).
 	rebindProtection bool
+
+	rateLimiter *rateLimiter
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -91,6 +93,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		threatBlockDryRun:    cfg.ThreatBlockDryRun,
 		abusedTLDs:           abusedTLDs,
 		rebindProtection:     cfg.RebindProtection,
+		rateLimiter:          newRateLimiter(cfg.ClientRateLimitPerSec),
 	}, nil
 }
 
@@ -229,6 +232,17 @@ func normalizeDomain(d string) string {
 	return strings.TrimSuffix(strings.ToLower(d), ".")
 }
 
+// clientIPFromAddr extracts the host portion (IP) from a net.Addr so the rate
+// limiter keys on the client IP rather than the ephemeral source port, which
+// changes on every UDP query.
+func clientIPFromAddr(addr net.Addr) string {
+	s := addr.String()
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		return host
+	}
+	return s
+}
+
 // Known private/local DNS suffixes appended by routers via DHCP search domains.
 // When a router advertises a search domain (e.g., "hgu_lan", "home", "local"),
 // Windows/macOS append it to bare hostnames AND sometimes to FQDNs.
@@ -297,6 +311,19 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	if !e.state.acceptQueries.Load() {
+		m := new(dns.Msg)
+		m.SetRcode(r, dns.RcodeRefused)
+		_ = w.WriteMsg(m)
+		return
+	}
+
+	// --- Per-client rate limiting (default OFF; allows all when disabled) ---
+	rlClientIP := ""
+	if addr := w.RemoteAddr(); addr != nil {
+		rlClientIP = clientIPFromAddr(addr)
+	}
+	if !e.rateLimiter.allow(rlClientIP) {
+		logger.Log.Warnf("Rate limit exceeded for client %s, refusing query", rlClientIP)
 		m := new(dns.Msg)
 		m.SetRcode(r, dns.RcodeRefused)
 		_ = w.WriteMsg(m)

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -41,6 +41,10 @@ type Engine struct {
 	// is blocked. threatBlockDryRun logs a would-be block instead of blocking.
 	threatBlockThreshold float64
 	threatBlockDryRun    bool
+
+	// abusedTLDs is the set of high-abuse TLDs to block on the default allow
+	// path (lowercased, no leading dot). Empty/nil disables the feature.
+	abusedTLDs map[string]bool
 }
 
 func (e *Engine) AttachBlocklistChecker(b BlocklistChecker) {
@@ -56,6 +60,20 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 	if err != nil {
 		return nil, err
 	}
+
+	// Build the abused-TLD set once so the hot path does a plain map lookup
+	// instead of scanning a slice or reading globals.
+	var abusedTLDs map[string]bool
+	if len(cfg.AbusedTLDs) > 0 {
+		abusedTLDs = make(map[string]bool, len(cfg.AbusedTLDs))
+		for _, t := range cfg.AbusedTLDs {
+			t = strings.ToLower(strings.TrimSpace(t))
+			if t != "" {
+				abusedTLDs[t] = true
+			}
+		}
+	}
+
 	return &Engine{
 		upstreamManager:      mgr,
 		policyEngine:         pE,
@@ -66,7 +84,22 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		threatDetector:       threat.NewDetector(),
 		threatBlockThreshold: cfg.ThreatBlockThreshold,
 		threatBlockDryRun:    cfg.ThreatBlockDryRun,
+		abusedTLDs:           abusedTLDs,
 	}, nil
+}
+
+// isAbusedTLD reports whether the domain's final label (TLD) is in the
+// configured high-abuse set. Returns false when the set is empty (feature off).
+// domain is expected to be already normalized (lowercased, no trailing dot).
+func (e *Engine) isAbusedTLD(domain string) bool {
+	if len(e.abusedTLDs) == 0 {
+		return false
+	}
+	tld := domain
+	if i := strings.LastIndex(domain, "."); i >= 0 {
+		tld = domain[i+1:]
+	}
+	return e.abusedTLDs[strings.ToLower(tld)]
 }
 
 func (e *Engine) SetAcceptQueries(enabled bool) {
@@ -294,6 +327,16 @@ func (e *Engine) ProcessDNSQuery(w dns.ResponseWriter, r *dns.Msg) {
 				domainName, threatResult.ThreatScore, e.threatBlockThreshold, threatResult.DetectionMethod)
 		}
 
+		// Abused-TLD block applies only on the default allow path (no explicit
+		// policy matched). An explicit ALLOW policy, which carries a PolicyID,
+		// still wins and is forwarded normally.
+		if decision.PolicyID == "" && e.isAbusedTLD(domainName) {
+			logger.Log.Infof("Blocking via abused TLD: %s", domainName)
+			e.logQuery(domainName, clientIP, "block", threatResult)
+			e.respondBlocked(w, r, domainName, "abused-tld")
+			success = true
+			return
+		}
 		action := "allow"
 		if threatResult.IsSuspicious {
 			action = "flagged"

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -3,9 +3,11 @@ package dnsengine
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/lopster568/phantomDNS/internal/metrics"
 	"github.com/lopster568/phantomDNS/internal/policy"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"github.com/lopster568/phantomDNS/internal/threat"
 	"github.com/miekg/dns"
 )
@@ -36,6 +38,37 @@ func (w *mockResponseWriter) Close() error              { return nil }
 func (w *mockResponseWriter) TsigStatus() error         { return nil }
 func (w *mockResponseWriter) TsigTimersOnly(bool)       {}
 func (w *mockResponseWriter) Hijack()                   {}
+
+// mockQueryLog captures saved DNSQuery rows so tests can assert what was persisted.
+// logQuery saves asynchronously, so Save publishes onto a buffered channel.
+type mockQueryLog struct {
+	saved chan *models.DNSQuery
+}
+
+func newMockQueryLog() *mockQueryLog {
+	return &mockQueryLog{saved: make(chan *models.DNSQuery, 4)}
+}
+
+func (m *mockQueryLog) Save(q *models.DNSQuery) error {
+	m.saved <- q
+	return nil
+}
+
+func (m *mockQueryLog) ListRecent(limit int) ([]models.DNSQuery, error) {
+	return nil, nil
+}
+
+// waitSaved blocks until logQuery's goroutine persists a row (or times out).
+func (m *mockQueryLog) waitSaved(t *testing.T) *models.DNSQuery {
+	t.Helper()
+	select {
+	case q := <-m.saved:
+		return q
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for query to be logged")
+		return nil
+	}
+}
 
 func newTestQuery(domain string) *dns.Msg {
 	m := new(dns.Msg)
@@ -621,4 +654,87 @@ func TestFilterRebind_Empty(t *testing.T) {
 	if dropped != 0 || len(kept) != 0 {
 		t.Errorf("expected empty result for empty input, got dropped=%d kept=%d", dropped, len(kept))
 	}
+}
+
+// TestLogQuery_ThreadsBlockReason verifies logQuery persists the reason it is
+// given into DNSQuery.BlockReason (I-015) without touching the threat fields.
+func TestLogQuery_ThreadsBlockReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		reason string
+	}{
+		{"blocklist block", "block", "blocklist"},
+		{"policy block", "block", "block-ads"},
+		{"redirect", "redirect", "redirect:safe-search"},
+		{"plain allow", "allow", ""},
+		{"flagged uses threat method", "flagged", "entropy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mq := newMockQueryLog()
+			e := &Engine{queryLog: mq}
+
+			tr := threat.Result{DetectionMethod: "entropy", Reason: "high entropy"}
+			e.logQuery("example.com", "1.2.3.4", tt.action, tt.reason, tr)
+
+			got := mq.waitSaved(t)
+			if got.BlockReason != tt.reason {
+				t.Errorf("BlockReason = %q, want %q", got.BlockReason, tt.reason)
+			}
+			if got.Action != tt.action {
+				t.Errorf("Action = %q, want %q", got.Action, tt.action)
+			}
+			// Threat fields must be preserved unchanged.
+			if got.DetectionMethod != tr.DetectionMethod || got.ThreatReason != tr.Reason {
+				t.Errorf("threat fields altered: DetectionMethod=%q ThreatReason=%q", got.DetectionMethod, got.ThreatReason)
+			}
+		})
+	}
+}
+
+// TestProcessDNSQuery_LogsBlockReason verifies each blocking call site threads
+// the correct reason string end-to-end through ProcessDNSQuery.
+func TestProcessDNSQuery_LogsBlockReason(t *testing.T) {
+	t.Run("blocklist", func(t *testing.T) {
+		mq := newMockQueryLog()
+		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{"ads.example.com": true}}, nil)
+		e.queryLog = mq
+
+		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("ads.example.com"))
+
+		if got := mq.waitSaved(t); got.BlockReason != "blocklist" {
+			t.Errorf("BlockReason = %q, want %q", got.BlockReason, "blocklist")
+		}
+	})
+
+	t.Run("policy block records policy ID", func(t *testing.T) {
+		policies := []policy.Policy{
+			{ID: "block-ads", Action: "BLOCK", Priority: 100, Domains: []string{"policy-blocked.com"}},
+		}
+		mq := newMockQueryLog()
+		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, policies)
+		e.queryLog = mq
+
+		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("policy-blocked.com"))
+
+		if got := mq.waitSaved(t); got.BlockReason != "block-ads" {
+			t.Errorf("BlockReason = %q, want %q", got.BlockReason, "block-ads")
+		}
+	})
+
+	t.Run("redirect records redirect:policyID", func(t *testing.T) {
+		policies := []policy.Policy{
+			{ID: "safe-search", Action: "REDIRECT", Redirect: "1.2.3.4", Priority: 100, Domains: []string{"redirect-me.com"}},
+		}
+		mq := newMockQueryLog()
+		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, policies)
+		e.queryLog = mq
+
+		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("redirect-me.com"))
+
+		if got := mq.waitSaved(t); got.BlockReason != "redirect:safe-search" {
+			t.Errorf("BlockReason = %q, want %q", got.BlockReason, "redirect:safe-search")
+		}
+	})
 }

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lopster568/phantomDNS/internal/metrics"
 	"github.com/lopster568/phantomDNS/internal/policy"
+	"github.com/lopster568/phantomDNS/internal/threat"
 	"github.com/miekg/dns"
 )
 
@@ -335,5 +336,74 @@ func TestSetAcceptQueries(t *testing.T) {
 	e.SetAcceptQueries(true)
 	if !e.state.acceptQueries.Load() {
 		t.Error("expected true after SetAcceptQueries(true)")
+	}
+}
+
+func TestShouldEnforceThreat(t *testing.T) {
+	tests := []struct {
+		name      string
+		tr        threat.Result
+		threshold float64
+		want      bool
+	}{
+		{"threshold 0 disables", threat.Result{IsSuspicious: true, ThreatScore: 0.9}, 0, false},
+		{"above threshold", threat.Result{IsSuspicious: true, ThreatScore: 0.9}, 0.8, true},
+		{"equal to threshold", threat.Result{IsSuspicious: true, ThreatScore: 0.8}, 0.8, true},
+		{"below threshold", threat.Result{IsSuspicious: true, ThreatScore: 0.7}, 0.8, false},
+		{"not suspicious", threat.Result{IsSuspicious: false, ThreatScore: 0.9}, 0.8, false},
+	}
+	for _, tt := range tests {
+		if got := shouldEnforceThreat(tt.tr, tt.threshold); got != tt.want {
+			t.Errorf("%s: shouldEnforceThreat = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestThreatDecision(t *testing.T) {
+	sus := threat.Result{IsSuspicious: true, ThreatScore: 0.9}
+
+	if got := (&Engine{threatBlockThreshold: 0}).threatDecision(sus); got != threatNone {
+		t.Errorf("threshold 0: want threatNone, got %v", got)
+	}
+	if got := (&Engine{threatBlockThreshold: 0.8}).threatDecision(sus); got != threatBlock {
+		t.Errorf("enforce: want threatBlock, got %v", got)
+	}
+	if got := (&Engine{threatBlockThreshold: 0.8, threatBlockDryRun: true}).threatDecision(sus); got != threatDryRun {
+		t.Errorf("dry-run: want threatDryRun, got %v", got)
+	}
+}
+
+func TestProcessDNSQuery_ThreatBlockEnforced(t *testing.T) {
+	// A long hex label scores dga_hex (0.9). With enforcement on and no
+	// blocklist/policy match, it must be blocked — this returns before any
+	// upstream forward, so no UpstreamManager is required.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.threatDetector = threat.NewDetector()
+	e.threatBlockThreshold = 0.8
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("abcdef0123456789.example.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response for the suspicious domain")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected suspicious domain blocked (0.0.0.0), got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_ThreatBlockDisabledByDefault(t *testing.T) {
+	// With the default threshold of 0, the detector must not enforce even on a
+	// clearly suspicious domain (verified at the decision layer to avoid the
+	// upstream-forward path, which needs a real UpstreamManager).
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.threatDetector = threat.NewDetector()
+
+	sus := e.threatDetector.Analyze("abcdef0123456789.example.com")
+	if !sus.IsSuspicious {
+		t.Fatal("test precondition: expected the sample domain to be flagged suspicious")
+	}
+	if got := e.threatDecision(sus); got != threatNone {
+		t.Errorf("default threshold (0) must not enforce, got %v", got)
 	}
 }

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -430,6 +430,97 @@ func TestShouldEnforceThreat(t *testing.T) {
 	}
 }
 
+// mustRR builds a dns.RR from its zone-file string form or fails the test.
+func mustRR(t *testing.T, s string) dns.RR {
+	t.Helper()
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		t.Fatalf("failed to build RR %q: %v", s, err)
+	}
+	return rr
+}
+
+// TestFilterRebind_SingleRecord classifies one record at a time: private,
+// loopback, link-local (unicast + multicast), and unspecified addresses must be
+// dropped, while genuine public addresses must be kept — for both A and AAAA.
+func TestFilterRebind_SingleRecord(t *testing.T) {
+	tests := []struct {
+		name     string
+		rr       string
+		wantDrop bool
+	}{
+		// Private IPv4 (RFC 1918)
+		{"private-10", "example.com. 300 IN A 10.0.0.1", true},
+		{"private-172", "example.com. 300 IN A 172.16.5.4", true},
+		{"private-192", "example.com. 300 IN A 192.168.1.1", true},
+		// Loopback
+		{"loopback-v4", "example.com. 300 IN A 127.0.0.1", true},
+		{"loopback-v6", "example.com. 300 IN AAAA ::1", true},
+		// Link-local unicast
+		{"linklocal-v4", "example.com. 300 IN A 169.254.1.1", true},
+		{"linklocal-v6", "example.com. 300 IN AAAA fe80::1", true},
+		// Link-local multicast
+		{"llmulticast-v4", "example.com. 300 IN A 224.0.0.251", true},
+		{"llmulticast-v6", "example.com. 300 IN AAAA ff02::1", true},
+		// Unspecified
+		{"unspecified-v4", "example.com. 300 IN A 0.0.0.0", true},
+		{"unspecified-v6", "example.com. 300 IN AAAA ::", true},
+		// Private IPv6 (ULA fc00::/7)
+		{"ula-v6", "example.com. 300 IN AAAA fc00::1", true},
+		// Public — kept
+		{"public-v4-google", "example.com. 300 IN A 8.8.8.8", false},
+		{"public-v4-cf", "example.com. 300 IN A 1.1.1.1", false},
+		{"public-v6-cf", "example.com. 300 IN AAAA 2606:4700:4700::1111", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kept, dropped := filterRebind([]dns.RR{mustRR(t, tt.rr)})
+			if tt.wantDrop {
+				if dropped != 1 || len(kept) != 0 {
+					t.Errorf("%s: expected dropped=1 kept=0, got dropped=%d kept=%d", tt.rr, dropped, len(kept))
+				}
+			} else {
+				if dropped != 0 || len(kept) != 1 {
+					t.Errorf("%s: expected dropped=0 kept=1, got dropped=%d kept=%d", tt.rr, dropped, len(kept))
+				}
+			}
+		})
+	}
+}
+
+// TestFilterRebind_Mixed verifies a mixed answer set keeps only the public
+// records and reports the correct drop count.
+func TestFilterRebind_Mixed(t *testing.T) {
+	answers := []dns.RR{
+		mustRR(t, "example.com. 300 IN A 8.8.8.8"),                 // public, keep
+		mustRR(t, "example.com. 300 IN A 192.168.1.1"),             // private, drop
+		mustRR(t, "example.com. 300 IN AAAA 2606:4700:4700::1111"), // public, keep
+		mustRR(t, "example.com. 300 IN AAAA ::1"),                  // loopback, drop
+		mustRR(t, "example.com. 300 IN A 127.0.0.1"),               // loopback, drop
+	}
+	kept, dropped := filterRebind(answers)
+	if dropped != 3 {
+		t.Errorf("expected 3 dropped, got %d", dropped)
+	}
+	if len(kept) != 2 {
+		t.Fatalf("expected 2 kept, got %d", len(kept))
+	}
+	for _, rr := range kept {
+		switch v := rr.(type) {
+		case *dns.A:
+			if v.A.String() != "8.8.8.8" {
+				t.Errorf("unexpected A kept: %s", v.A.String())
+			}
+		case *dns.AAAA:
+			if v.AAAA.String() != "2606:4700:4700::1111" {
+				t.Errorf("unexpected AAAA kept: %s", v.AAAA.String())
+			}
+		default:
+			t.Errorf("unexpected record type kept: %T", rr)
+		}
+	}
+}
+
 func TestThreatDecision(t *testing.T) {
 	sus := threat.Result{IsSuspicious: true, ThreatScore: 0.9}
 
@@ -476,5 +567,58 @@ func TestProcessDNSQuery_ThreatBlockDisabledByDefault(t *testing.T) {
 	}
 	if got := e.threatDecision(sus); got != threatNone {
 		t.Errorf("default threshold (0) must not enforce, got %v", got)
+	}
+}
+
+// TestFilterRebind_NonAddressRecordsUntouched ensures records that are not
+// A/AAAA (CNAME, MX, TXT) are always preserved, even alongside dropped IPs.
+func TestFilterRebind_NonAddressRecordsUntouched(t *testing.T) {
+	answers := []dns.RR{
+		mustRR(t, "example.com. 300 IN CNAME target.example.net."),
+		mustRR(t, "example.com. 300 IN MX 10 mail.example.net."),
+		mustRR(t, "example.com. 300 IN TXT \"v=spf1 -all\""),
+		mustRR(t, "example.com. 300 IN A 10.0.0.1"), // private, drop
+	}
+	kept, dropped := filterRebind(answers)
+	if dropped != 1 {
+		t.Errorf("expected 1 dropped, got %d", dropped)
+	}
+	if len(kept) != 3 {
+		t.Fatalf("expected 3 non-address records kept, got %d", len(kept))
+	}
+	for _, rr := range kept {
+		switch rr.(type) {
+		case *dns.A, *dns.AAAA:
+			t.Errorf("no address record should survive, got %T", rr)
+		}
+	}
+}
+
+// TestFilterRebind_AllPublicUnchanged verifies a fully public answer set is
+// passed through untouched with zero drops.
+func TestFilterRebind_AllPublicUnchanged(t *testing.T) {
+	answers := []dns.RR{
+		mustRR(t, "example.com. 300 IN A 8.8.8.8"),
+		mustRR(t, "example.com. 300 IN A 1.1.1.1"),
+		mustRR(t, "example.com. 300 IN AAAA 2001:4860:4860::8888"),
+	}
+	kept, dropped := filterRebind(answers)
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	if len(kept) != len(answers) {
+		t.Errorf("expected all %d records kept, got %d", len(answers), len(kept))
+	}
+}
+
+// TestFilterRebind_Empty verifies the empty/nil-input edge cases.
+func TestFilterRebind_Empty(t *testing.T) {
+	kept, dropped := filterRebind(nil)
+	if dropped != 0 || len(kept) != 0 {
+		t.Errorf("expected empty result for nil input, got dropped=%d kept=%d", dropped, len(kept))
+	}
+	kept, dropped = filterRebind([]dns.RR{})
+	if dropped != 0 || len(kept) != 0 {
+		t.Errorf("expected empty result for empty input, got dropped=%d kept=%d", dropped, len(kept))
 	}
 }

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -738,3 +738,101 @@ func TestProcessDNSQuery_LogsBlockReason(t *testing.T) {
 		}
 	})
 }
+
+// cnameTarget returns the normalized target of the first CNAME answer, or "".
+func cnameTarget(m *dns.Msg) string {
+	if m == nil {
+		return ""
+	}
+	for _, rr := range m.Answer {
+		if c, ok := rr.(*dns.CNAME); ok {
+			return normalizeDomain(c.Target)
+		}
+	}
+	return ""
+}
+
+func TestProcessDNSQuery_SafeSearchRewrite(t *testing.T) {
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{"www.google.com", "forcesafesearch.google.com"},
+		{"google.com", "forcesafesearch.google.com"},
+		{"www.bing.com", "strict.bing.com"},
+		{"duckduckgo.com", "safe.duckduckgo.com"},
+		{"www.youtube.com", "restrictmoderate.youtube.com"},
+		{"m.youtube.com", "restrictmoderate.youtube.com"},
+		{"youtubei.googleapis.com", "restrictmoderate.youtube.com"},
+	}
+	for _, tt := range tests {
+		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+		e.safeSearch = true
+
+		w := &mockResponseWriter{}
+		e.ProcessDNSQuery(w, newTestQuery(tt.query))
+
+		if w.msg == nil {
+			t.Fatalf("%s: expected a response, got nil", tt.query)
+		}
+		if got := cnameTarget(w.msg); got != tt.want {
+			t.Errorf("%s: expected CNAME to %q, got %q (answer=%+v)", tt.query, tt.want, got, w.msg.Answer)
+		}
+	}
+}
+
+func TestProcessDNSQuery_SafeSearchUnmappedHost(t *testing.T) {
+	// SafeSearch on, but an unmapped host must not be rewritten. With an empty
+	// upstream manager the allow path yields SERVFAIL (no network) — the point
+	// is that there is no CNAME rewrite.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.safeSearch = true
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("example.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response")
+	}
+	if got := cnameTarget(w.msg); got != "" {
+		t.Errorf("expected no CNAME rewrite for unmapped host, got CNAME to %q", got)
+	}
+}
+
+func TestProcessDNSQuery_SafeSearchDisabled(t *testing.T) {
+	// SafeSearch disabled (default): a mapped host must not be rewritten.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.safeSearch = false
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("www.google.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response")
+	}
+	if got := cnameTarget(w.msg); got != "" {
+		t.Errorf("expected no CNAME rewrite when SafeSearch disabled, got CNAME to %q", got)
+	}
+}
+
+func TestProcessDNSQuery_SafeSearchDoesNotOverrideBlock(t *testing.T) {
+	// A mapped host that is also blocklisted must still be blocked, not rewritten.
+	bl := &mockBlocklist{blocked: map[string]bool{"www.google.com": true}}
+	e := newTestEngine(bl, nil)
+	e.safeSearch = true
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("www.google.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected a response")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected block to win over SafeSearch rewrite, got %+v", w.msg.Answer)
+	}
+	if got := cnameTarget(w.msg); got != "" {
+		t.Errorf("expected no CNAME on blocked host, got CNAME to %q", got)
+	}
+}

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -325,6 +325,77 @@ func TestEngineStatus_WithError(t *testing.T) {
 	}
 }
 
+func TestProcessDNSQuery_AbusedTLDBlocks(t *testing.T) {
+	// TLD in the configured set is blocked on the default allow path.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.abusedTLDs = map[string]bool{"zip": true, "mov": true}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("malware.zip"))
+
+	if w.msg == nil {
+		t.Fatal("expected response for abused-TLD domain")
+	}
+	if !isBlockedResponse(w.msg) {
+		t.Errorf("expected blocked (0.0.0.0) for abused TLD, got rcode %d", w.msg.Rcode)
+	}
+}
+
+func TestProcessDNSQuery_AbusedTLDNotInSetAllowed(t *testing.T) {
+	// TLD not in the set reaches the allow path (no block).
+	// Empty (pool-less) upstream manager returns SERVFAIL without a network call.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	e.abusedTLDs = map[string]bool{"zip": true}
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("example.com"))
+
+	if w.msg == nil {
+		t.Fatal("expected response for allowed domain")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("expected non-abused TLD to reach allow path, but it was blocked")
+	}
+}
+
+func TestProcessDNSQuery_AbusedTLDEmptySetIsOff(t *testing.T) {
+	// Empty set = feature off: a .zip domain must not be blocked.
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	// abusedTLDs left nil (empty).
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("example.zip"))
+
+	if w.msg == nil {
+		t.Fatal("expected response when abused-TLD feature is off")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("expected no block with empty abused-TLD set, but domain was blocked")
+	}
+}
+
+func TestProcessDNSQuery_AbusedTLDAllowPolicyOverrides(t *testing.T) {
+	// An explicit ALLOW policy for the domain must win over the TLD block.
+	policies := []policy.Policy{
+		{ID: "allow-trusted", Action: "ALLOW", Priority: 100, Domains: []string{"trusted.zip"}},
+	}
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, policies)
+	e.abusedTLDs = map[string]bool{"zip": true}
+	e.upstreamManager = &UpstreamManager{}
+
+	w := &mockResponseWriter{}
+	e.ProcessDNSQuery(w, newTestQuery("trusted.zip"))
+
+	if w.msg == nil {
+		t.Fatal("expected response for explicitly-allowed abused-TLD domain")
+	}
+	if isBlockedResponse(w.msg) {
+		t.Error("expected explicit ALLOW policy to override abused-TLD block, but domain was blocked")
+	}
+}
+
 func TestSetAcceptQueries(t *testing.T) {
 	e := newTestEngine(nil, nil)
 

--- a/internal/dnsengine/ratelimit.go
+++ b/internal/dnsengine/ratelimit.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"sync"
+	"time"
+)
+
+// Bounds for the per-client rate limiter's memory footprint. Idle clients are
+// evicted lazily so a large, churning client population cannot grow the map
+// without limit.
+const (
+	rateLimitMaxClients = 65536
+	rateLimitIdleEvict  = 10 * time.Second
+)
+
+// clientWindow tracks the fixed one-second window state for a single client IP.
+type clientWindow struct {
+	windowStart time.Time
+	count       int
+	lastSeen    time.Time
+}
+
+// rateLimiter is a thread-safe, per-client-IP fixed-window rate limiter. It
+// allows up to perSec queries per client per second. When perSec <= 0 it is a
+// no-op that allows everything, so it is always safe to construct and call.
+type rateLimiter struct {
+	perSec     int
+	maxClients int
+	idleAfter  time.Duration
+
+	mu      sync.Mutex
+	clients map[string]*clientWindow
+
+	// now is injectable so tests can drive time deterministically without
+	// real sleeps. It defaults to time.Now.
+	now func() time.Time
+}
+
+// newRateLimiter builds a limiter capped at perSec queries per client IP each
+// second. A perSec <= 0 yields an allow-all limiter (rate limiting disabled).
+func newRateLimiter(perSec int) *rateLimiter {
+	return &rateLimiter{
+		perSec:     perSec,
+		maxClients: rateLimitMaxClients,
+		idleAfter:  rateLimitIdleEvict,
+		clients:    make(map[string]*clientWindow),
+		now:        time.Now,
+	}
+}
+
+// allow reports whether a query from clientIP may proceed. It returns true
+// (allow) when rate limiting is disabled (perSec <= 0) or the limiter is nil,
+// so callers need not special-case those states.
+func (rl *rateLimiter) allow(clientIP string) bool {
+	if rl == nil || rl.perSec <= 0 {
+		return true
+	}
+
+	now := rl.now()
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	w, ok := rl.clients[clientIP]
+	if !ok {
+		if len(rl.clients) >= rl.maxClients {
+			rl.evictIdle(now)
+		}
+		w = &clientWindow{windowStart: now}
+		rl.clients[clientIP] = w
+	}
+
+	// Roll to a fresh window once a full second has elapsed.
+	if now.Sub(w.windowStart) >= time.Second {
+		w.windowStart = now
+		w.count = 0
+	}
+
+	w.lastSeen = now
+	if w.count >= rl.perSec {
+		return false
+	}
+	w.count++
+	return true
+}
+
+// evictIdle removes clients that have not been seen within idleAfter. It must
+// be called with rl.mu held. This is best-effort: if every tracked client is
+// active the map may still exceed maxClients, but memory stays bounded by the
+// active client population rather than growing forever.
+func (rl *rateLimiter) evictIdle(now time.Time) {
+	for ip, w := range rl.clients {
+		if now.Sub(w.lastSeen) >= rl.idleAfter {
+			delete(rl.clients, ip)
+		}
+	}
+}

--- a/internal/dnsengine/ratelimit_test.go
+++ b/internal/dnsengine/ratelimit_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// fakeClock is a manually advanced clock for deterministic, sleep-free tests.
+type fakeClock struct {
+	t time.Time
+}
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newTestLimiter(perSec int, clk *fakeClock) *rateLimiter {
+	rl := newRateLimiter(perSec)
+	rl.now = clk.now
+	return rl
+}
+
+func TestRateLimiter_UnderLimitAllowed(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(5, clk)
+
+	for i := 0; i < 5; i++ {
+		if !rl.allow("10.0.0.1") {
+			t.Fatalf("query %d within limit should be allowed", i+1)
+		}
+	}
+}
+
+func TestRateLimiter_OverLimitDenied(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(3, clk)
+
+	for i := 0; i < 3; i++ {
+		if !rl.allow("10.0.0.1") {
+			t.Fatalf("query %d within limit should be allowed", i+1)
+		}
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("query over the limit should be denied")
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("subsequent query over the limit should stay denied")
+	}
+}
+
+func TestRateLimiter_WindowResets(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(2, clk)
+
+	if !rl.allow("10.0.0.1") || !rl.allow("10.0.0.1") {
+		t.Fatal("first two queries should be allowed")
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("third query in the same window should be denied")
+	}
+
+	// Advance past the one-second window; the counter must reset.
+	clk.advance(time.Second)
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("query should be allowed after the window resets")
+	}
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("second query in the new window should be allowed")
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("third query in the new window should be denied")
+	}
+}
+
+func TestRateLimiter_PartialWindowDoesNotReset(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(2, clk)
+
+	if !rl.allow("10.0.0.1") || !rl.allow("10.0.0.1") {
+		t.Fatal("first two queries should be allowed")
+	}
+	// Less than a full second: still the same window, still denied.
+	clk.advance(500 * time.Millisecond)
+	if rl.allow("10.0.0.1") {
+		t.Fatal("query within the same window should be denied")
+	}
+}
+
+func TestRateLimiter_ClientsIndependent(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(1, clk)
+
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("first client's first query should be allowed")
+	}
+	if rl.allow("10.0.0.1") {
+		t.Fatal("first client's second query should be denied")
+	}
+	// A different client has its own budget and is unaffected.
+	if !rl.allow("10.0.0.2") {
+		t.Fatal("second client's first query should be allowed")
+	}
+	if rl.allow("10.0.0.2") {
+		t.Fatal("second client's second query should be denied")
+	}
+}
+
+func TestRateLimiter_DisabledAllowsAll(t *testing.T) {
+	for _, perSec := range []int{0, -1} {
+		clk := &fakeClock{t: time.Unix(0, 0)}
+		rl := newTestLimiter(perSec, clk)
+		for i := 0; i < 1000; i++ {
+			if !rl.allow("10.0.0.1") {
+				t.Fatalf("perSec=%d should allow all queries, denied at %d", perSec, i)
+			}
+		}
+	}
+}
+
+func TestRateLimiter_NilReceiverAllows(t *testing.T) {
+	var rl *rateLimiter
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("nil limiter should allow all queries")
+	}
+}
+
+func TestRateLimiter_EvictsIdleClients(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	rl := newTestLimiter(1, clk)
+	rl.maxClients = 2
+
+	rl.allow("10.0.0.1")
+	rl.allow("10.0.0.2")
+	if len(rl.clients) != 2 {
+		t.Fatalf("expected 2 tracked clients, got %d", len(rl.clients))
+	}
+
+	// Move well past the idle threshold, then add a new client. The full map
+	// triggers an idle sweep that clears the two stale entries.
+	clk.advance(rateLimitIdleEvict + time.Second)
+	rl.allow("10.0.0.3")
+	if _, ok := rl.clients["10.0.0.1"]; ok {
+		t.Error("idle client 10.0.0.1 should have been evicted")
+	}
+	if _, ok := rl.clients["10.0.0.2"]; ok {
+		t.Error("idle client 10.0.0.2 should have been evicted")
+	}
+	if _, ok := rl.clients["10.0.0.3"]; !ok {
+		t.Error("active client 10.0.0.3 should be tracked")
+	}
+}
+
+// TestProcessDNSQuery_RateLimited exercises the limiter through the engine's
+// request path: the second query from the same client in one window is REFUSED.
+func TestProcessDNSQuery_RateLimited(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, nil)
+	rl := newRateLimiter(1)
+	rl.now = clk.now
+	e.rateLimiter = rl
+
+	// First query is under the limit. With no upstream manager configured the
+	// forward path is not what we assert here; a fresh writer keeps it isolated.
+	w1 := &mockResponseWriter{}
+	func() {
+		defer func() { _ = recover() }() // forwardUpstream has no upstream in tests
+		e.ProcessDNSQuery(w1, newTestQuery("example.com"))
+	}()
+
+	// Second query in the same window must be refused before any forwarding.
+	w2 := &mockResponseWriter{}
+	e.ProcessDNSQuery(w2, newTestQuery("example.com"))
+	if w2.msg == nil {
+		t.Fatal("expected a REFUSED response for the rate-limited query")
+	}
+	if w2.msg.Rcode != dns.RcodeRefused {
+		t.Errorf("expected REFUSED rcode for rate-limited query, got %d", w2.msg.Rcode)
+	}
+}

--- a/internal/dnsengine/ratelimit_test.go
+++ b/internal/dnsengine/ratelimit_test.go
@@ -54,8 +54,10 @@ func TestRateLimiter_WindowResets(t *testing.T) {
 	clk := &fakeClock{t: time.Unix(0, 0)}
 	rl := newTestLimiter(2, clk)
 
-	if !rl.allow("10.0.0.1") || !rl.allow("10.0.0.1") {
-		t.Fatal("first two queries should be allowed")
+	for i := 0; i < 2; i++ {
+		if !rl.allow("10.0.0.1") {
+			t.Fatalf("query %d should be allowed", i+1)
+		}
 	}
 	if rl.allow("10.0.0.1") {
 		t.Fatal("third query in the same window should be denied")
@@ -78,8 +80,10 @@ func TestRateLimiter_PartialWindowDoesNotReset(t *testing.T) {
 	clk := &fakeClock{t: time.Unix(0, 0)}
 	rl := newTestLimiter(2, clk)
 
-	if !rl.allow("10.0.0.1") || !rl.allow("10.0.0.1") {
-		t.Fatal("first two queries should be allowed")
+	for i := 0; i < 2; i++ {
+		if !rl.allow("10.0.0.1") {
+			t.Fatalf("query %d should be allowed", i+1)
+		}
 	}
 	// Less than a full second: still the same window, still denied.
 	clk.advance(500 * time.Millisecond)

--- a/internal/dnsengine/upstream_manager.go
+++ b/internal/dnsengine/upstream_manager.go
@@ -3,6 +3,7 @@
 package dnsengine
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/lopster568/phantomDNS/internal/logger"
@@ -11,11 +12,25 @@ import (
 
 type UpstreamManager struct {
 	pools []*UpstreamPool
+	// dns0x20 enables DNS 0x20 case-randomization on outbound queries.
+	// When false the send path behaves exactly as before.
+	dns0x20 bool
+}
+
+// UpstreamOption customizes an UpstreamManager at construction time.
+type UpstreamOption func(*UpstreamManager)
+
+// WithDNS0x20 toggles DNS 0x20 case-randomization on outbound upstream queries.
+func WithDNS0x20(enabled bool) UpstreamOption {
+	return func(m *UpstreamManager) { m.dns0x20 = enabled }
 }
 
 // NewUpstreamManager builds a pool for each configured resolver
-func NewUpstreamManager(resolvers []string, poolSize int) (*UpstreamManager, error) {
+func NewUpstreamManager(resolvers []string, poolSize int, opts ...UpstreamOption) (*UpstreamManager, error) {
 	manager := &UpstreamManager{}
+	for _, opt := range opts {
+		opt(manager)
+	}
 	for _, addr := range resolvers {
 		pool, err := NewUpstreamPool(addr, poolSize)
 		if err != nil {
@@ -32,13 +47,33 @@ func (m *UpstreamManager) Close() {
 	}
 }
 
+// prepareOutbound returns the message to send upstream and the original
+// question names for later restoration. When 0x20 is disabled it returns q
+// unchanged and a nil originals slice (restoration becomes a no-op), so the
+// send path is byte-for-byte identical to the pre-0x20 behaviour.
+func (m *UpstreamManager) prepareOutbound(q *dns.Msg, r *rand.Rand) (*dns.Msg, []string) {
+	if !m.dns0x20 || q == nil {
+		return q, nil
+	}
+	return encodeCase0x20(q, r)
+}
+
 // Exchange forwards query to resolvers with retry+failover
 func (m *UpstreamManager) Exchange(q *dns.Msg, timeout time.Duration, maxRetries int) (*dns.Msg, error) {
+	var r *rand.Rand
+	if m.dns0x20 {
+		r = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+	outbound, originals := m.prepareOutbound(q, r)
+
 	var lastErr error
 	for _, pool := range m.pools {
 		for attempt := 0; attempt < maxRetries; attempt++ {
-			resp, err := pool.Exchange(q, timeout)
+			resp, err := pool.Exchange(outbound, timeout)
 			if err == nil {
+				if originals != nil {
+					restoreCase0x20(resp, originals)
+				}
 				return resp, nil
 			}
 			lastErr = err

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -23,17 +23,22 @@ func (e *Engine) LoadPolicies(policies []Policy) error {
 }
 
 // Evaluate returns the decision for given domain and context.
-// Current implementation:
+// Evaluation order:
 //   - normalize domain
-//   - bloom negative => ALLOW
-//   - exact match => return highest-priority policy decision
-//   - otherwise => ALLOW (TODO: wildcard/regex)
+//   - exact-match/Bloom fast path (walks up parent domains) => decision
+//   - regex + wildcard slow path (only on exact miss) => decision
+//   - otherwise => ALLOW
+//
+// The exact-match fast path returns immediately when it hits, so an exact rule
+// always wins over regex/wildcard rules. Within the regex/wildcard slow path,
+// the usual priority ordering applies (higher priority wins; tie => lexicographic ID).
 func (e *Engine) Evaluate(domain string) (Decision, error) {
 	d := normalizeDomain(domain)
 	snap := e.snapshot.Load().(*PolicySnapshot)
 
 	// Check exact match first, then walk up parent domains for subdomain matching.
-	// e.g., www.godaddy.com → check www.godaddy.com, then godaddy.com
+	// e.g., www.godaddy.com → check www.godaddy.com, then godaddy.com.
+	// This is the hot path and is intentionally left untouched.
 	parts := strings.Split(d, ".")
 	for i := 0; i < len(parts)-1; i++ {
 		candidate := strings.Join(parts[i:], ".")
@@ -46,7 +51,34 @@ func (e *Engine) Evaluate(domain string) (Decision, error) {
 		}
 	}
 
+	// Slow path: no exact match. Evaluate wildcard and compiled-regex rules,
+	// respecting the same priority ordering as the exact path.
+	if best := matchDynamic(snap, d); best != nil {
+		return policyDecision(best), nil
+	}
+
 	return Decision{Action: ActionAllow}, nil
+}
+
+// matchDynamic returns the highest-priority policy whose wildcard or compiled
+// regex rule matches d, or nil when nothing matches. A wildcard "*.example.com"
+// matches the base domain ("example.com") and any subdomain of it.
+func matchDynamic(snap *PolicySnapshot, d string) *Policy {
+	var candidates []*Policy
+	for _, w := range snap.Wildcards {
+		if d == w.base || strings.HasSuffix(d, "."+w.base) {
+			candidates = append(candidates, w.policy)
+		}
+	}
+	for _, r := range snap.Regexes {
+		if r.re.MatchString(d) {
+			candidates = append(candidates, r.policy)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	return pickHighestPriority(candidates)
 }
 
 // pickHighestPriority returns the matching policy with highest priority (deterministic).

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -194,6 +194,190 @@ func TestPolicyDecision_Nil(t *testing.T) {
 	}
 }
 
+func TestEvaluate_BlockByRegex(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "rx-block", Action: "BLOCK", Priority: 100, Regexes: []string{`.*\.doubleclick\.net$`}},
+	})
+
+	d, err := e.Evaluate("ads.doubleclick.net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny {
+		t.Errorf("expected ActionDeny for regex match, got %v", d.Action)
+	}
+	if d.PolicyID != "rx-block" {
+		t.Errorf("expected policy ID rx-block, got %q", d.PolicyID)
+	}
+
+	// Non-matching domain should fall through to ALLOW.
+	d, err = e.Evaluate("safe.example.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow {
+		t.Errorf("expected ActionAllow for non-matching domain, got %v", d.Action)
+	}
+}
+
+func TestEvaluate_RegexAllowOverridesByPriority(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "rx-block", Action: "BLOCK", Priority: 10, Regexes: []string{`.*\.tracking\.com$`}},
+		{ID: "rx-allow", Action: "ALLOW", Priority: 100, Regexes: []string{`.*\.tracking\.com$`}},
+	})
+
+	d, err := e.Evaluate("beacon.tracking.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow {
+		t.Errorf("expected higher-priority ALLOW regex to win, got %v", d.Action)
+	}
+	if d.PolicyID != "rx-allow" {
+		t.Errorf("expected policy ID rx-allow, got %q", d.PolicyID)
+	}
+}
+
+func TestEvaluate_RegexTieBreakByID(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "zzz-rx", Action: "ALLOW", Priority: 50, Regexes: []string{`^tie\.rx$`}},
+		{ID: "aaa-rx", Action: "BLOCK", Priority: 50, Regexes: []string{`^tie\.rx$`}},
+	})
+
+	d, err := e.Evaluate("tie.rx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.PolicyID != "aaa-rx" {
+		t.Errorf("expected lexicographically first ID 'aaa-rx' on tie, got %q", d.PolicyID)
+	}
+	if d.Action != ActionDeny {
+		t.Errorf("expected ActionDeny from tie-break winner, got %v", d.Action)
+	}
+}
+
+func TestEvaluate_WildcardMatchesSubdomains(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "wild", Action: "BLOCK", Priority: 100, Domains: []string{"*.example.com"}},
+	})
+
+	// Wildcard matches the base domain and any depth of subdomain.
+	for _, domain := range []string{"example.com", "sub.example.com", "a.b.example.com"} {
+		d, err := e.Evaluate(domain)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Action != ActionDeny {
+			t.Errorf("expected %s to be blocked by wildcard, got %v", domain, d.Action)
+		}
+		if d.PolicyID != "wild" {
+			t.Errorf("expected policy ID wild for %s, got %q", domain, d.PolicyID)
+		}
+	}
+
+	// Unrelated domains must not match.
+	for _, domain := range []string{"notexample.com", "example.com.evil.net", "other.org"} {
+		d, err := e.Evaluate(domain)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Action != ActionAllow {
+			t.Errorf("expected %s to be allowed (no wildcard match), got %v", domain, d.Action)
+		}
+	}
+}
+
+func TestEvaluate_WildcardPriority(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "wild-block", Action: "BLOCK", Priority: 10, Domains: []string{"*.corp.com"}},
+		{ID: "wild-allow", Action: "ALLOW", Priority: 100, Domains: []string{"*.corp.com"}},
+	})
+
+	d, err := e.Evaluate("intra.corp.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow || d.PolicyID != "wild-allow" {
+		t.Errorf("expected higher-priority wildcard ALLOW to win, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
+func TestEvaluate_ExactWinsOverRegex(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "exact", Action: "BLOCK", Priority: 10, Domains: []string{"exact.com"}},
+		// Catch-all regex at much higher priority; exact fast path must still win.
+		{ID: "rx-all", Action: "ALLOW", Priority: 999, Regexes: []string{`.*`}},
+	})
+
+	d, err := e.Evaluate("exact.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny || d.PolicyID != "exact" {
+		t.Errorf("expected exact-match fast path to win, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+
+	// A domain with no exact match falls through to the regex slow path.
+	d, err = e.Evaluate("anything.else")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow || d.PolicyID != "rx-all" {
+		t.Errorf("expected regex slow path to match, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
+func TestEvaluate_InvalidRegexDoesNotCrash(t *testing.T) {
+	e := NewPolicyEngine()
+	// Bad regex reaches the snapshot directly (LoadPolicies skips load-time
+	// validation); it must be skipped, and valid rules must still work.
+	e.LoadPolicies([]Policy{
+		{ID: "bad-rx", Action: "BLOCK", Priority: 100, Regexes: []string{`[invalid(`}},
+		{ID: "good-rx", Action: "BLOCK", Priority: 100, Regexes: []string{`^good\.net$`}},
+	})
+
+	// The invalid regex is skipped; querying anything must not panic.
+	d, err := e.Evaluate("harmless.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionAllow {
+		t.Errorf("expected ActionAllow (invalid regex skipped), got %v", d.Action)
+	}
+
+	// The valid regex alongside it still matches.
+	d, err = e.Evaluate("good.net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny || d.PolicyID != "good-rx" {
+		t.Errorf("expected valid regex to still match, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
+func TestEvaluate_ExactStillWorksWithDynamicRulesPresent(t *testing.T) {
+	e := NewPolicyEngine()
+	e.LoadPolicies([]Policy{
+		{ID: "exact-block", Action: "BLOCK", Priority: 100, Domains: []string{"ads.example.com"}},
+		{ID: "wild", Action: "BLOCK", Priority: 100, Domains: []string{"*.tracker.net"}},
+		{ID: "rx", Action: "BLOCK", Priority: 100, Regexes: []string{`^evil\.io$`}},
+	})
+
+	d, err := e.Evaluate("ads.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Action != ActionDeny || d.PolicyID != "exact-block" {
+		t.Errorf("expected exact match to still work with regex/wildcard present, got action=%v id=%q", d.Action, d.PolicyID)
+	}
+}
+
 func TestActionString(t *testing.T) {
 	tests := []struct {
 		a    Action

--- a/internal/policy/snapshot.go
+++ b/internal/policy/snapshot.go
@@ -1,34 +1,67 @@
 package policy
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/willf/bloom"
 )
 
+// compiledRegexRule pairs a pre-compiled regex with the policy that owns it.
+type compiledRegexRule struct {
+	re     *regexp.Regexp
+	policy *Policy
+}
+
+// wildcardRule holds a wildcard entry (e.g. "*.example.com") reduced to its
+// base domain ("example.com") plus the policy that owns it.
+type wildcardRule struct {
+	base   string
+	policy *Policy
+}
+
 type PolicySnapshot struct {
 	Bloom *bloom.BloomFilter
 	Exact map[string][]*Policy // exact domain to policies
+
+	// Regexes and Wildcards are evaluated only AFTER the exact/Bloom fast
+	// path misses, so the hot path stays untouched. Regexes are compiled
+	// once at snapshot-build time and cached here.
+	Regexes   []compiledRegexRule
+	Wildcards []wildcardRule
 }
 
 func buildSnapshot(policies []Policy) *PolicySnapshot {
 	exact := make(map[string][]*Policy)
+	var wildcards []wildcardRule
+	var regexes []compiledRegexRule
 	totalDomains := 0
 
 	// normalize domains and count total
 	for i := range policies {
-		for _, d := range policies[i].Domains {
+		p := &policies[i]
+		for _, d := range p.Domains {
 			normalized := normalizeDomain(d)
 			totalDomains++
 			if strings.Contains(normalized, "*") {
-				// TODO: wildcard handling later - for now still add to bloom
+				// wildcard entry, e.g. "*.example.com"
+				if base := wildcardBase(normalized); base != "" {
+					wildcards = append(wildcards, wildcardRule{base: base, policy: p})
+				}
 				continue
 			}
-			exact[normalized] = append(exact[normalized], &policies[i])
+			exact[normalized] = append(exact[normalized], p)
 		}
-		for _, rx := range policies[i].Regexes {
+		for _, rx := range p.Regexes {
 			totalDomains++
-			_ = rx
+			re, err := regexp.Compile(rx)
+			if err != nil {
+				// Invalid regex: skip safely. Load-time validation already
+				// rejects these, but guard here so a bad rule that reaches
+				// the snapshot never crashes the query path.
+				continue
+			}
+			regexes = append(regexes, compiledRegexRule{re: re, policy: p})
 		}
 	}
 
@@ -54,7 +87,18 @@ func buildSnapshot(policies []Policy) *PolicySnapshot {
 	}
 
 	return &PolicySnapshot{
-		Exact: exact,
-		Bloom: bf,
+		Exact:     exact,
+		Bloom:     bf,
+		Regexes:   regexes,
+		Wildcards: wildcards,
 	}
+}
+
+// wildcardBase reduces a leading-label wildcard pattern to its base domain.
+// "*.example.com" => "example.com". Returns "" for unsupported patterns.
+func wildcardBase(pattern string) string {
+	if strings.HasPrefix(pattern, "*.") {
+		return pattern[2:]
+	}
+	return ""
 }

--- a/internal/storage/models/dns_query.model.go
+++ b/internal/storage/models/dns_query.model.go
@@ -13,4 +13,5 @@ type DNSQuery struct {
 	ThreatScore     float64   `gorm:"default:0"`
 	DetectionMethod string    `gorm:"default:''"`
 	ThreatReason    string    `gorm:"default:''"`
+	BlockReason     string    `gorm:"default:''"` // why the query was blocked/redirected: "blocklist", a policy ID, "redirect:<policyID>", a threat method, or "" for allow
 }


### PR DESCRIPTION
This chunk merges 8 default-off dataplane feature PRs, rebased onto staging/chunk-1 in dependency order.

- #30: evaluate regex and wildcard policy rules at query time (previously TODO in the policy engine).
- #29: enforce a configurable threat score threshold, blocking or dry-run-logging suspicious domains from the heuristic detector.
- #31: optional blocking of high-abuse TLDs on the default allow path.
- #32: optional DNS rebinding protection, stripping upstream answers that resolve a public name to a private/loopback IP.
- #33: optional per-client query rate limiting with a fixed-window limiter.
- #34: record the block/redirect reason in the query log.
- #36: optional SafeSearch and YouTube Restricted Mode enforcement via CNAME rewrite.
- #37: optional DNS 0x20 case-randomization on outbound upstream queries.

All eight features are additive and default-off via config (each ships a zero-value/false default that preserves current behavior). Conflicts between them were in shared files (config.go, engine.go, engine_test.go) and were resolved by keeping both sides: all config fields, all struct fields, all constructor wiring, and all pipeline checks in ProcessDNSQuery.

Note: #34 adds a BlockReason column to the DNSQuery storage model (internal/storage/models/dns_query.model.go), a schema change to the query log table. This deserves a look before merging to main.

This branch is based on staging/chunk-0, so its diff includes the gofmt and gitignore-anchor fixes from that chunk until PR #73 merges.
