### PR TITLE
fix: resolve all golangci-lint and gosec findings

### DIFF
--- a/cmd/controlplane/handlers/dns_test.go
+++ b/cmd/controlplane/handlers/dns_test.go
@@ -130,7 +130,9 @@ func TestCreateResolver_Success(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 	var list []Resolver
-	json.Unmarshal(env.Data, &list)
+	if err := json.Unmarshal(env.Data, &list); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if len(list) != 1 {
 		t.Fatalf("expected 1 persisted resolver, got %d", len(list))
 	}
@@ -148,7 +150,9 @@ func TestCreateResolver_DefaultsNameAndProtocol(t *testing.T) {
 		t.Fatalf("expected 201, got %d (body=%s)", w.Code, w.Body.String())
 	}
 	var res Resolver
-	json.Unmarshal(env.Data, &res)
+	if err := json.Unmarshal(env.Data, &res); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if res.Name != "1.1.1.1:53" {
 		t.Errorf("expected name to default to address, got %q", res.Name)
 	}
@@ -195,7 +199,9 @@ func TestCreateResolver_InvalidAddress(t *testing.T) {
 	// Nothing should have been persisted.
 	_, env := doJSON(t, r, http.MethodGet, "/api/v1/dns/resolvers", "")
 	var list []Resolver
-	json.Unmarshal(env.Data, &list)
+	if err := json.Unmarshal(env.Data, &list); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if len(list) != 0 {
 		t.Errorf("expected no resolvers persisted after invalid creates, got %d", len(list))
 	}
@@ -233,7 +239,9 @@ func TestUpdateResolver_EditAddress(t *testing.T) {
 		t.Fatalf("expected 200, got %d (body=%s)", w.Code, w.Body.String())
 	}
 	var updated Resolver
-	json.Unmarshal(env.Data, &updated)
+	if err := json.Unmarshal(env.Data, &updated); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if updated.Address != "9.9.9.9:53" {
 		t.Errorf("expected updated address 9.9.9.9:53, got %q", updated.Address)
 	}
@@ -285,7 +293,9 @@ func TestUpdateResolver_Reorder(t *testing.T) {
 	// List must now return the second resolver first (ordered by position asc).
 	_, env := doJSON(t, r, http.MethodGet, "/api/v1/dns/resolvers", "")
 	var list []Resolver
-	json.Unmarshal(env.Data, &list)
+	if err := json.Unmarshal(env.Data, &list); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if len(list) != 2 {
 		t.Fatalf("expected 2 resolvers, got %d", len(list))
 	}
@@ -310,7 +320,9 @@ func TestDeleteResolver(t *testing.T) {
 	// List is empty afterwards.
 	_, listEnv := doJSON(t, r, http.MethodGet, "/api/v1/dns/resolvers", "")
 	var list []Resolver
-	json.Unmarshal(listEnv.Data, &list)
+	if err := json.Unmarshal(listEnv.Data, &list); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
 	if len(list) != 0 {
 		t.Errorf("expected 0 resolvers after delete, got %d", len(list))
 	}

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -42,7 +42,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to load system state: %v", err)
 	}
-	c.SetAcceptQueries(state.DNSEnabled)
+	if err := c.SetAcceptQueries(state.DNSEnabled); err != nil {
+		log.Printf("warning: failed to apply accept-queries state to dataplane: %v", err)
+	}
 
 	// Passive LAN device inventory (disabled by default; configured via
 	// INVENTORY_ENABLED and DHCP_LEASES_PATH).

--- a/internal/blocklist/fetcher/http_client.go
+++ b/internal/blocklist/fetcher/http_client.go
@@ -42,7 +42,7 @@ func (h *HTTPFetcher) Fetch(ctx context.Context, src parser.SourceConfig, knownE
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }() // best-effort; body is fully drained below or discarded on non-2xx
 
 		if resp.StatusCode == http.StatusNotModified {
 			// nothing changed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 // SPDX-License-Identifier: GPL-3.0-or-later
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -250,7 +251,10 @@ func defaultConfig() *Config {
 }
 
 func loadConfig(path string) *Config {
-	data, err := os.ReadFile(path)
+	// path comes from PHANTOM_CONFIG or the fixed default location, both
+	// operator-controlled, not request input. Reading an arbitrary path here
+	// is by design; filepath.Clean normalizes it before use.
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- operator-supplied config file path, by design
 	if err != nil {
 		logger.Log.Warnf("Config file not found (%s), using defaults", path)
 		return defaultConfig()

--- a/internal/diskhealth/stat_unix.go
+++ b/internal/diskhealth/stat_unix.go
@@ -5,6 +5,7 @@
 package diskhealth
 
 import (
+	"fmt"
 	"syscall"
 	"time"
 )
@@ -19,7 +20,11 @@ func readDiskStat(dir string) (diskStat, error) {
 		return diskStat{}, err
 	}
 
-	// Bsize is signed on some platforms; normalise to uint64.
+	// Bsize is signed on some platforms; normalise to uint64. Guard against a
+	// negative value (never expected from a real filesystem) before the cast.
+	if fs.Bsize < 0 {
+		return diskStat{}, fmt.Errorf("readDiskStat: negative block size %d from statfs", fs.Bsize)
+	}
 	bsize := uint64(fs.Bsize)
 	total := uint64(fs.Blocks) * bsize
 	free := uint64(fs.Bavail) * bsize

--- a/internal/dnsengine/connections.go
+++ b/internal/dnsengine/connections.go
@@ -233,7 +233,7 @@ func (p *UpstreamPool) Exchange(q *dns.Msg, timeout time.Duration) (*dns.Msg, er
 	}
 
 	var hadErr bool
-	defer p.releaseTCPConn(idx, hadErr)
+	defer func() { p.releaseTCPConn(idx, hadErr) }()
 
 	// wrap with dns.Conn for framing (length-prefix) and convenience
 	dnsConn := &dns.Conn{Conn: tcpConn}

--- a/internal/dnsengine/encrypted_upstream.go
+++ b/internal/dnsengine/encrypted_upstream.go
@@ -119,7 +119,7 @@ func (d *dohClient) Exchange(q *dns.Msg, _ time.Duration) (*dns.Msg, error) {
 	if err != nil {
 		return nil, fmt.Errorf("doh exchange to %s: %w", d.endpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // best-effort; body is fully drained below or discarded on non-2xx
 
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 512))

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -112,7 +112,10 @@ func newTestQuery(domain string) *dns.Msg {
 
 func newTestEngine(bl *mockBlocklist, policies []policy.Policy) *Engine {
 	pe := policy.NewPolicyEngine()
-	pe.LoadPolicies(policies)
+	// LoadPolicies never errors (buildSnapshot has no failure path); this
+	// helper has no *testing.T to report a failure with, and threading one
+	// through its ~40 call sites for an error that can't occur isn't worth it.
+	_ = pe.LoadPolicies(policies)
 
 	e := &Engine{
 		policyEngine: pe,

--- a/internal/dnsengine/export.go
+++ b/internal/dnsengine/export.go
@@ -339,7 +339,11 @@ func (h *webhookSink) Send(ev Event) error {
 	if err != nil {
 		return fmt.Errorf("post webhook: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			logger.Log.Warnf("event export: webhook response body close error: %v", cerr)
+		}
+	}()
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
 	}

--- a/internal/dnsengine/export_test.go
+++ b/internal/dnsengine/export_test.go
@@ -260,13 +260,13 @@ func TestSyslogSink_UDP_WritesRFC5424(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen udp: %v", err)
 	}
-	defer pc.Close()
+	defer func() { _ = pc.Close() }() // best-effort cleanup, test outcome doesn't depend on it
 
 	sink, err := newSyslogSink("udp://" + pc.LocalAddr().String())
 	if err != nil {
 		t.Fatalf("newSyslogSink: %v", err)
 	}
-	defer sink.Close()
+	defer func() { _ = sink.Close() }() // best-effort cleanup, test outcome doesn't depend on it
 
 	if err := sink.Send(sampleEvent()); err != nil {
 		t.Fatalf("syslog Send: %v", err)

--- a/internal/dnsengine/server.go
+++ b/internal/dnsengine/server.go
@@ -95,8 +95,12 @@ func (s *Server) Run() {
 
 	logger.Log.Info("entering drain mode")
 	s.engine.state.acceptQueries.Store(false)
-	udpSrv.Shutdown()
-	tcpSrv.Shutdown()
+	if err := udpSrv.Shutdown(); err != nil {
+		logger.Log.Warn("UDP server shutdown error: ", err)
+	}
+	if err := tcpSrv.Shutdown(); err != nil {
+		logger.Log.Warn("TCP server shutdown error: ", err)
+	}
 
 	logger.Log.Info("exited")
 }

--- a/internal/dnsengine/upstream_manager.go
+++ b/internal/dnsengine/upstream_manager.go
@@ -160,7 +160,12 @@ func (m *UpstreamManager) prepareOutbound(q *dns.Msg, r *rand.Rand) (*dns.Msg, [
 func (m *UpstreamManager) Exchange(q *dns.Msg, timeout time.Duration, maxRetries int) (*dns.Msg, error) {
 	var r *rand.Rand
 	if m.dns0x20 {
-		r = rand.New(rand.NewSource(time.Now().UnixNano()))
+		// DNS 0x20 case randomization (see case_randomize.go) needs an
+		// unpredictable-to-an-off-path-attacker source, not cryptographic
+		// security, and randomizeCase/encodeCase0x20 are written as pure
+		// functions of a *rand.Rand so tests can seed them deterministically.
+		// crypto/rand has no seeding API and would break that contract.
+		r = rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404 -- non-cryptographic use (0x20 entropy), deterministic seeding required for tests
 	}
 	outbound, originals := m.prepareOutbound(q, r)
 

--- a/internal/grpc/controlplane/client.go
+++ b/internal/grpc/controlplane/client.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	pb "github.com/lopster568/phantomDNS/internal/gen/proto/phantomdns/v1"
-	v1 "github.com/lopster568/phantomDNS/internal/gen/proto/phantomdns/v1"
+	"github.com/lopster568/phantomDNS/internal/logger"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -17,9 +18,11 @@ type Client struct {
 	metrics pb.DataPlaneMetricsServiceClient
 }
 
-// New creates and connects the gRPC client.
+// New creates the gRPC client. Like grpc.Dial before it, grpc.NewClient does
+// not block: it establishes the connection lazily on first use, so callers
+// relying on that (no grpc.WithBlock() is used here) see no behavior change.
 func New(address string) (*Client, error) {
-	conn, err := grpc.Dial(address, grpc.WithInsecure()) // TLS later
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials())) // TLS later
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
@@ -32,7 +35,9 @@ func New(address string) (*Client, error) {
 }
 
 func (c *Client) Close() {
-	c.conn.Close()
+	if err := c.conn.Close(); err != nil {
+		logger.Log.Warn("grpc controlplane client: close error: ", err)
+	}
 }
 
 // GetStatus fetches dataplane runtime status.
@@ -53,7 +58,7 @@ func (c *Client) SetAcceptQueries(enabled bool) error {
 	return err
 }
 
-func (c *Client) GetLiveQueryMetrics(ctx context.Context) (*v1.LiveQueryMetrics, error) {
+func (c *Client) GetLiveQueryMetrics(ctx context.Context) (*pb.LiveQueryMetrics, error) {
 	return c.metrics.GetLiveQueryMetrics(ctx, &emptypb.Empty{})
 }
 

--- a/internal/grpc/dataplane/metrics.go
+++ b/internal/grpc/dataplane/metrics.go
@@ -3,6 +3,7 @@ package dataplane
 
 import (
 	"context"
+	"time"
 
 	"github.com/lopster568/phantomDNS/internal/dnsengine"
 	pb "github.com/lopster568/phantomDNS/internal/gen/proto/phantomdns/v1"
@@ -37,8 +38,19 @@ func (s *MetricsService) GetLiveQueryMetrics(
 		TotalQueries: agg.Total,
 		ErrorQueries: agg.Errors,
 
-		P50Ms: uint64(p50.Milliseconds()),
-		P95Ms: uint64(p95.Milliseconds()),
-		P99Ms: uint64(p99.Milliseconds()),
+		P50Ms: durationMsToUint64(p50),
+		P95Ms: durationMsToUint64(p95),
+		P99Ms: durationMsToUint64(p99),
 	}, nil
+}
+
+// durationMsToUint64 converts a duration (always non-negative here, since it
+// comes from metrics.EstimatePercentile) to milliseconds as uint64, guarding
+// against a negative value rather than assuming the caller's invariant holds.
+func durationMsToUint64(d time.Duration) uint64 {
+	ms := d.Milliseconds()
+	if ms < 0 {
+		return 0
+	}
+	return uint64(ms)
 }

--- a/internal/heartbeat/heartbeat.go
+++ b/internal/heartbeat/heartbeat.go
@@ -193,7 +193,11 @@ func (r *Reporter) reportOnce(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("post heartbeat: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			logger.Log.Warnf("heartbeat: response body close error: %v", cerr)
+		}
+	}()
 
 	if resp.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("heartbeat collector returned status %d", resp.StatusCode)
@@ -309,6 +313,9 @@ func diskUsage(path string) (free, total uint64, err error) {
 	var st syscall.Statfs_t
 	if err := syscall.Statfs(path, &st); err != nil {
 		return 0, 0, err
+	}
+	if st.Bsize < 0 {
+		return 0, 0, fmt.Errorf("diskUsage: negative block size %d from statfs", st.Bsize)
 	}
 	bsize := uint64(st.Bsize)
 	return st.Bavail * bsize, st.Blocks * bsize, nil

--- a/internal/metrics/promexport/collector_test.go
+++ b/internal/metrics/promexport/collector_test.go
@@ -28,7 +28,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /metrics: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // best-effort cleanup, test outcome doesn't depend on it
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)

--- a/internal/metrics/query_metrics.go
+++ b/internal/metrics/query_metrics.go
@@ -21,8 +21,11 @@ type QueryMetrics struct {
 	windowSize time.Duration
 	sliceSize  time.Duration
 
-	slices  []metricsSlice
-	current atomic.Uint32
+	slices []metricsSlice
+	// sliceCount mirrors len(slices) as a uint32, computed once so the
+	// rotation path in currentSlice never has to convert an int length.
+	sliceCount uint32
+	current    atomic.Uint32
 }
 
 const (
@@ -40,11 +43,19 @@ type AggregatedMetrics struct {
 
 func NewQueryMetrics() *QueryMetrics {
 	sliceCount := int(defaultWindowSize / defaultSliceSize)
+	// sliceCount is a fixed, small constant derived from the window/slice
+	// duration constants above (10 with the current defaults); it can never
+	// approach uint32's range, but guard the conversion explicitly rather
+	// than assume it.
+	if sliceCount <= 0 || sliceCount > math.MaxUint32 {
+		sliceCount = 1
+	}
 
 	m := &QueryMetrics{
 		windowSize: defaultWindowSize,
 		sliceSize:  defaultSliceSize,
 		slices:     make([]metricsSlice, sliceCount),
+		sliceCount: uint32(sliceCount),
 	}
 
 	now := time.Now().Unix()
@@ -66,15 +77,17 @@ func (m *QueryMetrics) currentSlice() *metricsSlice {
 		return s
 	}
 
-	// Rotate to next slice
-	next := (idx + 1) % len(m.slices)
+	// Rotate to next slice. Computed natively in uint32 (the type m.current
+	// stores) against the precomputed sliceCount, so there is no int->uint32
+	// narrowing conversion on this path.
+	next := (m.current.Load() + 1) % m.sliceCount
 
 	// Reset the next slice
 	m.slices[next] = metricsSlice{
 		startUnix: now,
 	}
 
-	m.current.Store(uint32(next))
+	m.current.Store(next)
 	return &m.slices[next]
 }
 

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -35,9 +35,11 @@ func TestEvaluate_AllowByDefault(t *testing.T) {
 
 func TestEvaluate_BlockExactDomain(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "block-ads", Action: "BLOCK", Priority: 100, Domains: []string{"ads.example.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("ads.example.com", "")
 	if err != nil {
@@ -53,9 +55,11 @@ func TestEvaluate_BlockExactDomain(t *testing.T) {
 
 func TestEvaluate_CaseInsensitive(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "p1", Action: "BLOCK", Priority: 100, Domains: []string{"ADS.Example.COM"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("ads.example.com", "")
 	if err != nil {
@@ -68,9 +72,11 @@ func TestEvaluate_CaseInsensitive(t *testing.T) {
 
 func TestEvaluate_TrailingDotNormalized(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "p1", Action: "BLOCK", Priority: 100, Domains: []string{"blocked.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("blocked.com.", "")
 	if err != nil {
@@ -83,9 +89,11 @@ func TestEvaluate_TrailingDotNormalized(t *testing.T) {
 
 func TestEvaluate_Redirect(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "redir", Action: "REDIRECT", Priority: 100, Redirect: "1.2.3.4", Domains: []string{"redirect.me"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("redirect.me", "")
 	if err != nil {
@@ -101,10 +109,12 @@ func TestEvaluate_Redirect(t *testing.T) {
 
 func TestEvaluate_HighestPriorityWins(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "low", Action: "ALLOW", Priority: 10, Domains: []string{"test.com"}},
 		{ID: "high", Action: "BLOCK", Priority: 200, Domains: []string{"test.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("test.com", "")
 	if err != nil {
@@ -120,10 +130,12 @@ func TestEvaluate_HighestPriorityWins(t *testing.T) {
 
 func TestEvaluate_TieBreakByID(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "zzz", Action: "ALLOW", Priority: 100, Domains: []string{"tie.com"}},
 		{ID: "aaa", Action: "BLOCK", Priority: 100, Domains: []string{"tie.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("tie.com", "")
 	if err != nil {
@@ -136,9 +148,11 @@ func TestEvaluate_TieBreakByID(t *testing.T) {
 
 func TestEvaluate_BloomNegativeShortCircuit(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "p1", Action: "BLOCK", Priority: 100, Domains: []string{"blocked.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Domain not in bloom filter should be allowed without hitting exact map
 	d, err := e.Evaluate("notblocked.com", "")
@@ -152,9 +166,11 @@ func TestEvaluate_BloomNegativeShortCircuit(t *testing.T) {
 
 func TestEvaluate_MultipleDomainsSamePolicy(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "multi", Action: "BLOCK", Priority: 100, Domains: []string{"a.com", "b.com", "c.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, domain := range []string{"a.com", "b.com", "c.com"} {
 		d, err := e.Evaluate(domain, "")
@@ -169,7 +185,9 @@ func TestEvaluate_MultipleDomainsSamePolicy(t *testing.T) {
 
 func TestEvaluate_EmptyPolicies(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{})
+	if err := e.LoadPolicies([]Policy{}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("anything.com", "")
 	if err != nil {
@@ -196,9 +214,11 @@ func TestPolicyDecision_Nil(t *testing.T) {
 
 func TestEvaluate_BlockByRegex(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "rx-block", Action: "BLOCK", Priority: 100, Regexes: []string{`.*\.doubleclick\.net$`}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("ads.doubleclick.net", "")
 	if err != nil {
@@ -223,10 +243,12 @@ func TestEvaluate_BlockByRegex(t *testing.T) {
 
 func TestEvaluate_RegexAllowOverridesByPriority(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "rx-block", Action: "BLOCK", Priority: 10, Regexes: []string{`.*\.tracking\.com$`}},
 		{ID: "rx-allow", Action: "ALLOW", Priority: 100, Regexes: []string{`.*\.tracking\.com$`}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("beacon.tracking.com", "")
 	if err != nil {
@@ -242,10 +264,12 @@ func TestEvaluate_RegexAllowOverridesByPriority(t *testing.T) {
 
 func TestEvaluate_RegexTieBreakByID(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "zzz-rx", Action: "ALLOW", Priority: 50, Regexes: []string{`^tie\.rx$`}},
 		{ID: "aaa-rx", Action: "BLOCK", Priority: 50, Regexes: []string{`^tie\.rx$`}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("tie.rx", "")
 	if err != nil {
@@ -261,9 +285,11 @@ func TestEvaluate_RegexTieBreakByID(t *testing.T) {
 
 func TestEvaluate_WildcardMatchesSubdomains(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "wild", Action: "BLOCK", Priority: 100, Domains: []string{"*.example.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Wildcard matches the base domain and any depth of subdomain.
 	for _, domain := range []string{"example.com", "sub.example.com", "a.b.example.com"} {
@@ -293,10 +319,12 @@ func TestEvaluate_WildcardMatchesSubdomains(t *testing.T) {
 
 func TestEvaluate_WildcardPriority(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "wild-block", Action: "BLOCK", Priority: 10, Domains: []string{"*.corp.com"}},
 		{ID: "wild-allow", Action: "ALLOW", Priority: 100, Domains: []string{"*.corp.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("intra.corp.com", "")
 	if err != nil {
@@ -309,11 +337,13 @@ func TestEvaluate_WildcardPriority(t *testing.T) {
 
 func TestEvaluate_ExactWinsOverRegex(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "exact", Action: "BLOCK", Priority: 10, Domains: []string{"exact.com"}},
 		// Catch-all regex at much higher priority; exact fast path must still win.
 		{ID: "rx-all", Action: "ALLOW", Priority: 999, Regexes: []string{`.*`}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("exact.com", "")
 	if err != nil {
@@ -337,10 +367,12 @@ func TestEvaluate_InvalidRegexDoesNotCrash(t *testing.T) {
 	e := NewPolicyEngine()
 	// Bad regex reaches the snapshot directly (LoadPolicies skips load-time
 	// validation); it must be skipped, and valid rules must still work.
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "bad-rx", Action: "BLOCK", Priority: 100, Regexes: []string{`[invalid(`}},
 		{ID: "good-rx", Action: "BLOCK", Priority: 100, Regexes: []string{`^good\.net$`}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// The invalid regex is skipped; querying anything must not panic.
 	d, err := e.Evaluate("harmless.com", "")
@@ -363,11 +395,13 @@ func TestEvaluate_InvalidRegexDoesNotCrash(t *testing.T) {
 
 func TestEvaluate_ExactStillWorksWithDynamicRulesPresent(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "exact-block", Action: "BLOCK", Priority: 100, Domains: []string{"ads.example.com"}},
 		{ID: "wild", Action: "BLOCK", Priority: 100, Domains: []string{"*.tracker.net"}},
 		{ID: "rx", Action: "BLOCK", Priority: 100, Regexes: []string{`^evil\.io$`}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("ads.example.com", "")
 	if err != nil {

--- a/internal/policy/loader.go
+++ b/internal/policy/loader.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -14,24 +15,27 @@ type policyFile struct {
 
 func LoadPoliciesFromFile(path string) ([]Policy, error) {
 	if path == "" {
-		return nil, fmt.Errorf("No file path provided")
+		return nil, fmt.Errorf("no file path provided")
 	}
 
-	f, err := os.ReadFile(path)
+	// path is an operator-supplied policy file location (config/CLI flag), not
+	// derived from untrusted request input. Reading an arbitrary path here is
+	// by design; filepath.Clean normalizes it before use.
+	f, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- operator-supplied policy file path, by design
 
 	if err != nil {
-		return nil, fmt.Errorf("Unable to read file")
+		return nil, fmt.Errorf("unable to read file")
 	}
 
 	var pf policyFile
 
 	if err := json.Unmarshal(f, &pf); err != nil {
-		return nil, fmt.Errorf("Failed to marshal, check JSON syntax")
+		return nil, fmt.Errorf("failed to marshal, check JSON syntax")
 	}
 
 	for i := range pf.Policies {
 		if err := ValidatePolicy(&pf.Policies[i]); err != nil {
-			return nil, fmt.Errorf("Invalid policy %d: %v", i, err)
+			return nil, fmt.Errorf("invalid policy %d: %v", i, err)
 		}
 		// normalize domains
 		for j := range pf.Policies[i].Domains {

--- a/internal/policy/scope_test.go
+++ b/internal/policy/scope_test.go
@@ -6,10 +6,12 @@ import "testing"
 // applies to a query from a client inside its range.
 func TestEvaluate_ScopedPolicyMatchingClient(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "scoped", Action: "BLOCK", Priority: 100,
 			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("ads.example.com", "192.168.1.50:5353")
 	if err != nil {
@@ -27,10 +29,12 @@ func TestEvaluate_ScopedPolicyMatchingClient(t *testing.T) {
 // does NOT apply to a query from a client outside its range (default Allow).
 func TestEvaluate_ScopedPolicyNonMatchingClient(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "scoped", Action: "BLOCK", Priority: 100,
 			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("ads.example.com", "10.0.0.5:1234")
 	if err != nil {
@@ -45,9 +49,11 @@ func TestEvaluate_ScopedPolicyNonMatchingClient(t *testing.T) {
 // to every client, including one whose IP is unknown.
 func TestEvaluate_UnscopedPolicyAppliesToAll(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "all", Action: "BLOCK", Priority: 100, Domains: []string{"ads.example.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, client := range []string{"192.168.1.50:53", "10.0.0.5:53", "", "not-an-ip"} {
 		d, err := e.Evaluate("ads.example.com", client)
@@ -64,10 +70,12 @@ func TestEvaluate_UnscopedPolicyAppliesToAll(t *testing.T) {
 // matches when the client IP cannot be determined (fail-closed for scope).
 func TestEvaluate_ScopedPolicyUnknownClientIP(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "scoped", Action: "BLOCK", Priority: 100,
 			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := e.Evaluate("ads.example.com", "")
 	if err != nil {
@@ -82,10 +90,12 @@ func TestEvaluate_ScopedPolicyUnknownClientIP(t *testing.T) {
 // matches only that exact client.
 func TestEvaluate_ScopeSingleHostIP(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "host", Action: "BLOCK", Priority: 100,
 			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"192.168.1.10"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	if d, _ := e.Evaluate("ads.example.com", "192.168.1.10:5000"); d.Action != ActionDeny {
 		t.Errorf("expected ActionDeny for exact host, got %v", d.Action)
@@ -100,12 +110,14 @@ func TestEvaluate_ScopeSingleHostIP(t *testing.T) {
 // while an unscoped policy on a different domain hits both.
 func TestEvaluate_MultipleClientsIndependent(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "kids-block", Action: "BLOCK", Priority: 100,
 			Domains: []string{"social.example.com"}, ClientCIDRs: []string{"192.168.10.0/24"}},
 		{ID: "global-block", Action: "BLOCK", Priority: 100,
 			Domains: []string{"malware.example.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	const kid = "192.168.10.5:53"
 	const staff = "192.168.20.9:53"
@@ -132,12 +144,14 @@ func TestEvaluate_MultipleClientsIndependent(t *testing.T) {
 // unscoped policy on the parent domain rather than stopping early.
 func TestEvaluate_ScopeWalksToParentPolicy(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "sub-scoped", Action: "REDIRECT", Priority: 100, Redirect: "1.2.3.4",
 			Domains: []string{"api.example.com"}, ClientCIDRs: []string{"192.168.1.0/24"}},
 		{ID: "parent-all", Action: "BLOCK", Priority: 100,
 			Domains: []string{"example.com"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Out-of-scope client: subdomain rule is skipped, parent BLOCK applies.
 	d, err := e.Evaluate("api.example.com", "10.0.0.1:53")
@@ -162,10 +176,12 @@ func TestEvaluate_ScopeWalksToParentPolicy(t *testing.T) {
 // bracketed host:port form handed out by the dataplane.
 func TestEvaluate_ScopeIPv6(t *testing.T) {
 	e := NewPolicyEngine()
-	e.LoadPolicies([]Policy{
+	if err := e.LoadPolicies([]Policy{
 		{ID: "v6", Action: "BLOCK", Priority: 100,
 			Domains: []string{"ads.example.com"}, ClientCIDRs: []string{"2001:db8::/32"}},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	if d, _ := e.Evaluate("ads.example.com", "[2001:db8::1]:53"); d.Action != ActionDeny {
 		t.Errorf("expected ActionDeny for in-scope IPv6 client, got %v", d.Action)

--- a/internal/policy/snapshot.go
+++ b/internal/policy/snapshot.go
@@ -88,9 +88,9 @@ func buildSnapshot(policies []Policy) *PolicySnapshot {
 		// are skipped here; the loader/control-plane validate on ingest, so a
 		// bad range means "no valid ranges" and the scoped policy simply never
 		// matches (fail-closed for scope, not for the whole policy set).
-		for _, c := range policies[i].ClientCIDRs {
+		for _, c := range p.ClientCIDRs {
 			if n, err := parseClientScope(c); err == nil {
-				clientNets[policies[i].ID] = append(clientNets[policies[i].ID], n)
+				clientNets[p.ID] = append(clientNets[p.ID], n)
 			}
 		}
 	}
@@ -108,10 +108,11 @@ func buildSnapshot(policies []Policy) *PolicySnapshot {
 
 	// add raw domains with wildcard and plain regex tokens as strings
 	for i := range policies {
-		for _, d := range policies[i].Domains {
+		p := &policies[i]
+		for _, d := range p.Domains {
 			bf.AddString(normalizeDomain(d))
 		}
-		for _, r := range policies[i].Regexes {
+		for _, r := range p.Regexes {
 			bf.AddString(r)
 		}
 	}

--- a/internal/storage/repositories/repositories_test.go
+++ b/internal/storage/repositories/repositories_test.go
@@ -18,7 +18,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}
-	db.AutoMigrate(
+	if err := db.AutoMigrate(
 		&models.BlocklistSource{},
 		&models.BlocklistSnapshot{},
 		&models.BlocklistEntry{},
@@ -26,7 +26,9 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&models.Statistics{},
 		&models.SystemState{},
 		&models.Policy{},
-	)
+	); err != nil {
+		t.Fatalf("failed to migrate test db: %v", err)
+	}
 	return db
 }
 
@@ -222,8 +224,12 @@ func TestQueryLogRepo_SaveAndListRecent(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewGormQueryLogRepo(db)
 
-	repo.Save(&models.DNSQuery{Domain: "first.com", ClientIP: "1.2.3.4", Action: "allow"})
-	repo.Save(&models.DNSQuery{Domain: "second.com", ClientIP: "1.2.3.4", Action: "block"})
+	if err := repo.Save(&models.DNSQuery{Domain: "first.com", ClientIP: "1.2.3.4", Action: "allow"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Save(&models.DNSQuery{Domain: "second.com", ClientIP: "1.2.3.4", Action: "block"}); err != nil {
+		t.Fatal(err)
+	}
 
 	queries, err := repo.ListRecent(10)
 	if err != nil {
@@ -243,7 +249,9 @@ func TestQueryLogRepo_ListRecent_Limit(t *testing.T) {
 	repo := NewGormQueryLogRepo(db)
 
 	for i := 0; i < 5; i++ {
-		repo.Save(&models.DNSQuery{Domain: "test.com", ClientIP: "1.2.3.4", Action: "allow"})
+		if err := repo.Save(&models.DNSQuery{Domain: "test.com", ClientIP: "1.2.3.4", Action: "allow"}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	queries, err := repo.ListRecent(3)
@@ -261,10 +269,11 @@ func TestStatisticsRepo_IncrementCounter(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewGormStatisticsRepo(db)
 
-	repo.IncrementCounter("allow")
-	repo.IncrementCounter("allow")
-	repo.IncrementCounter("block")
-	repo.IncrementCounter("redirect")
+	for _, action := range []string{"allow", "allow", "block", "redirect"} {
+		if err := repo.IncrementCounter(action); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	var stats models.Statistics
 	db.First(&stats, 1)
@@ -287,7 +296,9 @@ func TestStatisticsRepo_UnknownAction(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewGormStatisticsRepo(db)
 
-	repo.IncrementCounter("something_weird")
+	if err := repo.IncrementCounter("something_weird"); err != nil {
+		t.Fatal(err)
+	}
 
 	var stats models.Statistics
 	db.First(&stats, 1)
@@ -324,7 +335,9 @@ func TestSystemStateRepo_SetDNSEnabled(t *testing.T) {
 	repo := NewSystemStateRepo(db)
 
 	// Create initial state
-	repo.Get()
+	if _, err := repo.Get(); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := repo.SetDNSEnabled(true); err != nil {
 		t.Fatal(err)
@@ -340,7 +353,9 @@ func TestSystemStateRepo_SetPolicyEnabled(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewSystemStateRepo(db)
 
-	repo.Get()
+	if _, err := repo.Get(); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := repo.SetPolicyEnabled(true); err != nil {
 		t.Fatal(err)
@@ -393,8 +408,12 @@ func TestPolicyRepo_List(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewPolicyRepo(db)
 
-	repo.Create(&models.Policy{ID: "p1", Name: "P1", Action: "BLOCK", Priority: 10, Enabled: true})
-	repo.Create(&models.Policy{ID: "p2", Name: "P2", Action: "ALLOW", Priority: 200, Enabled: false})
+	if err := repo.Create(&models.Policy{ID: "p1", Name: "P1", Action: "BLOCK", Priority: 10, Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Create(&models.Policy{ID: "p2", Name: "P2", Action: "ALLOW", Priority: 200, Enabled: false}); err != nil {
+		t.Fatal(err)
+	}
 
 	list, err := repo.List()
 	if err != nil {
@@ -413,7 +432,9 @@ func TestPolicyRepo_Delete(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewPolicyRepo(db)
 
-	repo.Create(&models.Policy{ID: "del-me", Name: "Del", Action: "BLOCK"})
+	if err := repo.Create(&models.Policy{ID: "del-me", Name: "Del", Action: "BLOCK"}); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := repo.Delete("del-me"); err != nil {
 		t.Fatal(err)
@@ -491,13 +512,17 @@ func TestBlocklistRepo_DeleteSourceCascades(t *testing.T) {
 	repo := NewBlocklistRepo(db)
 
 	src := &models.BlocklistSource{ID: "src1", Name: "Test", URL: "http://x", Format: "hosts", Enabled: true, CreatedAt: time.Now()}
-	repo.CreateSource(src)
+	if err := repo.CreateSource(src); err != nil {
+		t.Fatal(err)
+	}
 
 	entries := []models.BlocklistEntry{
 		{Domain: "a.com", SourceID: "src1"},
 		{Domain: "b.com", SourceID: "src1"},
 	}
-	repo.SaveSnapshotWithEntries(*src, "hash", entries)
+	if _, err := repo.SaveSnapshotWithEntries(*src, "hash", entries); err != nil {
+		t.Fatal(err)
+	}
 
 	// Verify entries exist
 	count, _ := repo.CountEntriesBySource("src1")
@@ -506,7 +531,9 @@ func TestBlocklistRepo_DeleteSourceCascades(t *testing.T) {
 	}
 
 	// Delete source — should cascade
-	repo.DeleteSource("src1")
+	if err := repo.DeleteSource("src1"); err != nil {
+		t.Fatal(err)
+	}
 
 	count, _ = repo.CountEntriesBySource("src1")
 	if count != 0 {

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -110,7 +110,7 @@ func EnsureSelfSigned(dir string, hosts []string) (certFile, keyFile string, err
 		return certFile, keyFile, nil
 	}
 
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return "", "", fmt.Errorf("create cert directory: %w", err)
 	}
 
@@ -119,7 +119,10 @@ func EnsureSelfSigned(dir string, hosts []string) (certFile, keyFile string, err
 		return "", "", err
 	}
 
-	if err := os.WriteFile(certFile, certPEM, 0o644); err != nil {
+	// Only this process reads certFile (via r.RunTLS below); it does not need
+	// to be world-readable, so it is written with the same restrictive mode
+	// as the key.
+	if err := os.WriteFile(certFile, certPEM, 0o600); err != nil {
 		return "", "", fmt.Errorf("write certificate: %w", err)
 	}
 	// The private key is written with restrictive permissions.


### PR DESCRIPTION
This resolves every finding golangci-lint v2.12.2 and gosec v2.28.0 report against current main, using the exact CI invocations (golangci-lint run --timeout=5m and gosec -exclude-dir=internal/gen ./...).

Lint findings before this PR: 69 total, all newly surfaced by the 40 feature PRs that just merged (60 errcheck, 2 ineffassign, 7 staticcheck). After: 0.

Gosec findings before this PR: 19 total (6 G115, 4 G602, 4 G104, 2 G304, 1 G404, 1 G306, 1 G301). After: 0.

grpc migration note: the controlplane gRPC client used grpc.Dial and grpc.WithInsecure, both deprecated (staticcheck SA1019). Migrated to grpc.NewClient and grpc.WithTransportCredentials(insecure.NewCredentials()). Neither call site used grpc.WithBlock(), and grpc.NewClient is lazy by default the same way grpc.Dial was, so the connection is still established on first use rather than at construction. No caller assumed eager connection.

Three #nosec annotations were added, each with its own justification comment at the site:

internal/policy/loader.go, G304: the path is an operator-supplied policy file location (config or CLI flag), not derived from request input. This is by design for this product. filepath.Clean is applied before the read.

internal/config/config.go, G304: the path comes from the PHANTOM_CONFIG env var or a fixed default location, both operator-controlled. filepath.Clean is applied before the read.

internal/dnsengine/upstream_manager.go, G404: DNS 0x20 case randomization needs unpredictability from an off-path attacker, not cryptographic security, and the encoding functions are written as pure functions of a *rand.Rand specifically so tests can seed them deterministically. crypto/rand has no seeding API and would break that test contract.

A fourth #nosec G304 annotation already existed in internal/diskhealth/wear_linux.go before this PR and was not touched.

Other notable fixes:

The ineffassign findings in dnsengine/connections.go were a real bug, not just a lint nit: the deferred call to releaseTCPConn captured hadErr's value at defer-registration time (always false), so the later hadErr = true assignments on the error paths never reached the release call, meaning failed TCP connections were never actually closed or removed from the pool. Wrapping the defer in a closure fixes this.

The two G602 findings in policy/snapshot.go were resolved by reusing the p := &policies[i] pointer already derived earlier in the same loop iteration instead of re-indexing policies[i] directly, which satisfies gosec's bounds analysis without changing behavior.

The G115 findings were fixed per site: guarded the signed statfs Bsize field against negative values before casting to uint64 in heartbeat.go and diskhealth/stat_unix.go, clamped negative durations to 0 before the millisecond cast in grpc/dataplane/metrics.go, and removed the int-to-uint32 cast entirely in metrics/query_metrics.go by precomputing the slice count once as uint32 at construction instead of converting len() on every rotation.

The G301/G306 findings in tlsutil.go were tightened rather than suppressed: the self-signed cert directory and certificate file are only ever read by this process, so MkdirAll now uses 0750 and the certificate WriteFile now uses 0600, matching the private key's existing mode. No test asserted the old, more permissive modes.

No API changes, no config changes, no behavior changes outside what is described above. gofmt, go build, go vet, and go test -race all pass, along with the two now-clean CI jobs.
