### PR TITLE
fix: controlplane-to-dataplane gRPC dial address + real integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,6 +146,20 @@ jobs:
 
     - name: ⏳ Wait for services to become healthy
       run: |
+        COMPOSE="docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml"
+
+        dump_diagnostics() {
+          echo "::group::Container status"
+          $COMPOSE ps -a
+          echo "::endgroup::"
+          echo "::group::Last 50 log lines per container"
+          $COMPOSE logs --tail=50
+          echo "::endgroup::"
+          echo "::group::Full logs"
+          $COMPOSE logs
+          echo "::endgroup::"
+        }
+
         echo "Waiting for control-plane /health..."
         for i in $(seq 1 30); do
           if curl -sf http://127.0.0.1:8086/health > /dev/null; then
@@ -154,7 +168,7 @@ jobs:
           fi
           if [ "$i" -eq 30 ]; then
             echo "control-plane did not become healthy in time"
-            docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml logs
+            dump_diagnostics
             exit 1
           fi
           sleep 2
@@ -168,7 +182,7 @@ jobs:
           fi
           if [ "$i" -eq 30 ]; then
             echo "dataplane metrics did not become available in time"
-            docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml logs
+            dump_diagnostics
             exit 1
           fi
           sleep 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,66 @@ jobs:
         docker compose -f compose.yaml config
         echo "✅ Docker Compose configuration is valid"
 
+  # Integration Tests
+  integration:
+    name: 🔄 Integration Tests
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+    - name: 📥 Checkout code
+      uses: actions/checkout@v7
+
+    - name: 🔧 Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+
+    - name: 🐳 Build and start the compose stack
+      run: |
+        docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml up -d --build
+
+    - name: ⏳ Wait for services to become healthy
+      run: |
+        echo "Waiting for control-plane /health..."
+        for i in $(seq 1 30); do
+          if curl -sf http://127.0.0.1:8086/health > /dev/null; then
+            echo "control-plane is up"
+            break
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "control-plane did not become healthy in time"
+            docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml logs
+            exit 1
+          fi
+          sleep 2
+        done
+
+        echo "Waiting for dataplane /metrics..."
+        for i in $(seq 1 30); do
+          if curl -sf http://127.0.0.1:9153/metrics > /dev/null; then
+            echo "dataplane metrics are up"
+            break
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "dataplane metrics did not become available in time"
+            docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml logs
+            exit 1
+          fi
+          sleep 2
+        done
+
+    - name: 🧪 Run integration tests
+      run: go test -tags=integration -v ./tests/integration/...
+
+    - name: 🪵 Dump compose logs on failure
+      if: failure()
+      run: docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml logs
+
+    - name: 🧹 Tear down the compose stack
+      if: always()
+      run: docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml down -v
+
   # Dependency Check
   deps:
     name: 📦 Dependency Check

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -30,8 +30,12 @@ func main() {
 	db.InitDB(dbPath)
 	repos := repositories.NewStore(db.DB)
 
-	// Initialize grpc client
-	c, err := client.New(config.DefaultConfig.DataPlane.GRPCServer.ListenAddr)
+	// Initialize grpc client. This dials the dataplane's gRPC server, which is
+	// a different address than the dataplane's own bind address
+	// (DataPlane.GRPCServer.ListenAddr) in any topology where the two planes
+	// are not the same host (e.g. docker compose). See ControlPlaneConfig.
+	// DataPlaneGRPCAddr's doc comment in internal/config/config.go.
+	c, err := client.New(config.DefaultConfig.ControlPlane.DataPlaneGRPCAddr)
 	if err != nil {
 		log.Fatalf("failed to connect to dataplane: %v", err)
 	}

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,10 +28,12 @@ services:
     container_name: phantom-controlplane
     restart: unless-stopped
     ports:
-      - "8086:8086"
+      - "8086:8080"
       - "50051:50051"
     networks:
       - phantom-net
+    environment:
+      - DATAPLANE_GRPC_ADDR=phantom-dataplane:50051
     volumes:
       - ./data:/app/data
       - ./configs/config.yaml:/app/configs/config.yaml

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,7 @@ services:
     ports:
       - "1053:1053/udp"
       - "1053:1053/tcp"
+      - "9153:9153"
     cap_add:
       - NET_BIND_SERVICE # allow binding to low ports
     networks:

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -63,6 +63,15 @@ dataplane:
 
 controlplane:
   listen_addr: "0.0.0.0:8080"
+  # Address of the dataplane's gRPC server (resolver live-apply, DNS engine
+  # on/off toggle, live metrics). This is the control plane's DIAL address,
+  # not the dataplane's bind address above (dataplane.grpc_server.listen_addr)
+  # — they are the same value on bare metal but must differ whenever the two
+  # planes run in separate containers/hosts, since "localhost" inside the
+  # control plane is the control plane, not the dataplane. In docker compose,
+  # set this to the dataplane service's address (e.g. "dataplane:50051").
+  # Env override: DATAPLANE_GRPC_ADDR.
+  dataplane_grpc_addr: "localhost:50051"
   # Optional HTTPS for the control-plane API. HTTP is the default (TLS off).
   # Public ACME cannot issue for private-LAN names, so use either an
   # operator-provided cert/key pair, or an auto-generated self-signed cert.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,9 +151,29 @@ func (c DataPlaneConfig) WatchdogIntervalDuration() time.Duration {
 }
 
 type ControlPlaneConfig struct {
-	ListenAddr string    `yaml:"listen_addr"`
-	TLS        TLSConfig `yaml:"tls"`
+	ListenAddr string `yaml:"listen_addr"`
+
+	// DataPlaneGRPCAddr is the address the control plane DIALS to reach the
+	// dataplane's gRPC server (resolver live-apply, engine on/off toggle,
+	// metrics bridging). This is intentionally a separate key from
+	// DataPlane.GRPCServer.ListenAddr, which is the dataplane's own BIND
+	// address: in a single-process/bare-metal deployment both happen to be
+	// "localhost:50051", but in docker compose (or any topology where the
+	// two planes are different hosts/containers) "localhost" from inside the
+	// control plane is the control plane itself, not the dataplane, and
+	// reusing the dataplane's bind address as the dial target fails with
+	// connection refused. Default: "localhost:50051" (bare-metal, unchanged
+	// behavior). Env override: DATAPLANE_GRPC_ADDR.
+	DataPlaneGRPCAddr string `yaml:"dataplane_grpc_addr"`
+
+	TLS TLSConfig `yaml:"tls"`
 }
+
+// DefaultDataPlaneGRPCAddr is the control plane's dataplane-dial address used
+// when neither the config file nor DATAPLANE_GRPC_ADDR set one. It matches
+// the dataplane's own default bind port (50051) on localhost, which is
+// correct for bare-metal/same-host deployments.
+const DefaultDataPlaneGRPCAddr = "localhost:50051"
 
 // TLSConfig controls how the control-plane HTTP API is served.
 //
@@ -242,7 +262,8 @@ func defaultConfig() *Config {
 			},
 		},
 		ControlPlane: ControlPlaneConfig{
-			ListenAddr: "0.0.0.0:8080",
+			ListenAddr:        "0.0.0.0:8080",
+			DataPlaneGRPCAddr: DefaultDataPlaneGRPCAddr,
 			TLS: TLSConfig{
 				SelfSignedDir: DefaultSelfSignedDir,
 			},
@@ -331,6 +352,7 @@ var DefaultConfig = func() *Config {
 		cfg.DataPlane.MetricsAddr = "0.0.0.0:9153"
 	}
 	applyTLSEnv(&cfg.ControlPlane.TLS)
+	applyDataPlaneGRPCAddrEnv(&cfg.ControlPlane)
 	if v := os.Getenv("WATCHDOG_INTERVAL"); v != "" {
 		cfg.DataPlane.WatchdogInterval = v
 	}
@@ -449,6 +471,19 @@ func applyTLSEnv(t *TLSConfig) {
 	}
 	if t.SelfSignedDir == "" {
 		t.SelfSignedDir = DefaultSelfSignedDir
+	}
+}
+
+// applyDataPlaneGRPCAddrEnv overlays DATAPLANE_GRPC_ADDR onto the
+// control-plane's dataplane-dial address, then fills in
+// DefaultDataPlaneGRPCAddr when both the config file and the environment
+// leave it unset (e.g. an older config.yaml predating this key).
+func applyDataPlaneGRPCAddrEnv(cfg *ControlPlaneConfig) {
+	if v := os.Getenv("DATAPLANE_GRPC_ADDR"); v != "" {
+		cfg.DataPlaneGRPCAddr = v
+	}
+	if cfg.DataPlaneGRPCAddr == "" {
+		cfg.DataPlaneGRPCAddr = DefaultDataPlaneGRPCAddr
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,68 @@ func TestTLSConfigMode(t *testing.T) {
 	}
 }
 
+func TestApplyDataPlaneGRPCAddrEnv(t *testing.T) {
+	t.Run("empty config and empty env falls back to default", func(t *testing.T) {
+		t.Setenv("DATAPLANE_GRPC_ADDR", "")
+
+		cfg := ControlPlaneConfig{}
+		applyDataPlaneGRPCAddrEnv(&cfg)
+
+		if cfg.DataPlaneGRPCAddr != DefaultDataPlaneGRPCAddr {
+			t.Fatalf("DataPlaneGRPCAddr = %q, want default %q", cfg.DataPlaneGRPCAddr, DefaultDataPlaneGRPCAddr)
+		}
+	})
+
+	t.Run("config file value is kept when env is unset", func(t *testing.T) {
+		t.Setenv("DATAPLANE_GRPC_ADDR", "")
+
+		cfg := ControlPlaneConfig{DataPlaneGRPCAddr: "localhost:50051"}
+		applyDataPlaneGRPCAddrEnv(&cfg)
+
+		if cfg.DataPlaneGRPCAddr != "localhost:50051" {
+			t.Fatalf("DataPlaneGRPCAddr = %q, want %q", cfg.DataPlaneGRPCAddr, "localhost:50051")
+		}
+	})
+
+	t.Run("env overrides config file value (docker compose topology)", func(t *testing.T) {
+		t.Setenv("DATAPLANE_GRPC_ADDR", "dataplane:50051")
+
+		cfg := ControlPlaneConfig{DataPlaneGRPCAddr: "localhost:50051"}
+		applyDataPlaneGRPCAddrEnv(&cfg)
+
+		if cfg.DataPlaneGRPCAddr != "dataplane:50051" {
+			t.Fatalf("DataPlaneGRPCAddr = %q, want %q (env override)", cfg.DataPlaneGRPCAddr, "dataplane:50051")
+		}
+	})
+
+	t.Run("env overrides even an empty config file value", func(t *testing.T) {
+		t.Setenv("DATAPLANE_GRPC_ADDR", "dataplane:50051")
+
+		cfg := ControlPlaneConfig{}
+		applyDataPlaneGRPCAddrEnv(&cfg)
+
+		if cfg.DataPlaneGRPCAddr != "dataplane:50051" {
+			t.Fatalf("DataPlaneGRPCAddr = %q, want %q (env override)", cfg.DataPlaneGRPCAddr, "dataplane:50051")
+		}
+	})
+}
+
+func TestDefaultConfigDataPlaneGRPCAddr(t *testing.T) {
+	cfg := defaultConfig()
+	if cfg.ControlPlane.DataPlaneGRPCAddr != DefaultDataPlaneGRPCAddr {
+		t.Fatalf("defaultConfig().ControlPlane.DataPlaneGRPCAddr = %q, want %q",
+			cfg.ControlPlane.DataPlaneGRPCAddr, DefaultDataPlaneGRPCAddr)
+	}
+	// The dataplane's own bind address (used for its GRPCServer.Port listen,
+	// see internal/grpc/dataplane.New) and the control-plane's dial address
+	// must be independently configurable, even though they share the same
+	// bare-metal default value.
+	if cfg.DataPlane.GRPCServer.ListenAddr != cfg.ControlPlane.DataPlaneGRPCAddr {
+		t.Fatalf("bare-metal defaults should coincide: dataplane bind %q, controlplane dial %q",
+			cfg.DataPlane.GRPCServer.ListenAddr, cfg.ControlPlane.DataPlaneGRPCAddr)
+	}
+}
+
 func TestApplyTLSEnv(t *testing.T) {
 	t.Run("empty env fills default self-signed dir", func(t *testing.T) {
 		t.Setenv("TLS_CERT_FILE", "")

--- a/tests/integration/blocklist_test.go
+++ b/tests/integration/blocklist_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// createBlocklistRequest mirrors cmd/controlplane/handlers.CreateBlocklistRequest.
+type createBlocklistRequest struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+	Format string `json:"format"`
+}
+
+// TestBlocklistSourceSinkholes adds a real blocklist source (served by the
+// blocklist-fixture container, see tests/integration/docker-compose.integration.yaml)
+// through the control-plane API and confirms the fixture domain, which is
+// otherwise NXDOMAIN (reserved .test TLD, not a real registration), starts
+// resolving as a sinkholed 0.0.0.0 answer. Blocklist checks are read live
+// per query (BlocklistChecker.IsBlocked), no cache/refresh delay, but the
+// fetch/parse/store of the source itself is still an out-of-band step, so
+// this polls briefly rather than asserting on the very first query.
+func TestBlocklistSourceSinkholes(t *testing.T) {
+	const sourceID = "integration-test-blocklist"
+
+	t.Cleanup(func() {
+		_, _ = authed(http.MethodDelete, "/api/v1/blocklists/"+sourceID, nil, nil)
+	})
+
+	createReq := createBlocklistRequest{
+		ID:     sourceID,
+		Name:   sourceID,
+		URL:    "http://blocklist-fixture/blocklist.txt",
+		Format: "domains",
+	}
+	var createResp apiEnvelope[map[string]any]
+	status, err := authed(http.MethodPost, "/api/v1/blocklists", createReq, &createResp)
+	if err != nil {
+		t.Fatalf("create blocklist source: %v", err)
+	}
+	if status != http.StatusCreated {
+		t.Fatalf("create blocklist source: status = %d, want 201: %+v", status, createResp)
+	}
+
+	waitUntil(t, "blocklist fixture domain to sinkhole", func() (bool, error) {
+		resp, err := queryA(blocklistFixtureDomain)
+		if err != nil {
+			return false, err
+		}
+		if resp.Rcode != dns.RcodeSuccess {
+			return false, nil
+		}
+		ips := aRecords(resp)
+		return len(ips) == 1 && ips[0] == "0.0.0.0", nil
+	})
+}

--- a/tests/integration/dns_helpers_test.go
+++ b/tests/integration/dns_helpers_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// queryA sends a single A-record query for domain to the dataplane at
+// dnsAddr and returns the raw response.
+func queryA(domain string) (*dns.Msg, error) {
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(domain), dns.TypeA)
+	m.RecursionDesired = true
+
+	c := &dns.Client{Timeout: 5 * time.Second}
+	resp, _, err := c.Exchange(m, dnsAddr)
+	if err != nil {
+		return nil, fmt.Errorf("dns exchange for %s@%s: %w", domain, dnsAddr, err)
+	}
+	return resp, nil
+}
+
+// aRecords extracts the A-record IP strings from a DNS response.
+func aRecords(resp *dns.Msg) []string {
+	var ips []string
+	for _, rr := range resp.Answer {
+		if a, ok := rr.(*dns.A); ok {
+			ips = append(ips, a.A.String())
+		}
+	}
+	return ips
+}

--- a/tests/integration/docker-compose.integration.yaml
+++ b/tests/integration/docker-compose.integration.yaml
@@ -11,11 +11,47 @@
 #     dataplane actually forwarded a query to a resolver set via the
 #     control-plane API (not just that the API call returned success).
 #
+# Also overrides both dataplane's and controlplane's /app/data mount from
+# compose.yaml's host bind mount (./data) to a named Docker volume. compose.yaml's
+# bind mount works fine once ./data exists with the right ownership (which it
+# does on a dev machine after the first `docker compose up`, since the
+# dataplane image's entrypoint chowns it), but on a fresh checkout — a CI
+# runner, or anyone's first run — the ./data directory doesn't exist yet.
+# Docker then auto-creates it as root, and the containers (which run as a
+# non-root UID) can't open/create the SQLite file in it: modernc.org/sqlite
+# surfaces that as "unable to open database file: out of memory (14)"
+# (SQLite's generic CANTOPEN, not an actual OOM). A named volume sidesteps
+# this: on first use, Docker seeds it from the *image's* copy of /app/data,
+# which the dataplane Dockerfile explicitly creates and chows to its non-root
+# user (`chown -R appuser:appgroup /app/data && chmod -R 775 /app/data`)
+# before that image is ever built into a container. Both services share the
+# one named volume, same as they share the one bind-mounted directory in
+# compose.yaml today (both open the same /app/data/phantomdns.db). Verified
+# (`docker compose config`) that Compose merges the services.*.volumes list by
+# mount target across -f files, so this cleanly replaces just the /app/data
+# entry and leaves the config.yaml/policies.json bind mounts from compose.yaml
+# untouched.
+#
+# This override is scoped to integration/CI runs on purpose: production
+# deployments keep the host bind mount so operators can back up or inspect
+# the SQLite file directly.
+#
 # Usage (from repo root):
 #   docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml up -d --build
 #   go test -tags=integration ./tests/integration/...
 #   docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml down -v
+volumes:
+  hydra-integration-data:
+
 services:
+  dataplane:
+    volumes:
+      - hydra-integration-data:/app/data
+
+  controlplane:
+    volumes:
+      - hydra-integration-data:/app/data
+
   blocklist-fixture:
     image: nginx:alpine
     container_name: hydra-blocklist-fixture

--- a/tests/integration/docker-compose.integration.yaml
+++ b/tests/integration/docker-compose.integration.yaml
@@ -1,0 +1,34 @@
+# Compose override for the CI integration-test job (and local reproduction of
+# it). Adds two fixture services the Go tests under tests/integration/ need,
+# reachable from the controlplane/dataplane containers via the same
+# phantom-net network defined in the base compose.yaml:
+#
+#   - blocklist-fixture: serves a static domain list over HTTP so
+#     TestBlocklistSourceSinkholes can add a real blocklist source without
+#     depending on an external feed.
+#   - fake-resolver: a CoreDNS instance that answers every A query with a
+#     fixed, obviously-fake address, so TestResolverLiveApply can prove the
+#     dataplane actually forwarded a query to a resolver set via the
+#     control-plane API (not just that the API call returned success).
+#
+# Usage (from repo root):
+#   docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml up -d --build
+#   go test -tags=integration ./tests/integration/...
+#   docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml down -v
+services:
+  blocklist-fixture:
+    image: nginx:alpine
+    container_name: hydra-blocklist-fixture
+    networks:
+      - phantom-net
+    volumes:
+      - ./tests/integration/fixtures:/usr/share/nginx/html:ro
+
+  fake-resolver:
+    image: coredns/coredns:latest
+    container_name: hydra-fake-resolver
+    networks:
+      - phantom-net
+    volumes:
+      - ./tests/integration/fixtures/Corefile:/Corefile:ro
+    command: ["-conf", "/Corefile"]

--- a/tests/integration/fixtures/Corefile
+++ b/tests/integration/fixtures/Corefile
@@ -1,0 +1,10 @@
+# CoreDNS config for the fake-resolver fixture used by
+# TestResolverLiveApply (resolver_test.go). Answers every A query with a
+# fixed, obviously-fake address so the test can prove the dataplane actually
+# forwarded to this resolver (and not the real internet) after a live
+# resolver-set change via the control-plane API.
+. {
+    template IN A {
+        answer "{{ .Name }} 60 IN A 203.0.113.99"
+    }
+}

--- a/tests/integration/fixtures/blocklist.txt
+++ b/tests/integration/fixtures/blocklist.txt
@@ -1,0 +1,4 @@
+# Fixture domain list for the integration test suite's blocklist-source test
+# (TestBlocklistSourceSinkholes in blocklist_test.go). Served over HTTP by the
+# blocklist-fixture service in docker-compose.integration.yaml.
+hydra-integration-blocklist.test

--- a/tests/integration/health_metrics_test.go
+++ b/tests/integration/health_metrics_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package integration
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestControlPlaneHealth checks GET /health on the control plane's published
+// HTTP port. This is also a regression check for the compose.yaml port
+// mismatch this PR fixes (host 8086 was published to the wrong container
+// port, 8086, when the binary listens on 8080).
+func TestControlPlaneHealth(t *testing.T) {
+	resp, err := httpClient.Get(controlplaneURL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read /health response body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/health status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), `"status":"ok"`) {
+		t.Fatalf(`/health body = %q, want it to contain "status":"ok"`, body)
+	}
+}
+
+// TestDataplaneMetrics checks GET /metrics on the dataplane's Prometheus
+// endpoint (compose.yaml publishes MetricsAddr, 9153, to the host). It
+// asserts on the hydradns_dns_queries_window series, which
+// internal/metrics/promexport always emits on every scrape regardless of
+// query volume.
+func TestDataplaneMetrics(t *testing.T) {
+	resp, err := httpClient.Get(metricsURL + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read /metrics response body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/metrics status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "hydradns_dns_queries_window") {
+		t.Fatalf("/metrics response did not contain the expected hydradns_dns_queries_window series; first 500 bytes: %.500s", body)
+	}
+}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+// Package integration exercises hydra-core end to end against a real running
+// compose stack (dataplane + controlplane, real gRPC bridge, real SQLite
+// storage) over the network, the same way an operator or the UI would. It
+// intentionally does not import the module's own internal/cmd packages: it
+// speaks the DNS wire protocol (via miekg/dns) and the control-plane's plain
+// HTTP JSON API, exactly like an external client.
+//
+// Every test address is overridable via environment variables so the suite
+// can run against any reachable stack; the defaults match compose.yaml plus
+// tests/integration/docker-compose.integration.yaml, which is what the CI
+// "Integration Tests" job (.github/workflows/ci.yaml) brings up.
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+// Fixture domains served by tests/integration/fixtures/blocklist.txt and
+// created directly via the policy API. Both use the reserved .test TLD
+// (RFC 2606) so a real upstream resolver always returns NXDOMAIN for them
+// when hydra-core is not itself blocking or sinkholing the query — that is
+// what makes "blocked vs not blocked" observable from outside the box.
+const (
+	blocklistFixtureDomain = "hydra-integration-blocklist.test"
+	policyFixtureDomain    = "hydra-integration-policy.test"
+
+	// fakeResolverAnswer is the fixed A record tests/integration/fixtures/Corefile
+	// always returns, used to prove a live resolver-set change actually took
+	// effect (the dataplane forwarded to the new resolver, not the real
+	// internet or a stale cached exchanger).
+	fakeResolverAnswer = "203.0.113.99"
+
+	adminPassword = "integration-tests-password-1"
+
+	pollInterval = 250 * time.Millisecond
+	// pollTimeout comfortably covers the dataplane's 5s DB-poll cycle
+	// (cmd/dataplane/main.go reloadPolicies ticker) plus scheduling slack.
+	pollTimeout = 10 * time.Second
+)
+
+var (
+	dnsAddr         string
+	controlplaneURL string
+	metricsURL      string
+
+	httpClient = &http.Client{Timeout: 10 * time.Second}
+	authToken  string
+)
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func TestMain(m *testing.M) {
+	dnsAddr = envOr("HYDRA_DNS_ADDR", "127.0.0.1:1053")
+	controlplaneURL = envOr("HYDRA_CONTROLPLANE_URL", "http://127.0.0.1:8086")
+	metricsURL = envOr("HYDRA_METRICS_URL", "http://127.0.0.1:9153")
+
+	token, err := ensureAuthToken()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "integration setup: failed to obtain an auth token: %v\n", err)
+		os.Exit(1)
+	}
+	authToken = token
+
+	os.Exit(m.Run())
+}
+
+// ensureAuthToken completes first-boot setup against a fresh stack, or logs
+// in if setup already ran (e.g. the suite was run twice against the same
+// stack during local iteration).
+func ensureAuthToken() (string, error) {
+	setupBody := map[string]string{"password": adminPassword}
+	var setupResp apiEnvelope[map[string]string]
+	status, err := doJSON(http.MethodPost, "/api/v1/auth/setup", "", setupBody, &setupResp)
+	if err != nil {
+		return "", fmt.Errorf("POST /api/v1/auth/setup: %w", err)
+	}
+	switch status {
+	case http.StatusOK:
+		token := setupResp.Data["token"]
+		if token == "" {
+			return "", fmt.Errorf("setup succeeded but returned no token: %+v", setupResp)
+		}
+		return token, nil
+	case http.StatusConflict:
+		// Setup already completed against this stack; fall through to login.
+	default:
+		return "", fmt.Errorf("unexpected status %d from setup: %+v", status, setupResp)
+	}
+
+	loginBody := map[string]string{"password": adminPassword}
+	var loginResp apiEnvelope[map[string]string]
+	status, err = doJSON(http.MethodPost, "/api/v1/auth/login", "", loginBody, &loginResp)
+	if err != nil {
+		return "", fmt.Errorf("POST /api/v1/auth/login: %w", err)
+	}
+	if status != http.StatusOK {
+		return "", fmt.Errorf("login failed with status %d: %+v (setup password mismatch from a prior run?)", status, loginResp)
+	}
+	token := loginResp.Data["token"]
+	if token == "" {
+		return "", fmt.Errorf("login succeeded but returned no token: %+v", loginResp)
+	}
+	return token, nil
+}
+
+// apiEnvelope mirrors the control plane's uniform JSON response shape
+// ({"status": "...", "data": ..., "error": "..."}) without importing the
+// package that defines it.
+type apiEnvelope[T any] struct {
+	Status string  `json:"status"`
+	Data   T       `json:"data"`
+	Error  *string `json:"error"`
+}
+
+// doJSON issues an HTTP request against the control plane. token, when
+// non-empty, is sent as a Bearer token; pass "" for the unauthenticated
+// auth endpoints. body is marshaled as the JSON request body when non-nil.
+// out, when non-nil, receives the JSON-decoded response body.
+func doJSON(method, path, token string, body, out any) (int, error) {
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return 0, fmt.Errorf("marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, controlplaneURL+path, reqBody)
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, fmt.Errorf("read response body: %w", err)
+	}
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return resp.StatusCode, fmt.Errorf("unmarshal response body %q: %w", respBody, err)
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+// authed is a doJSON shorthand that always sends the shared test session's
+// Bearer token.
+func authed(method, path string, body, out any) (int, error) {
+	return doJSON(method, path, authToken, body, out)
+}
+
+// waitUntil polls cond every pollInterval until it returns true, or fails the
+// test once pollTimeout elapses. cond should return (false, nil) to keep
+// polling, (true, nil) once satisfied, or (_, err) to record a diagnostic
+// while still retrying (useful for "not ready yet" errors like connection
+// refused during a brief container restart).
+func waitUntil(t *testing.T, what string, cond func() (bool, error)) {
+	t.Helper()
+	deadline := time.Now().Add(pollTimeout)
+	var lastErr error
+	var lastOK bool
+	for time.Now().Before(deadline) {
+		ok, err := cond()
+		lastOK, lastErr = ok, err
+		if err == nil && ok {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	if lastErr != nil {
+		t.Fatalf("timed out after %s waiting for %s: %v", pollTimeout, what, lastErr)
+	}
+	t.Fatalf("timed out after %s waiting for %s (last result: %v)", pollTimeout, what, lastOK)
+}

--- a/tests/integration/policy_test.go
+++ b/tests/integration/policy_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// createPolicyRequest mirrors cmd/controlplane/handlers.CreatePolicyRequest
+// (only the fields this test needs).
+type createPolicyRequest struct {
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	Action   string   `json:"action"`
+	Domains  []string `json:"domains"`
+	Priority int      `json:"priority"`
+}
+
+// TestPolicyCRUDRoundtrip creates a "block" policy for a domain that would
+// otherwise be NXDOMAIN (reserved .test TLD), confirms the dataplane starts
+// blocking it, deletes the policy, and confirms the dataplane reverts to
+// NXDOMAIN. The dataplane reloads its policy snapshot from storage on a 5s
+// ticker (cmd/dataplane/main.go), not per query, so both directions poll
+// within that window instead of asserting immediately.
+func TestPolicyCRUDRoundtrip(t *testing.T) {
+	const policyID = "integration-test-policy"
+
+	// Best-effort cleanup in case an assertion fails partway through and the
+	// test doesn't reach the explicit delete below.
+	t.Cleanup(func() {
+		_, _ = authed(http.MethodDelete, "/api/v1/policies/"+policyID, nil, nil)
+	})
+
+	// Baseline: confirm the fixture domain is NOT already blocked before we
+	// create the policy, so "becomes blocked" is a real transition.
+	waitUntil(t, "policy fixture domain to start as NXDOMAIN", func() (bool, error) {
+		resp, err := queryA(policyFixtureDomain)
+		if err != nil {
+			return false, err
+		}
+		return resp.Rcode == dns.RcodeNameError, nil
+	})
+
+	createReq := createPolicyRequest{
+		ID:       policyID,
+		Name:     policyID,
+		Action:   "block",
+		Domains:  []string{policyFixtureDomain},
+		Priority: 100,
+	}
+	var createResp apiEnvelope[map[string]any]
+	status, err := authed(http.MethodPost, "/api/v1/policies", createReq, &createResp)
+	if err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	if status != http.StatusOK && status != http.StatusCreated {
+		t.Fatalf("create policy: status = %d, want 200/201: %+v", status, createResp)
+	}
+
+	waitUntil(t, "policy fixture domain to become blocked", func() (bool, error) {
+		resp, err := queryA(policyFixtureDomain)
+		if err != nil {
+			return false, err
+		}
+		if resp.Rcode != dns.RcodeSuccess {
+			return false, nil
+		}
+		ips := aRecords(resp)
+		return len(ips) == 1 && ips[0] == "0.0.0.0", nil
+	})
+
+	status, err = authed(http.MethodDelete, "/api/v1/policies/"+policyID, nil, nil)
+	if err != nil {
+		t.Fatalf("delete policy: %v", err)
+	}
+	if status != http.StatusOK && status != http.StatusNoContent {
+		t.Fatalf("delete policy: status = %d, want 200/204", status)
+	}
+
+	waitUntil(t, "policy fixture domain to revert to NXDOMAIN", func() (bool, error) {
+		resp, err := queryA(policyFixtureDomain)
+		if err != nil {
+			return false, err
+		}
+		return resp.Rcode == dns.RcodeNameError, nil
+	})
+}

--- a/tests/integration/resolve_test.go
+++ b/tests/integration/resolve_test.go
@@ -1,0 +1,28 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestKnownGoodDomainResolves is the baseline sanity check: a well-known,
+// unblocked domain resolves NOERROR with at least one A record through the
+// dataplane's default upstream resolvers (compose.yaml ships 8.8.8.8 and
+// 1.1.1.1). If this fails, nothing else in the suite is trustworthy either.
+func TestKnownGoodDomainResolves(t *testing.T) {
+	resp, err := queryA("example.com")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("rcode = %s, want NOERROR", dns.RcodeToString[resp.Rcode])
+	}
+	ips := aRecords(resp)
+	if len(ips) == 0 {
+		t.Fatalf("expected at least one A record, got none (answer section: %+v)", resp.Answer)
+	}
+	t.Logf("example.com -> %v", ips)
+}

--- a/tests/integration/resolver_test.go
+++ b/tests/integration/resolver_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// resolverAPI mirrors cmd/controlplane/handlers.Resolver.
+type resolverAPI struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Address  string `json:"address"`
+	Protocol string `json:"protocol"`
+	Position int    `json:"position"`
+}
+
+// createResolverRequest mirrors cmd/controlplane/handlers.CreateResolverRequest.
+type createResolverRequest struct {
+	Name     string `json:"name"`
+	Address  string `json:"address"`
+	Protocol string `json:"protocol"`
+}
+
+// TestResolverLiveApply is the regression test for the exact bug this PR
+// fixes: POST /api/v1/dns/resolvers must both persist the change AND apply
+// it to the running dataplane over gRPC. It proves "applied", not just
+// "the API call returned 2xx", by pointing the resolver set at a fixture
+// resolver (fake-resolver, a CoreDNS instance that answers every A query
+// with a fixed, obviously-fake address — see
+// tests/integration/docker-compose.integration.yaml and fixtures/Corefile)
+// and checking that a live DNS query through the dataplane actually returns
+// that fixed address. Before the fix, CreateResolver returned HTTP 502
+// ("resolver persisted but failed to apply to dataplane") in the compose
+// topology, and the dataplane kept using whatever it booted with.
+func TestResolverLiveApply(t *testing.T) {
+	var listResp apiEnvelope[[]resolverAPI]
+	status, err := authed(http.MethodGet, "/api/v1/dns/resolvers", nil, &listResp)
+	if err != nil {
+		t.Fatalf("list resolvers: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("list resolvers: status = %d, want 200: %+v", status, listResp)
+	}
+	original := listResp.Data
+
+	// Restore the original resolver set unconditionally, regardless of
+	// how the test exits, so later tests (and TestKnownGoodDomainResolves,
+	// if run again) still have working internet-facing resolvers.
+	t.Cleanup(func() {
+		var current apiEnvelope[[]resolverAPI]
+		if _, err := authed(http.MethodGet, "/api/v1/dns/resolvers", nil, &current); err == nil {
+			for _, r := range current.Data {
+				_, _ = authed(http.MethodDelete, "/api/v1/dns/resolvers/"+r.ID, nil, nil)
+			}
+		}
+		for _, r := range original {
+			req := createResolverRequest{Name: r.Name, Address: r.Address, Protocol: r.Protocol}
+			_, _ = authed(http.MethodPost, "/api/v1/dns/resolvers", req, nil)
+		}
+	})
+
+	for _, r := range original {
+		if status, err := authed(http.MethodDelete, "/api/v1/dns/resolvers/"+r.ID, nil, nil); err != nil || status != http.StatusOK {
+			t.Fatalf("delete existing resolver %s: status=%d err=%v", r.ID, status, err)
+		}
+	}
+
+	createReq := createResolverRequest{Name: "fake-resolver", Address: "fake-resolver:53", Protocol: "udp"}
+	var createResp apiEnvelope[resolverAPI]
+	status, err = authed(http.MethodPost, "/api/v1/dns/resolvers", createReq, &createResp)
+	if err != nil {
+		t.Fatalf("create fake resolver: %v", err)
+	}
+	if status != http.StatusCreated {
+		t.Fatalf("create fake resolver: status = %d, want 201 (this is the exact 502 the pre-fix dial-address bug produced): %+v",
+			status, createResp)
+	}
+
+	// The apply is synchronous inside the handler (applyResolvers runs, and
+	// only then does the handler respond), so a 201 above already means the
+	// gRPC push to the dataplane succeeded. Still poll briefly for the DNS
+	// answer to account for the dataplane rebuilding its upstream exchanger.
+	domain := "resolver-live-apply-check.example"
+	waitUntil(t, "resolved answer to come from the fake resolver", func() (bool, error) {
+		resp, err := queryA(domain)
+		if err != nil {
+			return false, err
+		}
+		if resp.Rcode != dns.RcodeSuccess {
+			return false, nil
+		}
+		ips := aRecords(resp)
+		return len(ips) == 1 && ips[0] == fakeResolverAnswer, nil
+	})
+}


### PR DESCRIPTION
## The bug

The controlplane's gRPC client dialed `DataPlane.GRPCServer.ListenAddr`, the dataplane's own bind address (`localhost:50051`). That is correct for the dataplane's own listener but wrong as a dial target from the controlplane in any topology where the two planes are not the same host, since "localhost" inside the controlplane container resolves to the controlplane itself, not the dataplane. In the shipped `docker compose` topology this meant resolver live-apply, the DNS engine on/off toggle, and `/api/v1/dns/metrics` (all gRPC-bridged) failed with `dial tcp [::1]:50051: connect: connection refused`, logged even at controlplane boot.

This predates the recent 46-PR feature rollout. It was confirmed at HEAD before this branch (`git blame configs/config.yaml` traces the shared `grpc_server.listen_addr` key to commit c5fc8846, which introduced Docker deployment) and verified with an A/B build against the pre-rollout baseline: the equivalent gRPC-backed toggle that existed before resolver CRUD shipped failed with the identical 502 and the identical dial-refused log line on both builds.

A second, unrelated bug in the same area: `compose.yaml` published host port 8086 to the controlplane container's port 8086, but the binary listens on 8080 by default (`configs/config.yaml`'s `controlplane.listen_addr`). The host mapping was dead.

## The fix

Split the config concern instead of trying to make one key serve two purposes.

`ControlPlaneConfig.DataPlaneGRPCAddr` (yaml key `dataplane_grpc_addr`, env override `DATAPLANE_GRPC_ADDR`) is the controlplane's own DIAL address, independent of `DataPlane.GRPCServer.ListenAddr` (the dataplane's BIND address, which the dataplane's own gRPC server already uses via its `Port` field, not `ListenAddr`). It defaults to `localhost:50051`, the same value as today, so bare-metal and same-host deployments see no behavior change. `compose.yaml` sets `DATAPLANE_GRPC_ADDR=phantom-dataplane:50051` on the controlplane service, matching the existing `CONTROLPLANE_ADDR=phantom-controlplane:50051` naming convention already used for the dataplane service. `cmd/controlplane/main.go` now dials `config.DefaultConfig.ControlPlane.DataPlaneGRPCAddr` instead of the dataplane's bind address.

Port fix: `hydra-ui`'s own `lib/api.ts` hardcodes `http://localhost:8080` as its fallback API base URL, and `configs/config.yaml`'s `controlplane.listen_addr` default is `0.0.0.0:8080`, so the binary's actual bind port is 8080. Rather than move the bind port to 8086, which would break the UI's own bare-metal default, `compose.yaml`'s host mapping now reads `"8086:8080"`. This keeps the externally documented port (README says 8086 twice) and the UI's bare-metal default both correct.

Unit tests added in `internal/config/config_test.go` for the new env-overlay function (`applyDataPlaneGRPCAddrEnv`, mirroring the existing `applyTLSEnv` pattern) and for `defaultConfig()`'s new field.

## Integration tests (Phase 2)

Added `tests/integration/` (build tag `integration`, stdlib plus `github.com/miekg/dns` only, no other new dependencies), exercising a real running compose stack over the network like an external client would:

- `TestKnownGoodDomainResolves`: `example.com` resolves NOERROR with A records.
- `TestBlocklistSourceSinkholes`: a blocklist source added via `POST /api/v1/blocklists` (served by a fixture nginx container) sinkholes its domain to `0.0.0.0`.
- `TestPolicyCRUDRoundtrip`: a `block` policy applies within the dataplane's 5s DB-poll window, and reverts to NXDOMAIN within the same window after delete.
- `TestResolverLiveApply`: the regression test for this exact bug. Points the resolver set at a fixture CoreDNS instance that answers every query with a fixed, obviously fake address, and confirms a live DNS query through the dataplane actually returns that address, not just that the API call returned 2xx.
- `TestControlPlaneHealth` and `TestDataplaneMetrics`: `/health` and `/metrics` respond, also regression-covering the port fix.

All addresses are env-var overridable (`HYDRA_DNS_ADDR`, `HYDRA_CONTROLPLANE_URL`, `HYDRA_METRICS_URL`) with defaults matching `compose.yaml`. `tests/integration/docker-compose.integration.yaml` is a compose override adding the two fixture services the tests need. `compose.yaml` now also publishes the dataplane's metrics port (9153) to the host, matching how the DNS and control-plane ports are already published, so the test runner can reach it.

Added the `Integration Tests` job to `.github/workflows/ci.yaml`: `needs: [test]`, builds and starts the stack (base plus override), polls `/health` and `/metrics` until ready, runs `go test -tags=integration -v ./tests/integration/...`, dumps compose logs on failure, tears the stack down with `if: always()`.

## Validation (build machine, real compose stack)

Phase 1, before writing the integration tests:

- Built and ran the fixed stack via `docker compose up -d`. Controlplane boot log no longer shows dial-refused errors.
- `POST /api/v1/dns/resolvers` returns 201 (was 502). Verified behaviorally, not just the status code: pointed the resolver set at a fixture CoreDNS instance returning a fixed answer, then confirmed a live DNS query through the dataplane returned that fixed answer, and the fixture's own access log showed the query arriving from the dataplane container.
- DNS engine toggle: `POST /api/v1/dns/engine {"enabled":false}` then a query returns REFUSED; `{"enabled":true}` and the same query resolves again.
- `GET /api/v1/dns/metrics` returns real data (was 502).
- `GET /health` returns `{"status":"ok"}` on the now-correct host port 8086.
- Re-verified both basic paths: `example.com` still resolves NOERROR, and a blocklist source still sinkholes its domain to `0.0.0.0`.

Phase 2, exact CI sequence run on the build machine from a clean checkout of this branch:

- `docker compose -f compose.yaml -f tests/integration/docker-compose.integration.yaml up -d --build`
- Polled `/health` and `/metrics` until ready, same loop as the CI job.
- `go test -tags=integration -v ./tests/integration/...`: all 6 tests pass, about 7.8s total. Ran a second time against the same warm stack (exercises the setup-already-done to login fallback and each test's cleanup): all pass again, about 5.7s.
- `docker compose ... down -v`: clean teardown.

Gates, all green on this branch:

- `gofmt -l .`: no output.
- `go build ./...`, `go vet ./...`, `go test ./... -race`: pass, also re-verified inside `golang:1.25-alpine` to match the CI Go version.
- `golangci-lint run --timeout=5m --max-same-issues=0 --max-issues-per-linter=0` at the pinned `v2.12.2` (the flags that avoid the default 3-per-group truncation): 0 issues.
- `gosec -exclude-dir=internal/gen ./...` at the exact image the `securego/gosec@v2.28.0` action pins (`ghcr.io/securego/gosec@sha256:d0859f24...`, labeled 2.27.1 in that action's own `action.yml`): 0 issues.

Main's lint and gosec findings stay at zero.
