### PR TITLE
Bound the query log writer with a fixed worker pool

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -38,6 +38,13 @@ dataplane:
   dns_0x20: false
   # Address for the Prometheus /metrics endpoint (defaults to 0.0.0.0:9153).
   metrics_addr: "0.0.0.0:9153"
+  # Bounded async query-log writer: buffer capacity and worker count. Once the
+  # buffer is full, new rows are dropped and counted (see the
+  # hydradns_dns_querylog_dropped_total metric) rather than blocking DNS
+  # resolution. <= 0 (default) uses the package defaults: 1024 / 2.
+  # Env overrides: QUERY_LOG_BUFFER_SIZE, QUERY_LOG_WORKERS.
+  query_log_buffer_size: 1024
+  query_log_workers: 2
   # Self-heal watchdog: probe cadence and consecutive-failure threshold before
   # recovery. Set watchdog_interval to "off" or "0" to disable. Overridable via
   # WATCHDOG_INTERVAL / WATCHDOG_FAILURE_THRESHOLD env vars.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,16 @@ type DataPlaneConfig struct {
 	NRDFeedURL         string `yaml:"nrd_feed_url"`
 	NRDBlock           bool   `yaml:"nrd_block"`
 	NRDRefreshInterval string `yaml:"nrd_refresh_interval"`
+
+	// QueryLogBufferSize is the capacity of the bounded async query-log queue.
+	// <= 0 (the default) uses the package default (1024). Once the buffer is
+	// full, new rows are dropped and counted rather than blocking the query
+	// path. Env override: QUERY_LOG_BUFFER_SIZE.
+	QueryLogBufferSize int `yaml:"query_log_buffer_size"`
+	// QueryLogWorkers is the number of fixed workers draining the query-log
+	// queue. <= 0 (the default) uses the package default (2). Env override:
+	// QUERY_LOG_WORKERS.
+	QueryLogWorkers int `yaml:"query_log_workers"`
 }
 
 // GeoIPConfig configures optional ASN/GeoIP answer filtering. It is disabled
@@ -432,6 +442,20 @@ var DefaultConfig = func() *Config {
 	}
 	if interval := os.Getenv("NRD_REFRESH_INTERVAL"); interval != "" {
 		cfg.DataPlane.NRDRefreshInterval = interval
+	}
+	if v := os.Getenv("QUERY_LOG_BUFFER_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.DataPlane.QueryLogBufferSize = n
+		} else {
+			logger.Log.Warnf("Invalid QUERY_LOG_BUFFER_SIZE=%q, ignoring: %v", v, err)
+		}
+	}
+	if v := os.Getenv("QUERY_LOG_WORKERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.DataPlane.QueryLogWorkers = n
+		} else {
+			logger.Log.Warnf("Invalid QUERY_LOG_WORKERS=%q, ignoring: %v", v, err)
+		}
 	}
 	return cfg
 }()

--- a/internal/dnsengine/engine.go
+++ b/internal/dnsengine/engine.go
@@ -67,8 +67,14 @@ type Engine struct {
 	metrics         *metrics.QueryMetrics
 	queryLog        repositories.QueryLogRepository
 	statistics      repositories.StatisticsRepository
-	threatDetector  *threat.Detector
-	exporter        *Exporter
+	// qlWriter is the bounded async writer logQuery submits persistence work
+	// to. Built alongside queryLog in NewDNSEngine; tests that set queryLog
+	// directly must also set qlWriter (see newQueryLogWriter). Submit/Close
+	// are nil-receiver-safe, but a non-nil queryLog with a nil qlWriter would
+	// silently drop every row, so treat the two as always paired.
+	qlWriter       *queryLogWriter
+	threatDetector *threat.Detector
+	exporter       *Exporter
 	// geo is nil when ASN/GeoIP answer filtering is disabled (the default, no
 	// database configured). When set, resolved answer IPs on the allow path are
 	// evaluated against it.
@@ -229,6 +235,7 @@ func NewDNSEngine(cfg config.DataPlaneConfig, repos *repositories.Store, pE *pol
 		metrics:              qm,
 		queryLog:             repos.QueryLogs,
 		statistics:           repos.Statistics,
+		qlWriter:             newQueryLogWriter(repos.QueryLogs, repos.Statistics, qm, cfg.QueryLogBufferSize, cfg.QueryLogWorkers),
 		threatDetector:       detector,
 		exporter:             exporter,
 		threatBlockThreshold: cfg.ThreatBlockThreshold,
@@ -315,6 +322,9 @@ func (e *Engine) Shutdown() {
 		(*p).Close()
 	}
 	e.exporter.Close() // nil-safe
+	// Drain the query log writer last: it waits for queued rows already
+	// submitted by in-flight logQuery calls to finish persisting.
+	e.qlWriter.Close() // nil-safe
 }
 
 func (e *Engine) respondBlocked(w dns.ResponseWriter, r *dns.Msg, domain, reason string) {
@@ -865,16 +875,11 @@ func (e *Engine) logQuery(domain, clientIP, action, reason string, tr threat.Res
 		statsAction = "allow"
 	}
 
-	go func() {
-		if err := e.queryLog.Save(q); err != nil {
-			logger.Log.Errorf("Failed to log query: %v", err)
-		}
-		if e.statistics != nil {
-			if err := e.statistics.IncrementCounter(statsAction); err != nil {
-				logger.Log.Errorf("Failed to increment stats: %v", err)
-			}
-		}
-	}()
+	// Persist through the bounded async writer rather than spawning a
+	// goroutine per query: under a burst, unbounded fan-out against the
+	// single SQLite file backing both planes amplified write contention.
+	// The writer never blocks this path (drop-with-counter on a full queue).
+	e.qlWriter.Submit(q, statsAction)
 }
 
 // recordBlocked feeds one blocked resolution into the infected-device alerter,

--- a/internal/dnsengine/engine_test.go
+++ b/internal/dnsengine/engine_test.go
@@ -710,7 +710,8 @@ func TestLogQuery_ThreadsBlockReason(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mq := newMockQueryLog()
-			e := &Engine{queryLog: mq}
+			e := &Engine{queryLog: mq, qlWriter: newQueryLogWriter(mq, nil, nil, 0, 0)}
+			defer e.qlWriter.Close()
 
 			tr := threat.Result{DetectionMethod: "entropy", Reason: "high entropy"}
 			e.logQuery("example.com", "1.2.3.4", tt.action, tt.reason, tr)
@@ -737,6 +738,8 @@ func TestProcessDNSQuery_LogsBlockReason(t *testing.T) {
 		mq := newMockQueryLog()
 		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{"ads.example.com": true}}, nil)
 		e.queryLog = mq
+		e.qlWriter = newQueryLogWriter(mq, nil, nil, 0, 0)
+		defer e.qlWriter.Close()
 
 		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("ads.example.com"))
 
@@ -752,6 +755,8 @@ func TestProcessDNSQuery_LogsBlockReason(t *testing.T) {
 		mq := newMockQueryLog()
 		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, policies)
 		e.queryLog = mq
+		e.qlWriter = newQueryLogWriter(mq, nil, nil, 0, 0)
+		defer e.qlWriter.Close()
 
 		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("policy-blocked.com"))
 
@@ -767,6 +772,8 @@ func TestProcessDNSQuery_LogsBlockReason(t *testing.T) {
 		mq := newMockQueryLog()
 		e := newTestEngine(&mockBlocklist{blocked: map[string]bool{}}, policies)
 		e.queryLog = mq
+		e.qlWriter = newQueryLogWriter(mq, nil, nil, 0, 0)
+		defer e.qlWriter.Close()
 
 		e.ProcessDNSQuery(&mockResponseWriter{}, newTestQuery("redirect-me.com"))
 

--- a/internal/dnsengine/querylog_writer.go
+++ b/internal/dnsengine/querylog_writer.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/lopster568/phantomDNS/internal/logger"
+	"github.com/lopster568/phantomDNS/internal/metrics"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+)
+
+// defaultQueryLogBufferSize and defaultQueryLogWorkers are used whenever the
+// operator leaves DataPlaneConfig's QueryLogBufferSize/QueryLogWorkers at
+// their zero value. 1024 in-flight rows is generous slack for a burst while
+// still bounding memory; 2 workers is enough to keep up with normal query
+// volume against a single SQLite file without over-parallelizing writes to it.
+const (
+	defaultQueryLogBufferSize = 1024
+	defaultQueryLogWorkers    = 2
+)
+
+// queryLogEntry is one persisted row plus the stats bucket it should be
+// counted under, queued together so a worker does both in one dequeue.
+type queryLogEntry struct {
+	query       *models.DNSQuery
+	statsAction string
+}
+
+// queryLogWriter persists query log rows asynchronously through a bounded
+// queue drained by a small, fixed pool of workers. It exists so a burst of
+// DNS queries never spawns one goroutine per query (the previous behaviour):
+// under sustained SQLite write contention that unbounded fan-out could pile
+// up hundreds of in-flight goroutines all blocked on the same file. The
+// queue is drop-on-full: logQuery must never block the query path waiting
+// for a slow write, so once the buffer is saturated new rows are dropped and
+// counted rather than queued. A nil *queryLogWriter is a valid no-op.
+type queryLogWriter struct {
+	queue      chan queryLogEntry
+	queryLog   repositories.QueryLogRepository
+	statistics repositories.StatisticsRepository
+	qm         *metrics.QueryMetrics
+
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+	dropped   atomic.Uint64
+}
+
+// newQueryLogWriter builds a queryLogWriter and starts its worker pool.
+// bufferSize and workers <= 0 fall back to the package defaults. qm may be
+// nil (drops are still counted locally via Dropped(), just not surfaced
+// through /metrics).
+func newQueryLogWriter(queryLog repositories.QueryLogRepository, statistics repositories.StatisticsRepository, qm *metrics.QueryMetrics, bufferSize, workers int) *queryLogWriter {
+	if bufferSize <= 0 {
+		bufferSize = defaultQueryLogBufferSize
+	}
+	if workers <= 0 {
+		workers = defaultQueryLogWorkers
+	}
+
+	w := &queryLogWriter{
+		queue:      make(chan queryLogEntry, bufferSize),
+		queryLog:   queryLog,
+		statistics: statistics,
+		qm:         qm,
+	}
+
+	w.wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go w.run()
+	}
+	return w
+}
+
+// Submit enqueues a row for persistence. It never blocks: if the queue is
+// full the entry is dropped and the drop counter (local + metrics, when
+// wired) is incremented. Safe to call on a nil receiver.
+func (w *queryLogWriter) Submit(q *models.DNSQuery, statsAction string) {
+	if w == nil {
+		return
+	}
+	select {
+	case w.queue <- queryLogEntry{query: q, statsAction: statsAction}:
+	default:
+		n := w.dropped.Add(1)
+		if w.qm != nil {
+			w.qm.RecordQueryLogDropped()
+		}
+		// Log sparingly to avoid amplifying pressure under sustained overflow.
+		if n == 1 || n%1024 == 0 {
+			logger.Log.Warnf("query log writer: queue full, dropped %d entries", n)
+		}
+	}
+}
+
+// Dropped returns the total number of rows dropped due to a full queue.
+// Safe to call on a nil receiver.
+func (w *queryLogWriter) Dropped() uint64 {
+	if w == nil {
+		return 0
+	}
+	return w.dropped.Load()
+}
+
+// Close stops accepting new work, waits for every worker to drain the
+// remaining queued entries, and returns once all in-flight rows have been
+// persisted. Safe to call multiple times and on a nil receiver.
+func (w *queryLogWriter) Close() {
+	if w == nil {
+		return
+	}
+	w.closeOnce.Do(func() {
+		close(w.queue)
+		w.wg.Wait()
+	})
+}
+
+func (w *queryLogWriter) run() {
+	defer w.wg.Done()
+	for e := range w.queue {
+		if err := w.queryLog.Save(e.query); err != nil {
+			logger.Log.Errorf("Failed to log query: %v", err)
+		}
+		if w.statistics != nil {
+			if err := w.statistics.IncrementCounter(e.statsAction); err != nil {
+				logger.Log.Errorf("Failed to increment stats: %v", err)
+			}
+		}
+	}
+}

--- a/internal/dnsengine/querylog_writer_test.go
+++ b/internal/dnsengine/querylog_writer_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package dnsengine
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lopster568/phantomDNS/internal/metrics"
+	"github.com/lopster568/phantomDNS/internal/storage/models"
+	"github.com/lopster568/phantomDNS/internal/storage/repositories"
+)
+
+// recordingQueryLog captures every saved row, optionally blocking each Save
+// call on a gate channel so tests can hold workers busy on demand. When
+// started is non-nil, the *first* Save call signals on it right before
+// blocking on gate, so a test can deterministically wait until a worker is
+// actually occupied instead of racing worker scheduling against filling the
+// queue buffer. Only the first call signals (via startedOnce): once gate is
+// closed, later Save calls return immediately, and re-signaling on an
+// already-drained/unread "started" would deadlock the worker permanently.
+type recordingQueryLog struct {
+	mu          sync.Mutex
+	saved       []*models.DNSQuery
+	gate        chan struct{} // if non-nil, each Save blocks until this is closed
+	started     chan struct{} // if non-nil, the first Save sends here just before blocking on gate
+	startedOnce sync.Once
+}
+
+func (r *recordingQueryLog) Save(q *models.DNSQuery) error {
+	if r.gate != nil {
+		if r.started != nil {
+			r.startedOnce.Do(func() { r.started <- struct{}{} })
+		}
+		<-r.gate
+	}
+	r.mu.Lock()
+	r.saved = append(r.saved, q)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingQueryLog) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.saved)
+}
+
+func (r *recordingQueryLog) ListRecent(limit int) ([]models.DNSQuery, error) { return nil, nil }
+
+func (r *recordingQueryLog) List(filter repositories.QueryLogFilter) ([]models.DNSQuery, int64, error) {
+	return nil, 0, nil
+}
+
+func (r *recordingQueryLog) TopClients(w repositories.AnalyticsWindow) ([]repositories.ClientActivity, error) {
+	return nil, nil
+}
+
+func (r *recordingQueryLog) TopBlockedDomains(w repositories.AnalyticsWindow) ([]repositories.DomainCount, error) {
+	return nil, nil
+}
+
+func (r *recordingQueryLog) CategoryBreakdown(w repositories.AnalyticsWindow) ([]repositories.CategoryCount, error) {
+	return nil, nil
+}
+
+func (r *recordingQueryLog) ClientTimeline(clientIP string, w repositories.AnalyticsWindow) ([]repositories.TimeBucket, error) {
+	return nil, nil
+}
+
+func (r *recordingQueryLog) CategoryHourHeatmap(w repositories.AnalyticsWindow) ([]repositories.HeatmapCell, error) {
+	return nil, nil
+}
+
+func (r *recordingQueryLog) GatherWindowStats(w repositories.AnalyticsWindow) (repositories.WindowStats, error) {
+	return repositories.WindowStats{}, nil
+}
+
+func (r *recordingQueryLog) AnomalyDigestBetween(current, prior repositories.AnalyticsWindow, cfg repositories.AnomalyThresholds) (repositories.AnomalyDigest, error) {
+	return repositories.AnomalyDigest{}, nil
+}
+
+// recordingStats counts IncrementCounter calls per action.
+type recordingStats struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func newRecordingStats() *recordingStats {
+	return &recordingStats{counts: map[string]int{}}
+}
+
+func (s *recordingStats) Save(stat *models.Statistics) error { return nil }
+
+func (s *recordingStats) ListRecent(limit int) ([]models.Statistics, error) { return nil, nil }
+
+func (s *recordingStats) IncrementCounter(action string) error {
+	s.mu.Lock()
+	s.counts[action]++
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *recordingStats) get(action string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.counts[action]
+}
+
+// waitFor polls cond until it returns true or the timeout elapses, failing
+// the test on timeout. Used instead of a fixed sleep so the test is not
+// flaky under load while still bounded in wall-clock time.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !cond() {
+		t.Fatalf("condition not met within %s", timeout)
+	}
+}
+
+// TestQueryLogWriter_ProcessesQueued verifies every submitted row is
+// eventually persisted and its paired statistics counter incremented.
+func TestQueryLogWriter_ProcessesQueued(t *testing.T) {
+	ql := &recordingQueryLog{}
+	st := newRecordingStats()
+	w := newQueryLogWriter(ql, st, metrics.NewQueryMetrics(), 0, 0)
+	defer w.Close()
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		w.Submit(&models.DNSQuery{Domain: "example.com"}, "allow")
+	}
+
+	waitFor(t, 2*time.Second, func() bool { return ql.count() == n })
+
+	if got := st.get("allow"); got != n {
+		t.Errorf("stats count for %q = %d, want %d", "allow", got, n)
+	}
+	if d := w.Dropped(); d != 0 {
+		t.Errorf("Dropped() = %d, want 0", d)
+	}
+}
+
+// TestQueryLogWriter_DropsWhenSaturated verifies Submit never blocks the
+// caller and drops (with a counted, metrics-visible drop) once the buffer
+// and worker are saturated, rather than piling up unbounded work.
+func TestQueryLogWriter_DropsWhenSaturated(t *testing.T) {
+	const bufSize = 2
+	const workers = 1
+
+	gate := make(chan struct{})             // Save blocks here until closed
+	started := make(chan struct{}, workers) // Save signals here just before blocking
+	ql := &recordingQueryLog{gate: gate, started: started}
+	st := newRecordingStats()
+	qm := metrics.NewQueryMetrics()
+
+	w := newQueryLogWriter(ql, st, qm, bufSize, workers)
+	defer w.Close()
+
+	// Submit one entry and wait for the (single) worker to actually pick it
+	// up and block in Save. After this, the queue channel is empty again but
+	// the worker is occupied, so it is deterministic that the next bufSize
+	// Submits fill the channel exactly.
+	w.Submit(&models.DNSQuery{Domain: "occupy-worker"}, "allow")
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the worker to become occupied")
+	}
+
+	// Fill the buffer exactly to capacity; each send must return immediately.
+	fillDone := make(chan struct{})
+	go func() {
+		for i := 0; i < bufSize; i++ {
+			w.Submit(&models.DNSQuery{Domain: "fill.example"}, "allow")
+		}
+		close(fillDone)
+	}()
+	select {
+	case <-fillDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out filling the writer buffer; Submit should never block")
+	}
+
+	// The worker is occupied and the buffer is now full. The next Submit
+	// must be dropped, not queued, and must return immediately rather than
+	// blocking on the saturated channel.
+	submitDone := make(chan struct{})
+	go func() {
+		w.Submit(&models.DNSQuery{Domain: "overflow.example"}, "allow")
+		close(submitDone)
+	}()
+	select {
+	case <-submitDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Submit blocked on a saturated writer instead of dropping")
+	}
+
+	if d := w.Dropped(); d != 1 {
+		t.Errorf("Dropped() = %d, want 1", d)
+	}
+	if agg := qm.Aggregate(); agg.QueryLogDropped != 1 {
+		t.Errorf("metrics QueryLogDropped = %d, want 1", agg.QueryLogDropped)
+	}
+
+	// Release the worker and let everything queued actually persist:
+	// the one occupying the worker plus the bufSize that filled the channel.
+	close(gate)
+	waitFor(t, 2*time.Second, func() bool { return ql.count() == 1+bufSize })
+}
+
+// TestQueryLogWriter_DrainsOnShutdown verifies Close waits for every already
+// -submitted row to finish persisting before returning (graceful drain).
+func TestQueryLogWriter_DrainsOnShutdown(t *testing.T) {
+	ql := &recordingQueryLog{}
+	st := newRecordingStats()
+	w := newQueryLogWriter(ql, st, metrics.NewQueryMetrics(), 64, 2)
+
+	const n = 30
+	for i := 0; i < n; i++ {
+		w.Submit(&models.DNSQuery{Domain: "example.com"}, "allow")
+	}
+
+	w.Close() // must not return until all n rows are persisted
+
+	if got := ql.count(); got != n {
+		t.Errorf("after Close: persisted %d rows, want %d", got, n)
+	}
+
+	// Close must be idempotent.
+	w.Close()
+}
+
+// TestQueryLogWriter_NilSafe verifies every method tolerates a nil receiver,
+// matching the Exporter convention elsewhere in this package.
+func TestQueryLogWriter_NilSafe(t *testing.T) {
+	var w *queryLogWriter
+	w.Submit(&models.DNSQuery{Domain: "example.com"}, "allow") // must not panic
+	if d := w.Dropped(); d != 0 {
+		t.Errorf("Dropped() on nil = %d, want 0", d)
+	}
+	w.Close() // must not panic
+}

--- a/internal/metrics/promexport/collector.go
+++ b/internal/metrics/promexport/collector.go
@@ -31,9 +31,10 @@ var latencyQuantiles = []float64{0.50, 0.95, 0.99}
 type Collector struct {
 	src Source
 
-	queries *prometheus.Desc
-	errors  *prometheus.Desc
-	latency *prometheus.Desc
+	queries         *prometheus.Desc
+	errors          *prometheus.Desc
+	latency         *prometheus.Desc
+	queryLogDropped *prometheus.Desc
 }
 
 // NewCollector builds a Collector reading from src.
@@ -55,6 +56,11 @@ func NewCollector(src Source) *Collector {
 			"Estimated DNS query latency percentiles over the rolling metrics window.",
 			[]string{"quantile"}, nil,
 		),
+		queryLogDropped: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "dns", "querylog_dropped_total"),
+			"Cumulative query log rows dropped because the bounded async writer's buffer was full.",
+			nil, nil,
+		),
 	}
 }
 
@@ -63,6 +69,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.queries
 	ch <- c.errors
 	ch <- c.latency
+	ch <- c.queryLogDropped
 }
 
 // Collect implements prometheus.Collector. It reads a fresh aggregate from the
@@ -72,6 +79,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(c.queries, prometheus.GaugeValue, float64(agg.Total))
 	ch <- prometheus.MustNewConstMetric(c.errors, prometheus.GaugeValue, float64(agg.Errors))
+	ch <- prometheus.MustNewConstMetric(c.queryLogDropped, prometheus.CounterValue, float64(agg.QueryLogDropped))
 
 	for _, q := range latencyQuantiles {
 		d := metrics.EstimatePercentile(agg.Buckets, q)

--- a/internal/metrics/query_metrics.go
+++ b/internal/metrics/query_metrics.go
@@ -26,6 +26,13 @@ type QueryMetrics struct {
 	// rotation path in currentSlice never has to convert an int length.
 	sliceCount uint32
 	current    atomic.Uint32
+
+	// queryLogDropped is a cumulative (never rotated/reset) counter of query
+	// log rows dropped by the bounded async writer when its buffer was full.
+	// Kept outside the rolling slices deliberately: drops should stay visible
+	// in Aggregate()/the /metrics scrape for the life of the process, not
+	// fall out of a 5-minute window like the query counters above.
+	queryLogDropped atomic.Uint64
 }
 
 const (
@@ -39,6 +46,12 @@ type AggregatedMetrics struct {
 	Blocked uint64
 
 	Buckets [BucketCount]uint64
+
+	// QueryLogDropped is the cumulative count of query log rows dropped
+	// because the bounded async writer's buffer was full. Unlike Total/
+	// Errors/Blocked this is not windowed: it is the running total since
+	// process start.
+	QueryLogDropped uint64
 }
 
 func NewQueryMetrics() *QueryMetrics {
@@ -111,6 +124,12 @@ func (m *QueryMetrics) RecordBlocked() {
 	s.blocked.Add(1)
 }
 
+// RecordQueryLogDropped increments the cumulative count of query log rows
+// dropped by the bounded async writer because its buffer was full.
+func (m *QueryMetrics) RecordQueryLogDropped() {
+	m.queryLogDropped.Add(1)
+}
+
 // Window returns the rolling window duration the metrics are aggregated over.
 func (m *QueryMetrics) Window() time.Duration {
 	return m.windowSize
@@ -137,6 +156,7 @@ func (m *QueryMetrics) Aggregate() AggregatedMetrics {
 			out.Buckets[b] += s.latency[b].Load()
 		}
 	}
+	out.QueryLogDropped = m.queryLogDropped.Load()
 	return out
 }
 


### PR DESCRIPTION
This fixes an unbounded goroutine fan-out in the DNS query logging path.

logQuery currently spawns one goroutine per DNS query to persist the row and increment statistics. Under a burst of queries this has no upper bound. A 100-way query burst produces 200+ goroutines, all racing to write the same SQLite file the control plane also shares, which amplifies write contention rather than absorbing it.

This replaces that with a bounded async writer: a buffered channel drained by a small, fixed pool of workers. When the buffer fills up, a submission is dropped and counted instead of blocking the query path, so DNS resolution latency is never affected by a slow or contended write.

Defaults are 1024 buffered entries and 2 workers, both configurable via DataPlaneConfig (query_log_buffer_size / query_log_workers in config.yaml, or the QUERY_LOG_BUFFER_SIZE / QUERY_LOG_WORKERS env vars), following the same config conventions as the other dataplane knobs.

Dropped entries are counted and exposed through the existing metrics path as hydradns_dns_querylog_dropped_total on /metrics, alongside the existing query/error/latency series.

Engine.Shutdown now also drains the writer, so any rows already queued from in-flight queries get persisted before the process exits, the same way the event exporter is drained today.

logQuery's function signature and its call sites in engine.go are untouched, so the diff is limited to the writer itself, the Engine wiring, the new config fields, and the metrics plumbing.

Testing:
- New unit tests cover: the writer persists everything submitted under normal load, it drops (without blocking the caller) once the buffer and worker are saturated and counts the drop both locally and through QueryMetrics, and Close drains all queued entries before returning.
- Fixed a couple of existing tests that constructed an Engine with a query log repository set directly (bypassing NewDNSEngine) to also wire up a writer, since the writer is now required for logQuery to actually persist anything.
- gofmt, go build, go vet all clean.
- go test ./... -race passes across the whole module.
- golangci-lint (locally available 2.11.3, closest to the pinned 2.12.2) and gosec (built from the pinned v2.28.0 tag) both report 0 issues on the full module.

Not a change to the DNS resolution logic itself, just how the query log gets persisted.
