### PR TITLE
fix: repair main test build (recordingQueryLog missing Aggregate)

### DIFF
--- a/internal/dnsengine/querylog_writer_test.go
+++ b/internal/dnsengine/querylog_writer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lopster568/phantomDNS/internal/metrics"
+	"github.com/lopster568/phantomDNS/internal/report"
 	"github.com/lopster568/phantomDNS/internal/storage/models"
 	"github.com/lopster568/phantomDNS/internal/storage/repositories"
 )
@@ -78,6 +79,10 @@ func (r *recordingQueryLog) GatherWindowStats(w repositories.AnalyticsWindow) (r
 
 func (r *recordingQueryLog) AnomalyDigestBetween(current, prior repositories.AnalyticsWindow, cfg repositories.AnomalyThresholds) (repositories.AnomalyDigest, error) {
 	return repositories.AnomalyDigest{}, nil
+}
+
+func (r *recordingQueryLog) Aggregate(from, to time.Time, topN int) (report.Aggregates, error) {
+	return report.Aggregates{}, nil
 }
 
 // recordingStats counts IncrementCounter calls per action.


### PR DESCRIPTION
Main's test build is currently broken by a semantic merge conflict that no single PR's CI could catch.

PR #82 (reporting engine, #67) added `Aggregate` to the `QueryLogRepository` interface. PR #80 (bounded query-log writer) added the `recordingQueryLog` test mock. The two PRs touch different files, so GitHub reported no conflict and both merged, but each was tested against a main that did not yet contain the other. Together, `recordingQueryLog` no longer implements the interface and `go test ./internal/dnsengine/` fails to build. Production binaries are unaffected (`go build ./...` passes); only the test build breaks.

This adds the missing `Aggregate` stub to the mock, matching the existing analytics-method stubs. No production code changes.